### PR TITLE
Fix modern home row stacking and focus behavior

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -4494,24 +4494,9 @@ button:focus-visible {
   --home-continue-height: 293px;
 }
 
-.home-screen-shell.home-layout-modern .home-main {
-  position: relative;
-  height: 100%;
-  overflow: hidden;
-  background: #000;
-}
-
-.home-screen-shell.home-layout-modern .home-route-content {
-  height: 100%;
-}
-
-.home-screen-shell.home-layout-modern .home-modern-stage {
-  position: relative;
-  width: 100%;
-  height: 100%;
-  min-height: 100%;
-  background: #000;
-  isolation: isolate;
+.home-screen-shell.home-layout-modern.home-modern-landscape-posters {
+  --home-row-gap: 8px;
+  --modern-rows-viewport-height: 46%;
 }
 
 .home-screen-shell.home-layout-modern .home-hero,
@@ -4714,7 +4699,7 @@ button:focus-visible {
   overflow-y: auto;
   overflow-x: hidden;
   scrollbar-width: none;
-  scroll-snap-type: y mandatory;
+  scroll-padding-top: 24px;
 }
 
 .home-screen-shell.home-layout-modern .home-modern-rows-viewport::-webkit-scrollbar {
@@ -4723,27 +4708,37 @@ button:focus-visible {
 
 .home-screen-shell.home-layout-modern .home-modern-rows-scroll {
   min-height: 100%;
-  padding-bottom: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  padding: 24px 0 48px;
+}
+
+.home-screen-shell.home-layout-modern.home-modern-landscape-posters .home-modern-rows-scroll {
+  gap: 0;
 }
 
 .home-screen-shell.home-layout-modern .home-modern-catalogs {
   display: flex;
   flex-direction: column;
+  gap: 28px;
+}
+
+.home-screen-shell.home-layout-modern.home-modern-landscape-posters .home-modern-catalogs {
+  gap: 0;
 }
 
 .home-screen-shell.home-layout-modern .home-row {
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
-  justify-content: center;
-  height: var(--modern-rows-page-height);
-  min-height: var(--modern-rows-page-height);
+  justify-content: flex-start;
+  height: auto;
+  min-height: 0;
   position: relative;
   z-index: 2;
   margin-bottom: 0;
   padding-top: 0;
-  scroll-snap-align: start;
-  scroll-snap-stop: always;
 }
 
 .home-screen-shell.home-layout-modern .home-row-head,
@@ -4767,8 +4762,16 @@ button:focus-visible {
   align-items: flex-end;
 }
 
+.home-screen-shell.home-layout-modern.home-modern-landscape-posters .home-modern-row .home-track {
+  align-items: flex-start;
+}
+
 .home-screen-shell.home-layout-modern .home-row-continue {
   margin-top: 0;
+}
+
+.home-screen-shell.home-layout-modern.home-modern-landscape-posters .home-row-continue {
+  margin-bottom: 18px;
 }
 
 .home-screen-shell.home-layout-modern .home-hero-indicators {
@@ -4810,7 +4813,11 @@ button:focus-visible {
 }
 
 .home-screen-shell.home-layout-modern .home-poster-card.is-landscape:not(.is-expanded) {
-  margin-bottom: var(--home-poster-copy-height);
+  margin-bottom: 18px;
+}
+
+.home-screen-shell.home-layout-modern.home-modern-landscape-posters .home-modern-row .home-track.has-expanded-landscape .home-poster-card.is-landscape:not(.is-expanded) {
+  margin-top: calc(var(--home-poster-height) - var(--home-landscape-poster-height));
 }
 
 .home-screen-shell.home-layout-modern .home-poster-card.is-landscape.is-expanded .home-poster-landscape-copy {

--- a/js/ui/screens/home/homeScreen.js
+++ b/js/ui/screens/home/homeScreen.js
@@ -2446,6 +2446,7 @@ export const HomeScreen = {
   collapseFocusedPoster(node = this.expandedPosterNode) {
     const target = node || null;
     if (target) {
+      target.closest(".home-track")?.classList.remove("has-expanded-landscape");
       target.classList.remove("is-expanded", "is-trailer-active");
       this.clearTrailerLayer(target.querySelector(".home-poster-trailer-layer"));
     }
@@ -2463,6 +2464,9 @@ export const HomeScreen = {
     }
     if (this.expandedPosterNode && this.expandedPosterNode !== node) {
       this.collapseFocusedPoster(this.expandedPosterNode);
+    }
+    if (node.classList.contains("is-landscape")) {
+      node.closest(".home-track")?.classList.add("has-expanded-landscape");
     }
     node.classList.add("is-expanded");
     this.hydrateFocusedPosterAssets(node, { defer: true });
@@ -2972,8 +2976,37 @@ export const HomeScreen = {
       const currentAnchor = this.getMainFocusAnchor(current);
       const sameAnchor = Boolean(currentAnchor && currentAnchor === anchor);
       const isHorizontalMove = direction === "left" || direction === "right";
-      const anchorFullyVisible = anchorRect.top >= visibleTop && anchorRect.bottom <= visibleBottom;
-      if (isHorizontalMove && sameAnchor && anchorFullyVisible) {
+      const isVerticalMove = direction === "up" || direction === "down";
+      const verticalScrollOffset = isVerticalMove
+        ? Math.max(
+          10,
+          Math.min(
+            24,
+            Math.round(Math.max(
+              Number(anchor?.offsetHeight || 0) * 0.08,
+              Number(main?.clientHeight || 0) * 0.025
+            ))
+          )
+        )
+        : 0;
+      if (isHorizontalMove && sameAnchor) {
+        return;
+      }
+      if (isVerticalMove) {
+        const targetScrollTop = anchorTop - inset + verticalScrollOffset;
+        if (Math.abs(Number(main.scrollTop || 0) - targetScrollTop) <= 1) {
+          return;
+        }
+        this.animateScroll(main, "y", targetScrollTop, this.getScrollDuration(220));
+        return;
+      }
+      if (anchorRect.top < visibleTop) {
+        this.animateScroll(main, "y", anchorTop - inset, this.getScrollDuration(180));
+        return;
+      }
+      if (anchorRect.bottom > visibleBottom) {
+        const targetScrollTop = anchorBottom - main.clientHeight + 24;
+        this.animateScroll(main, "y", targetScrollTop, this.getScrollDuration(180));
         return;
       }
       const centeredScrollTop = anchorTop - Math.max(0, (main.clientHeight - anchor.offsetHeight) / 2);
@@ -3758,12 +3791,15 @@ export const HomeScreen = {
       ? null
       : normalizeCatalogItem(this.heroItem || this.heroCandidates?.[this.heroIndex] || this.pickHeroItem(this.rows), "movie");
     const showHeroSection = Boolean(this.layoutPrefs?.heroSectionEnabled) && Boolean(heroItem);
-    const layoutClass = `home-layout-${this.layoutMode}`;
+    const modernLandscapePostersEnabled = this.layoutMode === "modern"
+      && Boolean(this.layoutPrefs?.modernLandscapePostersEnabled);
+    const modernLandscapeLayoutClass = modernLandscapePostersEnabled
+      ? " home-modern-landscape-posters"
+      : "";
+    const layoutClass = `home-layout-${this.layoutMode}${modernLandscapeLayoutClass}`;
     const showPosterLabels = this.layoutPrefs?.posterLabelsEnabled !== false;
     const showCatalogAddonName = this.layoutPrefs?.catalogAddonNameEnabled !== false;
     const showCatalogTypeSuffix = this.layoutPrefs?.catalogTypeSuffixEnabled !== false;
-    const modernLandscapePostersEnabled = this.layoutMode === "modern"
-      && Boolean(this.layoutPrefs?.modernLandscapePostersEnabled);
     const focusState = retainedFocusState && retainedFocusState.focusKind === "item"
       ? retainedFocusState
       : null;

--- a/js/ui/screens/home/modernHomeLayout.js
+++ b/js/ui/screens/home/modernHomeLayout.js
@@ -101,7 +101,9 @@ export function renderModernHomeLayout({
               loading: continueWatchingLoading,
               loadingCount: continueWatchingLoadingCount
             })}
-            ${sectionsMarkup.join("")}
+            <div class="home-modern-catalogs">
+              ${sectionsMarkup.join("")}
+            </div>
           </div>
         </div>
       </section>


### PR DESCRIPTION
Makes modern home view more like Android TV Nuvio.

## Summary
- make modern home view more like Android TV Nuvio
- change modern home from a single snap-paged row view to a stacked vertical catalog layout
- add a dedicated modern catalog wrapper so all rows render in one scrollable column
- tighten spacing for landscape-poster rows and keep a bit of separation after Continue Watching
- improve focus behavior by avoiding vertical wobble during horizontal moves in the same row
- add adaptive vertical row scrolling so moving up and down hides more of the previous row across different screen sizes
- make landscape row expansion behave more consistently by adjusting sibling card alignment when a landscape card expands

## Testing
- `node --check js/ui/screens/home/homeScreen.js`
- `npm run build`