### PR TITLE
fix(router): resolve stream route lost to circular-dep init order

### DIFF
--- a/js/ui/navigation/router.js
+++ b/js/ui/navigation/router.js
@@ -39,27 +39,34 @@ export const Router = {
   skipConsumeNextPopstate: false,
   ignoreNextPopstate: false,
 
-  routes: {
-    home: HomeScreen,
-    player: PlayerScreen,
-    account: AccountScreen,
-    authQrSignIn: AuthQrSignInScreen,
-    authSignIn: AuthSignInScreen,
-    syncCode: SyncCodeScreen,
-    profileSelection: ProfileSelectionScreen,
-    detail: MetaDetailsScreen,
-    library: LibraryScreen,
-    search: SearchScreen,
-    discover: DiscoverScreen,
-    settings: SettingsScreen,
-    trakt: TraktScreen,
-    supportersContributors: SupportersContributorsScreen,
-    plugin: PluginScreen,
-    catalogOrder: CatalogOrderScreen,
-    stream: StreamScreen,
-    castDetail: CastDetailScreen,
-    catalogSeeAll: CatalogSeeAllScreen,
-    folderDetail: FolderDetailScreen
+  _routes: null,
+
+  get routes() {
+    if (!this._routes) {
+      this._routes = {
+        home: HomeScreen,
+        player: PlayerScreen,
+        account: AccountScreen,
+        authQrSignIn: AuthQrSignInScreen,
+        authSignIn: AuthSignInScreen,
+        syncCode: SyncCodeScreen,
+        profileSelection: ProfileSelectionScreen,
+        detail: MetaDetailsScreen,
+        library: LibraryScreen,
+        search: SearchScreen,
+        discover: DiscoverScreen,
+        settings: SettingsScreen,
+        trakt: TraktScreen,
+        supportersContributors: SupportersContributorsScreen,
+        plugin: PluginScreen,
+        catalogOrder: CatalogOrderScreen,
+        stream: StreamScreen,
+        castDetail: CastDetailScreen,
+        catalogSeeAll: CatalogSeeAllScreen,
+        folderDetail: FolderDetailScreen
+      };
+    }
+    return this._routes;
   },
 
   getRouteStateKey(routeName, params = {}) {


### PR DESCRIPTION
## What

Pressing **Play** on a movie/series did nothing on webOS: `navigateToStreamScreenForMovie()` → `Router.navigate("stream")` failed with `Route not found: stream` because `Router.routes.stream` was `undefined`.

Fixes #178.

## Root cause

`router.js` and `streamScreen.js` form a circular import (router imports `StreamScreen`, `streamScreen` imports `Router`). The bundle concatenates `streamScreen.js` after `router.js`, but the `routes` object was built **eagerly at module-init time**, reading the `StreamScreen` binding before it was assigned (~31 KB later in the bundle). The object captured `undefined` for `stream` (any screen affected by init ordering would hit the same trap).

Confirmed in the shipped `0.2.3` webOS IPK via remote DevTools: routes object built at bundle offset `1793739` with `stream:xN`, but `var xN=` assigned at `1824702`.

## Fix

Build the `routes` map lazily through a cached getter. On first access (navigation time, after the whole bundle has initialized) every screen binding is assigned, so all routes resolve. The change is confined to the `routes` definition; all access remains by key, so no call sites change.

## Testing

- Built and packaged the webOS IPK, installed on an **LG C5 (webOS)**.
- Before: Play does nothing, console spams `Route not found: stream`.
- After: source/stream list opens and playback starts normally.
