### PR TITLE
fix(search): left key not working on empty search input

### DIFF
--- a/js/ui/screens/search/searchScreen.js
+++ b/js/ui/screens/search/searchScreen.js
@@ -1491,6 +1491,21 @@ export const SearchScreen = {
       return false;
     }
 
+    // Release left/right once the caret sits at the matching edge of the value
+    // (always true for an empty input) so dpad navigation can move focus out
+    // of the input, e.g. to the discover/mic buttons.
+    const valueLength = String(input.value || "").length;
+    const selectionSnapshot = getInputSelectionSnapshot(input);
+    const caretStart = selectionSnapshot ? clamp(Number(selectionSnapshot.start || 0), 0, valueLength) : valueLength;
+    const caretEnd = selectionSnapshot ? clamp(Number(selectionSnapshot.end || 0), 0, valueLength) : valueLength;
+    const hasSelection = caretStart !== caretEnd;
+    if (code === 37 && !hasSelection && caretStart <= 0) {
+      return false;
+    }
+    if (code === 39 && !hasSelection && caretEnd >= valueLength) {
+      return false;
+    }
+
     if (document.activeElement !== input) {
       const selectionSnapshot = getInputSelectionSnapshot(input);
       input.focus?.();


### PR DESCRIPTION
Fixes #150

The search input was eating left/right key presses even when it was empty, so you couldn't reach the discover/mic buttons before doing a search. Now the input only keeps the key while the caret can still move, otherwise focus moves out normally.

Tested in browser - left from the empty input now goes to mic -> discover -> sidebar. With text in the field the caret still moves through the text first.