### PR TITLE
fix(home): hide search/discover only catalogs from the homescreen

### DIFF
--- a/js/core/addons/homeCatalogs.js
+++ b/js/core/addons/homeCatalogs.js
@@ -1,7 +1,7 @@
-export function isSearchOnlyCatalog(catalog) {
-  return Array.isArray(catalog?.extra) && catalog.extra.some((entry) =>
-    String(entry?.name || "").toLowerCase() === "search" && Boolean(entry?.isRequired)
-  );
+export function catalogRequiresExtras(catalog) {
+  // Catalogs that cannot be requested without extra params (required search,
+  // genre, ...) belong to the search/discover screens, not the home screen.
+  return Array.isArray(catalog?.extra) && catalog.extra.some((entry) => Boolean(entry?.isRequired));
 }
 
 export function buildCatalogOrderKey(addonId, type, catalogId) {
@@ -27,7 +27,7 @@ export function buildOrderedCatalogItems(addons, savedOrderKeys = [], disabledKe
 
   (addons || []).forEach((addon) => {
     (addon.catalogs || [])
-      .filter((catalog) => !isSearchOnlyCatalog(catalog))
+      .filter((catalog) => !catalogRequiresExtras(catalog))
       .forEach((catalog) => {
         const key = buildCatalogOrderKey(addon.id, catalog.apiType, catalog.id);
         if (seenKeys.has(key)) {

--- a/js/data/repository/addonRepository.js
+++ b/js/data/repository/addonRepository.js
@@ -372,13 +372,7 @@ class AddonRepository {
       id: catalog.id,
       name: catalog.name || catalog.id,
       apiType: (catalog.type || "").trim(),
-      extra: Array.isArray(catalog.extra)
-        ? catalog.extra.map((entry) => ({
-          name: entry.name,
-          isRequired: Boolean(entry.isRequired),
-          options: Array.isArray(entry.options) ? entry.options : null
-        }))
-        : []
+      extra: this.mapCatalogExtra(catalog)
     }));
 
     return {
@@ -394,6 +388,25 @@ class AddonRepository {
       catalogs,
       resources: this.parseResources(manifest.resources || [], types)
     };
+  }
+
+  mapCatalogExtra(catalog = {}) {
+    if (Array.isArray(catalog.extra)) {
+      return catalog.extra.map((entry) => ({
+        name: entry.name,
+        isRequired: Boolean(entry.isRequired),
+        options: Array.isArray(entry.options) ? entry.options : null
+      }));
+    }
+    // Legacy manifest format: extraSupported/extraRequired as plain name arrays.
+    const required = Array.isArray(catalog.extraRequired) ? catalog.extraRequired : [];
+    const supported = Array.isArray(catalog.extraSupported) ? catalog.extraSupported : [];
+    const names = supported.concat(required.filter((name) => supported.indexOf(name) === -1));
+    return names.map((name) => ({
+      name: String(name),
+      isRequired: required.indexOf(name) !== -1,
+      options: null
+    }));
   }
 
   parseResources(resources, defaultTypes) {

--- a/js/ui/screens/home/homeScreen.js
+++ b/js/ui/screens/home/homeScreen.js
@@ -29,7 +29,7 @@ import {
 import {
   buildCatalogDisableKey,
   buildCatalogOrderKey,
-  isSearchOnlyCatalog
+  catalogRequiresExtras
 } from "../../../core/addons/homeCatalogs.js";
 import {
   activateLegacySidebarAction,
@@ -6106,7 +6106,7 @@ export const HomeScreen = {
 
     addons.forEach((addon) => {
       addon.catalogs
-        .filter((catalog) => !isSearchOnlyCatalog(catalog))
+        .filter((catalog) => !catalogRequiresExtras(catalog))
         .forEach((catalog) => {
           catalogDescriptors.push({
             addonBaseUrl: addon.baseUrl,


### PR DESCRIPTION
Fixes #149

The homescreen was only filtering out catalogs with a required search extra. Catalogs with any other required extra (like genre, which AIOStreams uses for its "only on discover" option) were still showing up on home even though they can't be loaded without params.

Now any catalog that needs a required extra is skipped on home. Also added support for the old extraSupported/extraRequired manifest format which was being ignored before.

Tested with a local addon serving all the catalog variants - home only loads the ones that work without params, discover/search still show everything.