### PR TITLE
fix: app fails to start on older webOS (Object.entries is not a function)

### DIFF
--- a/js/runtime/polyfills.js
+++ b/js/runtime/polyfills.js
@@ -26,6 +26,90 @@ if (!Element.prototype.closest) {
   };
 }
 
+// polyfill for Object.entries (Chrome 54+) - older webOS/Tizen browsers lack it
+// and the app touches it during bootstrap, which crashes startup there.
+if (!Object.entries) {
+  Object.entries = function entries(obj) {
+    var ownKeys = Object.keys(Object(obj));
+    var result = [];
+    for (var i = 0; i < ownKeys.length; i++) {
+      result.push([ownKeys[i], obj[ownKeys[i]]]);
+    }
+    return result;
+  };
+}
+
+// polyfill for Object.values (Chrome 54+)
+if (!Object.values) {
+  Object.values = function values(obj) {
+    var ownKeys = Object.keys(Object(obj));
+    var result = [];
+    for (var i = 0; i < ownKeys.length; i++) {
+      result.push(obj[ownKeys[i]]);
+    }
+    return result;
+  };
+}
+
+// polyfill for Array.prototype.includes (Chrome 47+)
+if (!Array.prototype.includes) {
+  Object.defineProperty(Array.prototype, "includes", {
+    value: function includes(searchElement, fromIndex) {
+      var list = Object(this);
+      var length = list.length >>> 0;
+      if (length === 0) {
+        return false;
+      }
+      var start = Number(fromIndex) || 0;
+      var index = start < 0 ? Math.max(length + start, 0) : start;
+      for (; index < length; index++) {
+        var current = list[index];
+        if (current === searchElement || (current !== current && searchElement !== searchElement)) {
+          return true;
+        }
+      }
+      return false;
+    },
+    configurable: true,
+    writable: true
+  });
+}
+
+// polyfills for String padStart/padEnd (Chrome 57+)
+function buildStringPad(padStart) {
+  return function pad(targetLength, padString) {
+    var source = String(this);
+    var target = targetLength >> 0;
+    var filler = padString === undefined ? " " : String(padString);
+    if (source.length >= target || filler === "") {
+      return source;
+    }
+    var padLength = target - source.length;
+    var padding = "";
+    while (padding.length < padLength) {
+      padding += filler;
+    }
+    padding = padding.slice(0, padLength);
+    return padStart ? padding + source : source + padding;
+  };
+}
+
+if (!String.prototype.padStart) {
+  Object.defineProperty(String.prototype, "padStart", {
+    value: buildStringPad(true),
+    configurable: true,
+    writable: true
+  });
+}
+
+if (!String.prototype.padEnd) {
+  Object.defineProperty(String.prototype, "padEnd", {
+    value: buildStringPad(false),
+    configurable: true,
+    writable: true
+  });
+}
+
 // polyfill for Object.fromEntries
 if (!Object.fromEntries) {
   Object.fromEntries = function fromEntries(entries) {


### PR DESCRIPTION
Fixes #195 (and likely the same root cause behind #185 / #160)

On older webOS/Tizen browsers the app crashes at startup with "TypeError: undefined is not a function" in the profile store (getForProfile -> readEnvelope). The cause is Object.entries, which doesn't exist until Chrome 54 - those TV browsers are older than that, and it's used during bootstrap.

The build is set up with babel preset-env useBuiltIns:'entry' + corejs:3, but there's no `import 'core-js'` entry anywhere, so no built-in polyfills actually get injected. The hand-written polyfills.js covers a bunch of things but not these.

Rather than pull in all of core-js (~250KB), I added the specific missing built-ins to polyfills.js, matching the existing style. I checked the codebase for every method newer than the ones already working on these devices (Array.from etc. already run, so they're Chrome 45+): the only gaps used are Object.entries/Object.values (54), Array.prototype.includes (47) and String padStart/padEnd (57). Bundle only grows ~1KB.

Tested in browser by removing those methods before load to mimic the old browser: on main the app dies with 'App bootstrap failed: Object.entries is not a function' and renders nothing; with this change the polyfills restore them and the app boots to the profile screen normally.