### PR TITLE
fix(player): Brazilian Portuguese subtitles (pob) don't match preferred language

### DIFF
--- a/js/ui/screens/player/playerScreen.js
+++ b/js/ui/screens/player/playerScreen.js
@@ -144,6 +144,8 @@ const LANGUAGE_CODE_ALIASES = {
   jpn: "ja",
   kor: "ko",
   nld: "nl",
+  pb: "pt-br",
+  pob: "pt-br",
   pol: "pl",
   por: "pt",
   ron: "ro",


### PR DESCRIPTION
Fixes #184

Subtitle tracks labelled 'pob' (the OpenSubtitles code for Brazilian Portuguese) or 'pb' weren't recognised, so setting Brazilian Portuguese as the preferred subtitle language never matched them. The language alias table only had 'por' -> 'pt', and 'pob'/'pb' fell through unchanged, so they never equalled the 'pt-br' preference.

Added pob/pb -> pt-br to the alias table. European/generic Portuguese (por/pt) is untouched.

Tested the normalization directly: pob and pb now resolve to pt-br (matching the pt-br preference), while por still maps to pt.