### PR TITLE
fix(player): subtitle list sorting, selection state and scroll issues

### DIFF
--- a/js/ui/screens/player/playerScreen.js
+++ b/js/ui/screens/player/playerScreen.js
@@ -7859,11 +7859,20 @@ export const PlayerScreen = {
       });
     }
     const values = Array.from(groups.values());
-    const offIndex = values.findIndex((entry) => entry.key === SUBTITLE_LANGUAGE_OFF_KEY);
-    if (offIndex > 0) {
-      const [offEntry] = values.splice(offIndex, 1);
-      values.unshift(offEntry);
-    }
+    values.sort((left, right) => String(left.label || "").localeCompare(String(right.label || "")));
+    const moveToFront = (matchKey) => {
+      if (!matchKey) {
+        return;
+      }
+      const index = values.findIndex((entry) => entry.key === matchKey);
+      if (index > 0) {
+        const [entry] = values.splice(index, 1);
+        values.unshift(entry);
+      }
+    };
+    moveToFront(normalizeSubtitleLanguageKey(this.subtitleStyleSettings?.secondaryPreferredLanguage));
+    moveToFront(normalizeSubtitleLanguageKey(this.subtitleStyleSettings?.preferredLanguage));
+    moveToFront(SUBTITLE_LANGUAGE_OFF_KEY);
     this.trackDialogCache.subtitleLanguageRail = values;
     return values;
   },
@@ -7908,17 +7917,22 @@ export const PlayerScreen = {
     return this.selectSubtitleOption(options[0], { focusOptions });
   },
 
-  scrollSubtitleRailNodeIntoView(node, { center = false } = {}) {
+  scrollSubtitleRailNodeIntoView(node) {
     if (!(node instanceof HTMLElement)) {
       return;
     }
-    try {
-      node.scrollIntoView({
-        block: "nearest",
-        inline: "nearest"
-      });
-    } catch (_) {
-      node.scrollIntoView();
+    // Scroll the rail itself instead of scrollIntoView, which also scrolls
+    // every scrollable ancestor and drags the dialog/controls bar around.
+    const rail = node.closest(".player-subtitle-rail");
+    if (!rail) {
+      return;
+    }
+    const railRect = rail.getBoundingClientRect();
+    const nodeRect = node.getBoundingClientRect();
+    if (nodeRect.top < railRect.top) {
+      rail.scrollTop += nodeRect.top - railRect.top;
+    } else if (nodeRect.bottom > railRect.bottom) {
+      rail.scrollTop += nodeRect.bottom - railRect.bottom;
     }
   },
 
@@ -8627,6 +8641,7 @@ export const PlayerScreen = {
         this.selectedSubtitleTrackIndex = -1;
         this.selectedEmbeddedSubtitleTrackIndex = -1;
         this.selectedManifestSubtitleTrackId = null;
+        this.invalidateTrackDialogCaches();
         this.refreshSubtitleCueStyles();
         this.renderControlButtons();
         this.renderSubtitleDialog();
@@ -8681,6 +8696,7 @@ export const PlayerScreen = {
     this.selectedSubtitleTrackIndex = preferredIndex;
     this.selectedEmbeddedSubtitleTrackIndex = -1;
     this.selectedManifestSubtitleTrackId = null;
+    this.invalidateTrackDialogCaches();
     this.renderControlButtons();
     this.renderSubtitleDialog();
 


### PR DESCRIPTION
Fixes #162

A few things in the subtitle dialog:

- Languages are now sorted alphabetically instead of whatever order the addons return them in. Off stays at the top, and the preferred/secondary languages set in settings are pulled up right below it.
- Scrolling the list used scrollIntoView, which also scrolled the dialog and the controls bar around (the bottom bar creeping up + the wobble). Now it only scrolls the rail itself.
- The avplay subtitle path was missing the cache invalidation that the hls/dash/native paths all do, so after picking a track the list could still show the old selection (None looking selected). Added it there too.

Tested in the browser build with an addon returning unsorted languages and a language with two providers: list comes out alphabetical with Off + preferred on top, and selecting a provider correctly moves the checkmark off None onto the chosen language.