### PR TITLE
feat(settings): 'None' option for preferred audio language

### DIFF
--- a/js/ui/screens/settings/settingsScreen.js
+++ b/js/ui/screens/settings/settingsScreen.js
@@ -223,6 +223,7 @@ const PREFERRED_SUBTITLE_LANGUAGE_OPTIONS = [
 // so the full shared language catalogue can be offered.
 const PREFERRED_PLAYBACK_LANGUAGE_OPTIONS = [
   { id: "system", labelKey: "common.system" },
+  { id: "none", labelKey: "common.none" },
   ...AVAILABLE_LANGUAGES
 ];
 


### PR DESCRIPTION
Fixes #186

Adds a 'None' choice to the preferred audio language setting, like Stremio has. The player already treated a 'none' value as 'don't force an audio track' (getStartupPreferredAudioLanguageTargets returns nothing for it) - the option just wasn't offered in the UI.

Tested in browser: the audio language dialog now shows System / None / English / Italian, and picking None saves preferredAudioLanguage = 'none'.