### PR TITLE
feat(addons): home catalog reorder & hide controls

### DIFF
--- a/js/ui/screens/home/homeScreen.js
+++ b/js/ui/screens/home/homeScreen.js
@@ -6434,9 +6434,10 @@ export const HomeScreen = {
     const pinnedTopRows = collectionRows.filter((row) => row.pinToTop && !disabledKeys.has(row.homeCatalogDisableKey));
     const pinnedKeys = new Set(pinnedTopRows.map((row) => row.homeCatalogKey));
     const orderedRows = orderedKeys
-      .filter((key) => !pinnedKeys.has(key) && !disabledKeys.has(key))
+      .filter((key) => !pinnedKeys.has(key))
       .map((key) => rowMap.get(key))
-      .filter(Boolean);
+      .filter(Boolean)
+      .filter((row) => !disabledKeys.has(row.homeCatalogDisableKey));
     return [...pinnedTopRows, ...orderedRows];
   },
 

--- a/js/ui/screens/plugin/pluginScreen.js
+++ b/js/ui/screens/plugin/pluginScreen.js
@@ -166,9 +166,13 @@ export const PluginScreen = {
     this.rowColumns = new Map();
     this.actionMap = new Map();
     this.setRowColumns(0, [0]);
+    this.setRowColumns(1, [0]);
 
     this.actionMap.set("manage_from_phone", async () => {
       await this.openQrOverlay();
+    });
+    this.actionMap.set("reorder_home_catalogs", async () => {
+      Router.navigate("catalogOrder");
     });
     this.actionMap.set("close_qr_overlay", async () => {
       await this.closeQrOverlay();
@@ -205,6 +209,22 @@ export const PluginScreen = {
                 </span>
                 <span class="addons-large-row-tail-group">
                   <span class="addons-large-row-tail material-icons" aria-hidden="true">phone_android</span>
+                </span>
+              </div>
+              <div role="button"
+                   class="addons-large-row addons-large-row-centered addons-focusable"
+                   data-zone="content"
+                   data-row="1"
+                   data-col="0"
+                   data-action-id="reorder_home_catalogs"
+                   tabindex="-1">
+                <span class="addons-large-row-icon material-icons" aria-hidden="true">tune</span>
+                <span class="addons-large-row-copy">
+                  <strong>Reorder &amp; hide catalogs</strong>
+                  <small>Change the order of home rows and hide catalogs you don't want shown</small>
+                </span>
+                <span class="addons-large-row-tail-group">
+                  <span class="addons-large-row-tail material-icons" aria-hidden="true">chevron_right</span>
                 </span>
               </div>
             </section>


### PR DESCRIPTION
Fixes #121

The reorder/hide screen (catalogOrderScreen) already existed and was wired into the home screen, but nothing actually opened it - there was no entry point in the UI. Added a 'Reorder & hide catalogs' row in the Addons tab that opens it, so you can move catalog rows up/down and hide ones you don't want on the home screen.

While testing I also found hiding a catalog didn't work: the home screen was comparing the catalog's order key against the set of disabled keys, but those are two different key formats, so the disabled set never matched and hidden catalogs kept showing. Fixed it to check the disable key.

Tested in browser: the new row opens the reorder screen, disabling a catalog there now removes it from the home screen, and re-enabling brings it back.

Note: I couldn't find the separate '10 folder cap' mentioned at the bottom of the issue - both home layouts already render all collection folders without slicing, so that part may have been addressed already or lives in the phone-side manager.