### PR TITLE
fix(debrid): valid Torbox/debrid key rejected as invalid

### DIFF
--- a/js/data/remote/api/debridApi.js
+++ b/js/data/remote/api/debridApi.js
@@ -47,6 +47,25 @@ function authHeaders(apiKey) {
   };
 }
 
+// A debrid key is only treated as invalid when the server gives a definitive
+// auth rejection. If the validation request never reaches the server (network
+// error, or a CORS-blocked preflight on TV/web - some providers don't return
+// access-control-allow-origin), we can't disprove the key, so we accept it
+// rather than blocking the user from saving a key that actually works.
+function isDefinitiveAuthRejection(response) {
+  return response.status === 401 || response.status === 403;
+}
+
+function interpretKeyValidation(response, isValid) {
+  if (isDefinitiveAuthRejection(response)) {
+    return false;
+  }
+  // Reached the server with a 2xx: trust the provider-specific check.
+  // Anything else (network error, CORS block, 5xx) is inconclusive, so we
+  // don't reject the key on it.
+  return response.ok ? isValid : true;
+}
+
 function formBody(values = {}) {
   const body = new URLSearchParams();
   Object.entries(values).forEach(([key, value]) => {
@@ -65,21 +84,21 @@ export const DebridApi = {
     const response = await requestJson(TORBOX_BASE_URL, "v1/api/user/me", {
       headers: authHeaders(apiKey)
     });
-    return response.ok;
+    return interpretKeyValidation(response, response.ok);
   },
 
   async validatePremiumizeApiKey(apiKey) {
     const response = await requestJson(PREMIUMIZE_BASE_URL, "api/account/info", {
       headers: authHeaders(apiKey)
     });
-    return response.ok && String(response.data?.status || "").toLowerCase() !== "error";
+    return interpretKeyValidation(response, String(response.data?.status || "").toLowerCase() !== "error");
   },
 
   async validateRealDebridApiKey(apiKey) {
     const response = await requestJson(REAL_DEBRID_BASE_URL, "user", {
       headers: authHeaders(apiKey)
     });
-    return response.ok;
+    return interpretKeyValidation(response, response.ok);
   },
 
   async torboxCreateTorrent(apiKey, magnet) {


### PR DESCRIPTION
Fixes #131

The key validators returned response.ok, so any failed request was treated as a bad key. The problem is the validation call can fail without the key being wrong - Torbox's CORS preflight returns 400 with no access-control-allow-origin header, so on web/TV the browser blocks the request before it's even sent and fetch throws. That comes back as status 0 and the key gets rejected as invalid even though it's fine.

Now a key is only rejected when the server actually answers with an auth rejection (401/403). Network errors, CORS blocks and 5xx are inconclusive, so we let the key be saved instead of blocking it - it gets used for real when resolving streams anyway.

Tested the interpretation logic against the cases: 200 valid -> accept, 401/403 -> reject, status 0 (CORS/network) -> accept, 500 -> accept, premiumize 200-with-error-body -> reject.