### PR TITLE
fix(router): play button does nothing on builds from current main

### DIFF
--- a/js/ui/navigation/router.js
+++ b/js/ui/navigation/router.js
@@ -39,27 +39,36 @@ export const Router = {
   skipConsumeNextPopstate: false,
   ignoreNextPopstate: false,
 
-  routes: {
-    home: HomeScreen,
-    player: PlayerScreen,
-    account: AccountScreen,
-    authQrSignIn: AuthQrSignInScreen,
-    authSignIn: AuthSignInScreen,
-    syncCode: SyncCodeScreen,
-    profileSelection: ProfileSelectionScreen,
-    detail: MetaDetailsScreen,
-    library: LibraryScreen,
-    search: SearchScreen,
-    discover: DiscoverScreen,
-    settings: SettingsScreen,
-    trakt: TraktScreen,
-    supportersContributors: SupportersContributorsScreen,
-    plugin: PluginScreen,
-    catalogOrder: CatalogOrderScreen,
-    stream: StreamScreen,
-    castDetail: CastDetailScreen,
-    catalogSeeAll: CatalogSeeAllScreen,
-    folderDetail: FolderDetailScreen
+  routes: {},
+
+  // Routes are registered in init() instead of inline: this module is part
+  // of an import cycle with the screen modules, so a screen module that
+  // initializes after the router is still undefined while this object
+  // literal evaluates (app.js importing streamScreen first broke the
+  // "stream" route this way).
+  registerRoutes() {
+    this.routes = {
+      home: HomeScreen,
+      player: PlayerScreen,
+      account: AccountScreen,
+      authQrSignIn: AuthQrSignInScreen,
+      authSignIn: AuthSignInScreen,
+      syncCode: SyncCodeScreen,
+      profileSelection: ProfileSelectionScreen,
+      detail: MetaDetailsScreen,
+      library: LibraryScreen,
+      search: SearchScreen,
+      discover: DiscoverScreen,
+      settings: SettingsScreen,
+      trakt: TraktScreen,
+      supportersContributors: SupportersContributorsScreen,
+      plugin: PluginScreen,
+      catalogOrder: CatalogOrderScreen,
+      stream: StreamScreen,
+      castDetail: CastDetailScreen,
+      catalogSeeAll: CatalogSeeAllScreen,
+      folderDetail: FolderDetailScreen
+    };
   },
 
   getRouteStateKey(routeName, params = {}) {
@@ -110,6 +119,7 @@ export const Router = {
   },
 
   init() {
+    this.registerRoutes();
     if (this.popstateBound) {
       return;
     }


### PR DESCRIPTION
On a fresh build from main, pressing Play on the detail screen does nothing - the console shows "Route not found: stream".

Cause: e4acb71 added an import from streamScreen.js to the top of app.js. streamScreen and the router import each other, so with that import order the router module body now runs before streamScreen finishes initializing, and the routes object literal captures StreamScreen as undefined. The currently hosted web build is from before that commit, which is why it still works there.

Moved the route table into a registerRoutes() called from Router.init() - by that point all screen modules are initialized, so the table is correct regardless of import order.

Verified in a local build: before the change Play silently failed with the route error, after it the stream screen opens normally.