### PR TITLE
fix(detail): derive series season/episode when addons omit explicit fields

### DIFF
--- a/js/ui/screens/detail/metaDetailsScreen.js
+++ b/js/ui/screens/detail/metaDetailsScreen.js
@@ -44,9 +44,79 @@ function t(key, params = {}, fallback = key) {
   return I18n.t(key, params, { fallback });
 }
 
+// Returns the first value that is a non-negative integer (number or numeric
+// string); null when none is. Whitespace-only strings, non-integers and
+// non-numeric types count as missing — `Number("  ")` is 0 and would otherwise
+// turn an empty field into a fake specials season. An explicit 0 is reported
+// as 0 (not folded into a falsy default the way `Number(value || 0)` did) so
+// resolveSeasonEpisode() can keep a declared specials season out of its
+// missing-season fallback below.
+function firstNonNegativeInt(values = []) {
+  for (const value of values) {
+    if (typeof value !== "number" && typeof value !== "string") {
+      continue;
+    }
+    const normalized = typeof value === "string" ? value.trim() : value;
+    if (normalized === "") {
+      continue;
+    }
+    const num = Number(normalized);
+    if (Number.isInteger(num) && num >= 0) {
+      return num;
+    }
+  }
+  return null;
+}
+
+// Stremio video ids frequently encode the season and episode as the trailing
+// colon-separated segments (e.g. "tt1234567:1:2"). Many addons (AIOStreams and
+// other aggregators included) rely on this and do NOT populate the explicit
+// `season`/`episode` fields, which previously caused every episode to be
+// dropped and the detail screen to report "No episodes available".
+// Returns null when the id does not encode a season/episode pair.
+function parseSeasonEpisodeFromId(rawId) {
+  const id = String(rawId || "").trim();
+  if (!id) {
+    return null;
+  }
+  const segments = id.split(":");
+  if (segments.length < 3) {
+    return null;
+  }
+  const lastSegment = segments[segments.length - 1];
+  const secondLastSegment = segments[segments.length - 2];
+  if (!/^\d+$/.test(lastSegment) || !/^\d+$/.test(secondLastSegment)) {
+    return null;
+  }
+  // Three-segment ids are only safe to treat as "<series>:<season>:<episode>"
+  // when the prefix is an IMDb id (e.g. "tt1234567:1:2"). Otherwise the middle
+  // segment is an addon-specific identifier (e.g. "kitsu:12345:6") rather than a
+  // season, and those metas always provide explicit season/episode fields.
+  if (segments.length === 3 && !/^tt\d+$/i.test(segments[0])) {
+    return null;
+  }
+  return { season: Number(secondLastSegment), episode: Number(lastSegment) };
+}
+
+function resolveSeasonEpisode(video = {}) {
+  const fromId = parseSeasonEpisodeFromId(video.id);
+  const season = firstNonNegativeInt([video.season, video.seasonNumber, fromId?.season]);
+  const episode = firstNonNegativeInt([video.episode, video.episodeNumber, fromId?.episode, video.number]);
+  // Some addons omit the season entirely for single-season shows and only
+  // provide an episode/number; treat those as season 1 instead of discarding
+  // the episode. The explicit-0-vs-missing distinction from
+  // firstNonNegativeInt() is consumed right here: a season explicitly set to 0
+  // (specials) skips this fallback, so specials stay excluded from the regular
+  // episode list exactly as before. After the fallback, missing values are
+  // returned as 0, matching what normalizeEpisodes() filters on.
+  if (season == null && episode > 0) {
+    return { season: 1, episode };
+  }
+  return { season: season ?? 0, episode: episode ?? 0 };
+}
+
 function toEpisodeEntry(video = {}) {
-  const season = Number(video.season || 0);
-  const episode = Number(video.episode || 0);
+  const { season, episode } = resolveSeasonEpisode(video);
   const runtimeMinutes = Number(
     video.runtime
     || video.runtimeMinutes


### PR DESCRIPTION
### Summary

Series detail pages render an empty episode list ("No episodes found") for
addons that encode the season/episode **only in the Stremio video id** (e.g.
`tt1234567:1:2`) instead of populating explicit `season` / `episode` fields.
AIOStreams and several other aggregators do exactly this, which is what users
are hitting in #176.

### Root cause

`normalizeEpisodes()` in `js/ui/screens/detail/metaDetailsScreen.js` builds each
episode via `Number(video.season || 0)` / `Number(video.episode || 0)` and then
filters with `video.season > 0 && video.episode > 0`. When an addon does not
provide those numeric fields, every episode evaluates to season 0 / episode 0
and is discarded, so the screen reports that no episodes exist.

### Change

Add a small resolver that derives the season/episode robustly:

1. Explicit fields first (`season`/`episode`, null-aware so an explicit `0` is
   distinguished from a missing value) — no regression for well-formed
   Cinemeta/TMDB-style metas.
2. Then the trailing segments of an **IMDb-style** video id (`tt1234567:1:2`).
   Three-segment ids are only parsed when the prefix is an IMDb id, so
   addon-specific ids such as `kitsu:12345:6` are *not* misread as
   "season 12345".
3. Then common alternative field names (`seasonNumber` / `episodeNumber` /
   `number`).
4. Episodes with **no season information at all** that still number their
   episodes default to season 1 (single-season shows) instead of being dropped.
5. **Specials keep their existing behaviour**: a season explicitly set to 0 —
   via the field or id-encoded (`tt…:0:5`) — stays season 0 and remains
   excluded from the regular list, never promoted to season 1.

### Verification (runtime, end-to-end)

Built with the production toolchain and driven in the browser against a mock
Stremio addon serving the exact payload shape from #176 (videos with **no**
`season`/`episode` fields, S/E only in the id, plus one id-encoded
season-0 special):

- **Unpatched `main`**: detail screen shows **"No episodes found."** and a
  movie-style "Play" button — reproducing the reported symptom verbatim.
- **This branch**: same payload renders **Season 1 / Season 2** pickers,
  episodes "Pilot" / "Second Episode" / "Third Episode", a "Next S1E1" button,
  and correct per-season grouping (Season 2 → "S2 Opener" / "S2 Second"); the
  season-0 special is correctly excluded.

Also covered by a 25-case logic matrix (explicit fields, id-encoded, alt field
names, kitsu-style ids, specials via field and via id, string/NaN/negative/
float/empty inputs).

### Note for reviewers

While verifying this I could not reach playback on any branch because of the
separate `stream` route bug (#178, fix pending in #179) — the web build logs
`Route not found: stream`. At least one commenter on #176 describes a playback
failure rather than a missing episode list; that part is #178's territory.
This PR fixes the **empty-episodes** case, which reproduces exactly as
reported.

Fixes the empty-episode-list case reported in #176
