### PR TITLE
feat(settings): offer the full language list for preferred audio language

### DIFF
--- a/js/ui/screens/settings/settingsScreen.js
+++ b/js/ui/screens/settings/settingsScreen.js
@@ -130,13 +130,9 @@ const LANGUAGE_OPTIONS = [
     .sort((left, right) => String(left.label || "").localeCompare(String(right.label || "")))
 ];
 
-const PREFERRED_PLAYBACK_LANGUAGE_OPTIONS = [
-  { id: "system", labelKey: "common.system" },
-  { id: "en", labelKey: "common.english" },
-  { id: "it", labelKey: "common.italian" }
-];
-
-const AVAILABLE_SUBTITLE_LANGUAGES = [
+// Shared language catalogue used to build the subtitle, audio and TMDB
+// language pickers below.
+const AVAILABLE_LANGUAGES = [
   { id: "af", label: "Afrikaans" },
   { id: "sq", label: "Albanian" },
   { id: "am", label: "Amharic" },
@@ -219,7 +215,15 @@ const AVAILABLE_SUBTITLE_LANGUAGES = [
 
 const PREFERRED_SUBTITLE_LANGUAGE_OPTIONS = [
   { id: "off", label: "Off" },
-  ...AVAILABLE_SUBTITLE_LANGUAGES
+  ...AVAILABLE_LANGUAGES
+];
+
+// Preferred audio language previously only offered System / English / Italian.
+// The selected value is matched generically against each stream's audio tracks,
+// so the full shared language catalogue can be offered.
+const PREFERRED_PLAYBACK_LANGUAGE_OPTIONS = [
+  { id: "system", labelKey: "common.system" },
+  ...AVAILABLE_LANGUAGES
 ];
 
 const TMDB_LANGUAGE_OPTIONS = [
@@ -227,7 +231,7 @@ const TMDB_LANGUAGE_OPTIONS = [
   { id: "en-AU", label: "English (Australia)" },
   { id: "en-CA", label: "English (Canada)" },
   { id: "en-GB", label: "English (United Kingdom)" },
-  ...AVAILABLE_SUBTITLE_LANGUAGES.filter((option) => option.id !== "en")
+  ...AVAILABLE_LANGUAGES.filter((option) => option.id !== "en")
 ].sort((left, right) => String(left.label || "").localeCompare(String(right.label || "")));
 
 const DEBRID_PREPARE_LIMIT_OPTIONS = [


### PR DESCRIPTION
### Summary

The **preferred audio language** setting only offered *System*, *English* and
*Italian*, even though the selected value is matched generically against each
stream's audio tracks. Users who want to default to e.g. Japanese, Hindi or
German audio currently can't express that preference at all.

### Change

In `js/ui/screens/settings/settingsScreen.js`, build
`PREFERRED_PLAYBACK_LANGUAGE_OPTIONS` from the same language catalogue already
used for subtitles (`AVAILABLE_SUBTITLE_LANGUAGES`):

- *System* stays first,
- all other languages follow, alphabetically.

No consumer changes are needed: the player already matches the stored code
against audio tracks via `matchesStartupAudioTarget()` (exact code, base-code,
and label comparison), and the profile sync layer
(`normalizeAudioLanguageForAndroid` / `normalizeAudioLanguageForWeb`) passes
arbitrary language codes through unchanged, so cross-device sync keeps working.

### Verification (runtime, end-to-end)

Built with the production toolchain and driven in the browser:

- Settings → Playback → Audio & Video → **Preferred Audio Language** dialog now
  lists **System + the full catalogue (Afrikaans → Zulu)** instead of
  System/English/Italian.
- Selected **Hungarian** → the row label updates and the store persists
  `"preferredAudioLanguage": "hu"`.
- Full page reload → the selection survives (row still "Hungarian", store still
  `"hu"`); existing stored values (`system`, `en`, `it`) still resolve to a
  valid option.

### Known tradeoff

The language entries use the catalogue's English labels (same as the preferred
*subtitle* language dialog), whereas the previous three hard-coded entries had
i18n label keys. Display of the two previously-translated entries (English /
Italian) therefore matches the subtitle dialog's behaviour instead of being
localized. Happy to wire label keys for the full catalogue if preferred.

### Scope

This is a language-coverage parity improvement (related to #129, which notes
the Android TV app exposes more languages than the web/TV app). It does **not**
attempt to fix the separate Tizen multi-track audio switching bug (#142); it
only lets users express a preference for any audio language.
