### PR TITLE
fix(collections): poster style folder image shown as landscape

### DIFF
--- a/js/ui/screens/home/homeScreen.js
+++ b/js/ui/screens/home/homeScreen.js
@@ -2014,7 +2014,12 @@ export function createPosterCardMarkup(item, rowIndex, itemIndex, itemType, rowD
   if (collectionItem) {
     const visualSrc = firstNonEmpty(collectionItem.poster, collectionItem.coverImageUrl, collectionItem.backdrop);
     const subtitle = buildPosterSubtitle(collectionItem, layoutMode);
-    const shapeClass = " is-landscape is-collection-landscape";
+    const tileShape = normalizeCollectionPosterShape(collectionItem.tileShape);
+    const shapeClass = tileShape === "POSTER"
+      ? ""
+      : (tileShape === "SQUARE"
+        ? " is-collection-square"
+        : " is-landscape is-collection-landscape");
     const focusGifOverlay = collectionItem.focusGifEnabled && collectionItem.focusGifUrl
       ? `<img class="home-poster-focus-gif" data-src="${escapeAttribute(collectionItem.focusGifUrl)}" alt="" aria-hidden="true" />`
       : "";


### PR DESCRIPTION
Fixes #110

The home screen card markup had the landscape shape class hardcoded for every collection folder, so the tile shape setting (poster/square/landscape) was ignored. The CSS for the square shape even existed already but was never applied.

Now the card uses the folder's configured shape - poster folders get the normal poster aspect, square gets the square class, landscape stays as it was.

Checked in browser with one folder of each shape: aspect ratios now come out 2:3 / 1:1 / 16:9, where before all three rendered 16:9.