### PR TITLE
Modern home fixes for readability and poster scaling

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -4478,11 +4478,27 @@ button:focus-visible {
   --home-row-gap: 12px;
   --home-track-end: 52px;
   --home-continue-track-end: 52px;
-  --modern-rows-viewport-height: 52%;
-  --modern-rows-page-height: 52vh;
+  --modern-rows-viewport-height: 56%;
+  --modern-rows-page-height: 56vh;
   --modern-hero-media-width: 72%;
-  --modern-hero-media-height: calc(100% - var(--modern-rows-viewport-height) + 112px);
+  --modern-hero-media-height: calc(100% - var(--modern-rows-viewport-height) + 72px);
   --modern-trailer-overscan-zoom: 1.35;
+  --modern-hero-copy-top-safe: 40px;
+  --modern-hero-copy-bottom-gap: 32px;
+  --modern-hero-copy-right: 52px;
+  --modern-hero-copy-max-width: calc(var(--home-poster-width) * 4.4);
+  --modern-hero-logo-max-width: calc(var(--home-poster-width) * 2.5);
+  --modern-hero-logo-max-height: calc(var(--home-poster-height) * 0.65);
+  --modern-hero-title-size: calc(var(--home-poster-width) * 0.36);
+  --modern-hero-title-max-width: calc(var(--modern-hero-copy-max-width) * 0.82);
+  --modern-hero-meta-size: calc(var(--home-poster-width) * 0.1);
+  --modern-hero-meta-max-width: var(--modern-hero-copy-max-width);
+  --modern-hero-secondary-size: calc(var(--home-poster-width) * 0.085);
+  --modern-hero-description-size: calc(var(--home-poster-width) * 0.098);
+  --modern-hero-description-max-width: calc(var(--modern-hero-copy-max-width) * 0.46);
+  --home-modern-portrait-poster-width: var(--home-poster-width);
+  --home-modern-portrait-poster-height: calc(var(--home-modern-portrait-poster-width) * 1.5);
+  --home-modern-portrait-expanded-width: calc(var(--home-modern-portrait-poster-width) * 2.66);
   --home-poster-width: 224px;
   --home-poster-height: calc(var(--home-poster-width) * 1.5);
   --home-landscape-poster-width: calc(var(--home-poster-width) * 1.5);
@@ -4495,8 +4511,11 @@ button:focus-visible {
 }
 
 .home-screen-shell.home-layout-modern.home-modern-landscape-posters {
-  --home-row-gap: 8px;
-  --modern-rows-viewport-height: 46%;
+  --home-row-gap: 16px;
+  --modern-rows-viewport-height: 50%;
+  --home-landscape-poster-width: 336px;
+  --home-landscape-poster-height: 189px;
+  --home-poster-radius: 16px;
 }
 
 .home-screen-shell.home-layout-modern .home-hero,
@@ -4529,10 +4548,18 @@ button:focus-visible {
     linear-gradient(
       90deg,
       #000 0%,
-      rgba(0, 0, 0, 0.8) 22%,
-      rgba(0, 0, 0, 0.24) 46%,
-      rgba(0, 0, 0, 0.04) 76%,
+      rgba(0, 0, 0, 0.94) 18%,
+      rgba(0, 0, 0, 0.72) 38%,
+      rgba(0, 0, 0, 0.28) 58%,
+      rgba(0, 0, 0, 0.08) 78%,
       rgba(0, 0, 0, 0) 100%
+    ),
+    linear-gradient(
+      180deg,
+      rgba(0, 0, 0, 0.34) 0%,
+      rgba(0, 0, 0, 0.16) 18%,
+      rgba(0, 0, 0, 0.04) 34%,
+      rgba(0, 0, 0, 0) 54%
     ),
     radial-gradient(circle at 58% 50%, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0) 42%),
     linear-gradient(
@@ -4604,20 +4631,31 @@ button:focus-visible {
 .home-screen-shell.home-layout-modern .home-modern-hero-copy {
   position: absolute;
   left: var(--home-content-start);
-  right: 48px;
-  bottom: calc(var(--modern-rows-viewport-height) + 16px);
+  top: var(--modern-hero-copy-top-safe);
+  right: var(--modern-hero-copy-right);
+  bottom: calc(var(--modern-rows-viewport-height) + var(--modern-hero-copy-bottom-gap));
   z-index: 2;
-  width: min(42%, 620px);
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  align-items: flex-start;
+  gap: 16px;
+  width: min(var(--modern-hero-copy-max-width), calc(100% - var(--home-content-start) - var(--modern-hero-copy-right)));
+  max-width: calc(100% - var(--home-content-start) - var(--modern-hero-copy-right));
+  overflow: hidden;
 }
 
 .home-screen-shell.home-layout-modern .home-hero-logo {
-  max-width: 220px;
-  max-height: 118px;
+  width: auto;
+  max-width: min(100%, var(--modern-hero-logo-max-width));
+  max-height: var(--modern-hero-logo-max-height);
+  object-position: left top;
 }
 
 .home-screen-shell.home-layout-modern .home-hero-title-text {
-  max-width: 520px;
-  font-size: 60px;
+  max-width: min(100%, var(--modern-hero-title-max-width));
+  font-size: var(--modern-hero-title-size);
+  line-height: 0.94;
 }
 
 .home-screen-shell.home-layout-modern .home-hero-meta-primary {
@@ -4625,36 +4663,67 @@ button:focus-visible {
   gap: 10px;
 }
 
+.home-screen-shell.home-layout-modern .home-hero-brand {
+  flex: 0 0 auto;
+  gap: 16px;
+  width: 100%;
+}
+
 .home-screen-shell.home-layout-modern .home-modern-hero-meta-line,
 .home-screen-shell.home-layout-modern .home-modern-hero-secondary {
   display: flex;
-  align-items: center;
+  flex: 0 0 auto;
+  align-items: flex-start;
   flex-wrap: wrap;
-  gap: 8px;
-  margin-top: 8px;
-  color: rgba(255, 255, 255, 0.72);
-  font-size: 14px;
-  line-height: 1.43;
-  font-weight: 500;
+  gap: 14px;
+  margin-top: 0;
+  width: min(100%, var(--modern-hero-meta-max-width));
+  max-width: min(100%, var(--modern-hero-meta-max-width));
+  color: rgba(255, 255, 255, 0.84);
+  font-size: var(--modern-hero-meta-size);
+  line-height: 1.25;
+  font-weight: 600;
 }
 
 .home-screen-shell.home-layout-modern .home-modern-hero-meta-group {
   display: inline-flex;
+  flex-wrap: wrap;
   align-items: center;
-  gap: 8px;
+  gap: 12px;
+  min-width: 0;
+}
+
+.home-screen-shell.home-layout-modern .home-modern-hero-meta-group:empty {
+  display: none;
+}
+
+.home-screen-shell.home-layout-modern .home-modern-hero-meta-group-leading {
+  flex: 0 1 auto;
+  max-width: 100%;
+}
+
+.home-screen-shell.home-layout-modern .home-modern-hero-meta-group-trailing {
+  flex: 0 0 auto;
+  justify-content: flex-start;
+  margin-left: 0;
+  text-align: left;
 }
 
 .home-screen-shell.home-layout-modern .home-modern-hero-secondary {
-  color: rgba(255, 255, 255, 0.86);
+  color: rgba(255, 255, 255, 0.88);
+  font-size: var(--modern-hero-secondary-size);
+  line-height: 1.35;
+  font-weight: 600;
 }
 
 .home-screen-shell.home-layout-modern .home-modern-hero-highlight {
   color: #fff;
   font-weight: 600;
+  letter-spacing: 0.04em;
 }
 
 .home-screen-shell.home-layout-modern .home-modern-hero-secondary-detail {
-  color: rgba(255, 255, 255, 0.72);
+  color: rgba(255, 255, 255, 0.74);
 }
 
 .home-screen-shell.home-layout-modern .home-modern-hero-meta-line.is-empty,
@@ -4666,14 +4735,14 @@ button:focus-visible {
 .home-screen-shell.home-layout-modern .home-modern-hero-badge {
   display: inline-flex;
   align-items: center;
-  min-height: 32px;
-  padding: 0 14px;
+  min-height: 40px;
+  padding: 0 18px;
   border: 1px solid rgb(var(--focus-color-rgb) / 0.55);
-  border-radius: 10px;
+  border-radius: 12px;
   color: var(--text-color);
-  font-size: 12px;
+  font-size: 18px;
   font-weight: 600;
-  line-height: 30px;
+  line-height: 1;
   letter-spacing: 0.03em;
 }
 
@@ -4682,11 +4751,30 @@ button:focus-visible {
 }
 
 .home-screen-shell.home-layout-modern .home-hero-description {
-  margin-top: 8px;
-  max-width: 100%;
+  flex: 0 1 auto;
+  min-height: 0;
+  margin-top: 0;
+  max-width: min(100%, var(--modern-hero-description-max-width));
   display: block;
-  max-height: calc(1.55em * 4);
-  color: rgba(255, 255, 255, 0.72);
+  overflow: hidden;
+  color: rgba(255, 255, 255, 0.8);
+  font-size: var(--modern-hero-description-size);
+  line-height: 1.45;
+}
+
+.home-screen-shell.home-layout-modern .home-modern-hero-meta-line .home-hero-imdb,
+.home-screen-shell.home-layout-modern .home-modern-hero-secondary .home-hero-imdb {
+  gap: 10px;
+}
+
+.home-screen-shell.home-layout-modern .home-modern-hero-meta-line .home-hero-imdb img,
+.home-screen-shell.home-layout-modern .home-modern-hero-secondary .home-hero-imdb img {
+  width: 40px;
+}
+
+.home-screen-shell.home-layout-modern .home-modern-hero-meta-line .home-hero-dot,
+.home-screen-shell.home-layout-modern .home-modern-hero-secondary .home-hero-dot {
+  color: rgba(255, 255, 255, 0.34);
 }
 
 .home-screen-shell.home-layout-modern .home-modern-rows-viewport {
@@ -4751,7 +4839,7 @@ button:focus-visible {
 }
 
 .home-screen-shell.home-layout-modern .home-row-title {
-  font-size: 22px;
+  font-size: 26px;
   line-height: 1.2;
   font-weight: 600;
 }
@@ -4782,6 +4870,14 @@ button:focus-visible {
   transition: flex-basis 180ms ease-out, min-width 180ms ease-out, max-width 180ms ease-out;
 }
 
+.home-screen-shell.home-layout-modern .home-poster-card:not(.is-landscape),
+.home-screen-shell.home-layout-modern .home-seeall-card {
+  --home-poster-radius: 18px;
+  flex-basis: var(--home-modern-portrait-poster-width);
+  min-width: var(--home-modern-portrait-poster-width);
+  max-width: var(--home-modern-portrait-poster-width);
+}
+
 .home-screen-shell.home-layout-modern .home-poster-card.is-landscape {
   flex-basis: var(--home-landscape-poster-width);
   min-width: var(--home-landscape-poster-width);
@@ -4789,7 +4885,8 @@ button:focus-visible {
 }
 
 .home-screen-shell.home-layout-modern .home-poster-card.is-landscape .home-poster-frame {
-  height: var(--home-landscape-poster-height);
+  height: auto;
+  aspect-ratio: 16 / 9;
 }
 
 .home-screen-shell.home-layout-modern .home-poster-card.is-landscape .home-poster-expanded-gradient {
@@ -4844,9 +4941,19 @@ button:focus-visible {
   max-width: var(--home-poster-expanded-width);
 }
 
+.home-screen-shell.home-layout-modern .home-poster-card:not(.is-landscape).is-expanded {
+  flex-basis: var(--home-modern-portrait-expanded-width);
+  min-width: var(--home-modern-portrait-expanded-width);
+  max-width: var(--home-modern-portrait-expanded-width);
+}
+
 .home-screen-shell.home-layout-modern .home-poster-card.is-expanded .home-poster-frame {
   height: var(--home-poster-height);
   transform: none;
+}
+
+.home-screen-shell.home-layout-modern .home-poster-card:not(.is-landscape).is-expanded .home-poster-frame {
+  height: var(--home-modern-portrait-poster-height);
 }
 
 .home-screen-shell.home-layout-modern .home-poster-card.is-expanded.is-expanded-backdrop-ready .content-poster,
@@ -10319,7 +10426,7 @@ button:focus-visible {
 
 .performance-constrained .home-screen-shell.home-layout-modern .home-hero-description {
   max-height: none;
-  -webkit-line-clamp: 4;
+  -webkit-line-clamp: 5;
 }
 
 .performance-constrained .home-content-card.focused,

--- a/js/ui/screens/home/homeScreen.js
+++ b/js/ui/screens/home/homeScreen.js
@@ -122,6 +122,26 @@ function firstNonEmpty(...values) {
   return "";
 }
 
+function limitTextToWordCount(value, maxWords = 0) {
+  const text = String(value || "").trim();
+  if (!text || !Number.isFinite(maxWords) || maxWords <= 0) {
+    return { text, truncated: false };
+  }
+  const words = text.split(/\s+/).filter(Boolean);
+  if (words.length <= maxWords) {
+    return { text, truncated: false };
+  }
+  return {
+    text: words.slice(0, maxWords).join(" "),
+    truncated: true
+  };
+}
+
+function parseCssPx(value, fallback = 0) {
+  const parsed = parseFloat(String(value || "").trim());
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
 function uniqueById(items = []) {
   const seen = new Set();
   return items.filter((item) => {
@@ -785,9 +805,11 @@ function renderModernHeroPrimary(display) {
       </span>
     `);
   }
+  const hasRight = rightTokens.length > 0;
   return `
-    <div class="home-modern-hero-meta-group">${left}</div>
-    <div class="home-modern-hero-meta-group">${rightTokens.join('<span class="home-hero-dot">•</span>')}</div>
+    <div class="home-modern-hero-meta-group home-modern-hero-meta-group-leading">${left}</div>
+    ${left && hasRight ? '<span class="home-hero-dot">•</span>' : ""}
+    <div class="home-modern-hero-meta-group home-modern-hero-meta-group-trailing">${rightTokens.join('<span class="home-hero-dot">•</span>')}</div>
   `;
 }
 
@@ -1496,6 +1518,118 @@ export const HomeScreen = {
       return 24;
     }
     return 48;
+  },
+
+  getCachedModernLandscapePosterMetrics(shell = null) {
+    if (this.cachedModernLandscapePosterMetrics) {
+      return this.cachedModernLandscapePosterMetrics;
+    }
+    const targetShell = shell instanceof HTMLElement
+      ? shell
+      : this.container?.querySelector(".home-screen-shell.home-modern-landscape-posters");
+    if (!(targetShell instanceof HTMLElement)) {
+      return null;
+    }
+    const main = targetShell.querySelector(".home-main");
+    const shellStyles = getComputedStyle(targetShell);
+    const contentStart = parseCssPx(shellStyles.getPropertyValue("--home-content-start"), 52);
+    const trackEnd = parseCssPx(shellStyles.getPropertyValue("--home-track-end"), 52);
+    const rowGap = parseCssPx(shellStyles.getPropertyValue("--home-row-gap"), 16);
+    const visibleLandscapeCards = 4.25;
+    const gapCount = 4;
+    const shellWidth = main instanceof HTMLElement
+      ? main.clientWidth
+      : targetShell.clientWidth;
+    const fallbackWidth = Math.max(
+      Number(globalThis.innerWidth || 0),
+      Number(globalThis.document?.documentElement?.clientWidth || 0),
+      Number(shellWidth || 0)
+    );
+    const availableWidth = Math.max(
+      0,
+      Number(shellWidth || fallbackWidth) - contentStart - trackEnd - (rowGap * gapCount)
+    );
+    const fittedWidth = availableWidth > 0
+      ? Math.floor(availableWidth / visibleLandscapeCards)
+      : 336;
+    const posterWidth = Math.max(272, Math.min(420, fittedWidth || 336));
+    this.cachedModernLandscapePosterMetrics = {
+      width: posterWidth,
+      height: Math.round(posterWidth * 0.5625)
+    };
+    return this.cachedModernLandscapePosterMetrics;
+  },
+
+  applyCachedModernLandscapePosterMetrics(shell = null) {
+    const targetShell = shell instanceof HTMLElement
+      ? shell
+      : this.container?.querySelector(".home-screen-shell.home-modern-landscape-posters");
+    if (!(targetShell instanceof HTMLElement)) {
+      return;
+    }
+    const metrics = this.getCachedModernLandscapePosterMetrics(targetShell);
+    if (!metrics) {
+      return;
+    }
+    targetShell.style.setProperty("--home-landscape-poster-width", `${metrics.width}px`);
+    targetShell.style.setProperty("--home-landscape-poster-height", `${metrics.height}px`);
+  },
+
+  getCachedModernPortraitPosterMetrics(shell = null) {
+    if (this.cachedModernPortraitPosterMetrics) {
+      return this.cachedModernPortraitPosterMetrics;
+    }
+    const targetShell = shell instanceof HTMLElement
+      ? shell
+      : this.container?.querySelector(".home-screen-shell.home-layout-modern:not(.home-modern-landscape-posters)");
+    if (!(targetShell instanceof HTMLElement)) {
+      return null;
+    }
+    const main = targetShell.querySelector(".home-main");
+    const shellStyles = getComputedStyle(targetShell);
+    const contentStart = parseCssPx(shellStyles.getPropertyValue("--home-content-start"), 52);
+    const trackEnd = parseCssPx(shellStyles.getPropertyValue("--home-track-end"), 52);
+    const rowGap = parseCssPx(shellStyles.getPropertyValue("--home-row-gap"), 12);
+    const visiblePortraitCards = 7.25;
+    const gapCount = 7;
+    const shellWidth = main instanceof HTMLElement
+      ? main.clientWidth
+      : targetShell.clientWidth;
+    const fallbackWidth = Math.max(
+      Number(globalThis.innerWidth || 0),
+      Number(globalThis.document?.documentElement?.clientWidth || 0),
+      Number(shellWidth || 0)
+    );
+    const availableWidth = Math.max(
+      0,
+      Number(shellWidth || fallbackWidth) - contentStart - trackEnd - (rowGap * gapCount)
+    );
+    const fittedWidth = availableWidth > 0
+      ? Math.floor(availableWidth / visiblePortraitCards)
+      : 224;
+    const posterWidth = Math.max(208, Math.min(280, fittedWidth || 224));
+    this.cachedModernPortraitPosterMetrics = {
+      width: posterWidth,
+      height: Math.round(posterWidth * 1.5),
+      expandedWidth: Math.round(posterWidth * 2.66)
+    };
+    return this.cachedModernPortraitPosterMetrics;
+  },
+
+  applyCachedModernPortraitPosterMetrics(shell = null) {
+    const targetShell = shell instanceof HTMLElement
+      ? shell
+      : this.container?.querySelector(".home-screen-shell.home-layout-modern:not(.home-modern-landscape-posters)");
+    if (!(targetShell instanceof HTMLElement)) {
+      return;
+    }
+    const metrics = this.getCachedModernPortraitPosterMetrics(targetShell);
+    if (!metrics) {
+      return;
+    }
+    targetShell.style.setProperty("--home-modern-portrait-poster-width", `${metrics.width}px`);
+    targetShell.style.setProperty("--home-modern-portrait-poster-height", `${metrics.height}px`);
+    targetShell.style.setProperty("--home-modern-portrait-expanded-width", `${metrics.expandedWidth}px`);
   },
 
   getHomeViewport() {
@@ -2519,12 +2653,33 @@ export const HomeScreen = {
     }
   },
 
-  collapseFocusedPoster(node = this.expandedPosterNode) {
+  collapseFocusedPoster(node = this.expandedPosterNode, options = {}) {
     const target = node || null;
+    const instant = Boolean(options?.instant);
+    const frame = target?.querySelector?.(".home-poster-frame") || null;
+    const previousCardTransition = instant && target instanceof HTMLElement ? target.style.transition : "";
+    const previousFrameTransition = instant && frame instanceof HTMLElement ? frame.style.transition : "";
     if (target) {
+      if (instant && target instanceof HTMLElement) {
+        target.style.transition = "none";
+      }
+      if (instant && frame instanceof HTMLElement) {
+        frame.style.transition = "none";
+      }
       target.closest(".home-track")?.classList.remove("has-expanded-landscape");
       target.classList.remove("is-expanded", "is-trailer-active");
       this.clearTrailerLayer(target.querySelector(".home-poster-trailer-layer"));
+      if (instant && target instanceof HTMLElement) {
+        void target.offsetWidth;
+        requestAnimationFrame(() => {
+          if (target.isConnected) {
+            target.style.transition = previousCardTransition;
+          }
+          if (frame instanceof HTMLElement && frame.isConnected) {
+            frame.style.transition = previousFrameTransition;
+          }
+        });
+      }
     }
     const heroLayer = this.container?.querySelector(".home-hero-trailer-layer");
     this.clearTrailerLayer(heroLayer);
@@ -2707,8 +2862,10 @@ export const HomeScreen = {
     if (!this.container || this.isPerformanceConstrained()) {
       return;
     }
+    const modernHeroDescriptionWordLimit = 40;
     const root = this.homeTruncationScope || this.container;
     this.homeTruncationScope = null;
+    this.applyModernHeroDescriptionBounds(root);
     const nodes = root.querySelectorAll(
       ".home-hero-description, .home-poster-title, .home-poster-subtitle, .home-poster-expanded-meta, .home-poster-expanded-description"
     );
@@ -2719,16 +2876,21 @@ export const HomeScreen = {
       const currentText = node.textContent ?? "";
       const storedText = node.dataset.fullText || "";
       const shouldRefresh = !storedText || (currentText && currentText !== storedText && !currentText.trim().endsWith("..."));
-      const fullText = shouldRefresh ? currentText : storedText;
+      const sourceText = shouldRefresh ? currentText : storedText;
+      const isModernHeroDescription = node.classList.contains("home-hero-description")
+        && Boolean(node.closest(".home-modern-hero-copy"));
+      const { text: fullText, truncated: wordTrimmed } = isModernHeroDescription
+        ? limitTextToWordCount(sourceText, modernHeroDescriptionWordLimit)
+        : { text: sourceText, truncated: false };
       if (!fullText) {
         return;
       }
       node.dataset.fullText = fullText;
-      node.textContent = fullText;
+      node.textContent = wordTrimmed ? `${fullText}...` : fullText;
       const fits = node.scrollWidth <= (node.clientWidth + 1)
         && node.scrollHeight <= (node.clientHeight + 1);
       if (fits) {
-        node.classList.remove("is-truncated");
+        node.classList.toggle("is-truncated", wordTrimmed);
         return;
       }
 
@@ -2749,6 +2911,51 @@ export const HomeScreen = {
       const finalText = `${fullText.slice(0, Math.max(0, low)).trimEnd()}${ellipsis}`;
       node.textContent = finalText;
       node.classList.add("is-truncated");
+    });
+  },
+
+  applyModernHeroDescriptionBounds(root = null) {
+    if (!this.container || this.layoutMode !== "modern") {
+      return;
+    }
+    const modernHeroDescriptionMaxLines = 5;
+    const scope = root instanceof HTMLElement ? root : this.container;
+    const heroNodes = scope.classList?.contains("home-hero-card")
+      ? [scope]
+      : Array.from(scope.querySelectorAll(".home-hero-card"));
+    heroNodes.forEach((heroNode) => {
+      const copy = heroNode.querySelector(".home-modern-hero-copy");
+      const description = heroNode.querySelector(".home-hero-description");
+      if (!(copy instanceof HTMLElement) || !(description instanceof HTMLElement)) {
+        return;
+      }
+
+      description.style.maxHeight = "";
+      if (description.classList.contains("is-empty")) {
+        return;
+      }
+
+      const visibleSiblings = Array.from(copy.children).filter((node) => {
+        if (!(node instanceof HTMLElement) || node === description) {
+          return false;
+        }
+        return node.offsetHeight > 0 || node.offsetWidth > 0;
+      });
+      const gapValue = parseFloat(getComputedStyle(copy).rowGap || getComputedStyle(copy).gap || "0") || 0;
+      const reservedHeight = visibleSiblings.reduce((total, node) => total + node.offsetHeight, 0);
+      const visibleCount = visibleSiblings.length + 1;
+      const gapCount = Math.max(0, visibleCount - 1);
+      const availableHeight = Math.floor(copy.clientHeight - reservedHeight - (gapCount * gapValue));
+      const lineHeight = parseFloat(getComputedStyle(description).lineHeight || "0") || 0;
+      if (availableHeight <= 0) {
+        description.style.maxHeight = lineHeight > 0 ? `${lineHeight}px` : "0px";
+        return;
+      }
+      const maxDescriptionHeight = lineHeight > 0
+        ? (lineHeight * modernHeroDescriptionMaxLines)
+        : availableHeight;
+      const constrainedHeight = Math.min(availableHeight, maxDescriptionHeight);
+      description.style.maxHeight = `${Math.max(lineHeight, constrainedHeight)}px`;
     });
   },
 
@@ -3159,8 +3366,8 @@ export const HomeScreen = {
     if (!current || !target || current === target) {
       return false;
     }
-    if (this.layoutMode === "modern" && this.isPerformanceConstrained() && this.expandedPosterNode && this.expandedPosterNode !== target) {
-      this.collapseFocusedPoster(this.expandedPosterNode);
+    if (this.layoutMode === "modern" && this.expandedPosterNode && this.expandedPosterNode !== target) {
+      this.collapseFocusedPoster(this.expandedPosterNode, { instant: true });
     }
     current.classList.remove("focused");
     target.classList.add("focused");
@@ -4001,6 +4208,12 @@ export const HomeScreen = {
       ${this.renderContinueWatchingMenu()}
     `;
 
+    if (modernLandscapePostersEnabled) {
+      this.applyCachedModernLandscapePosterMetrics(this.container.querySelector(".home-screen-shell.home-modern-landscape-posters"));
+    } else if (this.layoutMode === "modern") {
+      this.applyCachedModernPortraitPosterMetrics(this.container.querySelector(".home-screen-shell.home-layout-modern:not(.home-modern-landscape-posters)"));
+    }
+
     bindRootSidebarEvents(this.container, {
       currentRoute: "home",
       onSelectedAction: () => this.closeSidebarToContent(),
@@ -4708,6 +4921,8 @@ export const HomeScreen = {
       this.homeTruncationFrame = null;
     }
     this.homeTruncationScope = null;
+    this.cachedModernPortraitPosterMetrics = null;
+    this.cachedModernLandscapePosterMetrics = null;
     ScreenUtils.hide(this.container);
   }
 };

--- a/js/ui/screens/home/modernHomeLayout.js
+++ b/js/ui/screens/home/modernHomeLayout.js
@@ -175,6 +175,7 @@ function renderModernHeroMarkup({
       </span>
     `);
   }
+  const hasPrimaryRight = primaryRightParts.length > 0;
   const secondaryParts = [];
   if (display.secondaryHighlightText) {
     secondaryParts.push(`<span class="home-modern-hero-highlight">${escapeHtml(display.secondaryHighlightText)}</span>`);
@@ -213,10 +214,11 @@ function renderModernHeroMarkup({
             <h1 class="home-hero-title-text${display.logo ? " is-hidden" : ""}">${escapeHtml(display.title)}</h1>
           </div>
           <div class="home-modern-hero-meta-line${display.leadingMeta.length || display.trailingMeta.length || display.showImdbPrimary ? "" : " is-empty"}">
-            <div class="home-modern-hero-meta-group">
+            <div class="home-modern-hero-meta-group home-modern-hero-meta-group-leading">
               ${primaryLeft}
             </div>
-            <div class="home-modern-hero-meta-group">
+            ${primaryLeft && hasPrimaryRight ? '<span class="home-hero-dot">•</span>' : ""}
+            <div class="home-modern-hero-meta-group home-modern-hero-meta-group-trailing">
               ${primaryRightParts.join('<span class="home-hero-dot">•</span>')}
             </div>
           </div>


### PR DESCRIPTION
## Summary

This PR improves the modern home screen readability, stabilizes poster sizing, and fixes focus/scroll behavior when expanded cards are enabled.

## What changed

- Reworked the modern hero layout for better TV readability.
- Moved the hero content stack to a bottom-left anchored layout.
- Reduced the visible hero area so rows start higher on screen.
- Kept hero sizing TV-first using stable layout tokens instead of continuous viewport scaling.
- Increased hero readability with larger logo/title/meta treatment and stronger backdrop shading.
- Restored the missing metadata separator so the hero reads as `Movie/Series • Genre • Year`.
- Kept the hero metadata line intact while making only the movie description wrap more.
- Added measured description bounds so the description truncates before pushing the logo out of the safe area.
- Increased the hero description allowance to a soft 40-word cap with a 5-line measured ceiling.
- Increased modern catalog row title size to 26px.

## Poster scaling

- Modern landscape rows now target about 4 full cards plus a quarter of the next card.
- Landscape poster sizing is no longer purely width-relative CSS math.
- Landscape poster width is now measured once from the initial screen size and cached as pixel values.
- Modern portrait rows now target about 7 full cards plus a quarter of the next card.
- Portrait poster sizing is also measured once from the initial screen size and cached as pixel values.
- This avoids cards shrinking too aggressively on smaller widths.
- Fixed the landscape card rendering regression by switching the landscape frame back to `aspect-ratio: 16 / 9`.
- Increased modern landscape row gap to 16px.
- Rounded modern landscape cards more.
- Rounded modern portrait cards more.

## Focus and scrolling fixes

- Fixed modern row/viewport scrolling so expanded cards do not change the effective scroll step.
- Collapsed expanded posters before focus-scroll calculations so up/down/left navigation uses the normal card footprint.
- Added an instant-collapse path during focus movement to avoid right-scroll calculations using stale expanded geometry.

## Files changed

- `css/components.css`
- `js/ui/screens/home/homeScreen.js`
- `js/ui/screens/home/modernHomeLayout.js`

## Validation

- `npm run build`
