### PR TITLE
feat(settings): add "None" preferred audio language option

### DIFF
--- a/js/core/profile/profileSettingsSyncService.js
+++ b/js/core/profile/profileSettingsSyncService.js
@@ -288,7 +288,11 @@ function normalizeAudioLanguageForAndroid(value) {
     return "DEVICE";
   }
   // Web "none" (never auto-select a track) corresponds to the Android apps'
-  // AudioLanguageOption.DEFAULT ("use media file default").
+  // AudioLanguageOption.DEFAULT ("use media file default"). "off" is accepted
+  // as an alias because the player's startup logic has always treated
+  // "off"/"none" interchangeably as "no preference"
+  // (getStartupPreferredAudioLanguageTargets), so an "off" value persisted by
+  // an older build maps to the same Android semantics.
   if (normalized.toLowerCase() === "none" || normalized.toLowerCase() === "off") {
     return "DEFAULT";
   }

--- a/js/core/profile/profileSettingsSyncService.js
+++ b/js/core/profile/profileSettingsSyncService.js
@@ -287,6 +287,11 @@ function normalizeAudioLanguageForAndroid(value) {
   if (!normalized || normalized.toLowerCase() === "system") {
     return "DEVICE";
   }
+  // Web "none" (never auto-select a track) corresponds to the Android apps'
+  // AudioLanguageOption.DEFAULT ("use media file default").
+  if (normalized.toLowerCase() === "none" || normalized.toLowerCase() === "off") {
+    return "DEFAULT";
+  }
   if (normalized.toUpperCase() === "DEFAULT") {
     return "DEFAULT";
   }
@@ -301,8 +306,13 @@ function normalizeAudioLanguageForWeb(value) {
   if (!normalized) {
     return null;
   }
-  if (normalized.toUpperCase() === "DEVICE" || normalized.toUpperCase() === "DEFAULT") {
+  if (normalized.toUpperCase() === "DEVICE") {
     return "system";
+  }
+  // Android "DEFAULT" means "use media file default", i.e. no preferred
+  // language — that is the web "none" option, not "system" (device locale).
+  if (normalized.toUpperCase() === "DEFAULT") {
+    return "none";
   }
   return normalized.toLowerCase();
 }

--- a/js/ui/screens/settings/settingsScreen.js
+++ b/js/ui/screens/settings/settingsScreen.js
@@ -225,7 +225,7 @@ const PREFERRED_PLAYBACK_LANGUAGE_OPTIONS = [
   { id: "system", labelKey: "common.system" },
   // "None" never auto-selects an audio track, leaving the stream's own
   // default playing (the player already treats "none" as no preference).
-  { id: "none", label: "None" },
+  { id: "none", labelKey: "common.none" },
   ...AVAILABLE_LANGUAGES
 ];
 

--- a/js/ui/screens/settings/settingsScreen.js
+++ b/js/ui/screens/settings/settingsScreen.js
@@ -223,6 +223,9 @@ const PREFERRED_SUBTITLE_LANGUAGE_OPTIONS = [
 // so the full shared language catalogue can be offered.
 const PREFERRED_PLAYBACK_LANGUAGE_OPTIONS = [
   { id: "system", labelKey: "common.system" },
+  // "None" never auto-selects an audio track, leaving the stream's own
+  // default playing (the player already treats "none" as no preference).
+  { id: "none", label: "None" },
   ...AVAILABLE_LANGUAGES
 ];
 


### PR DESCRIPTION
### Summary

Adds the "None" preferred audio language option requested in #186: never
auto-switch the audio track, keep whatever the stream plays by default,
matching Stremio's behaviour.

### Change

- `js/ui/screens/settings/settingsScreen.js`: a `None` entry directly after
  `System` in `PREFERRED_PLAYBACK_LANGUAGE_OPTIONS`. No player changes are
  needed; `getStartupPreferredAudioLanguageTargets()` already treats a stored
  `"none"` as "no preference" and returns no targets.
- `js/core/profile/profileSettingsSyncService.js`: map the new value onto the
  Android apps' existing vocabulary instead of leaking an unknown code
  (checked against `AudioLanguageOption` in the NuvioTV sources, which defines
  `DEFAULT = "use media file default"`):
  - push: web `"none"` (and legacy `"off"`) -> `DEFAULT`, same semantics;
  - pull: Android `DEFAULT` -> web `"none"`. Previously `DEFAULT` was folded
    into `"system"` (device locale), which silently converted an Android
    user's "media default" choice into locale-based auto-selection on web.
    That mapping fix benefits existing Android/web sync users on its own.

`original` (Android-only TMDB-based option) still passes through unchanged and
degrades safely on web (no matching track key, so it behaves as no
preference).

### Verification

- 14-case harness over both sync normalizers + the player's startup-target
  logic: `none` round-trips web -> `DEFAULT` -> web; `system` maps to and from
  `DEVICE`; concrete codes (`hu`) pass through; legacy `off` maps to
  `DEFAULT`; Android `original` doesn't crash or mis-match on web.
- Runtime, in the browser against the production build: the dialog now lists
  System -> None -> Afrikaans -> ...; selecting None updates the row label
  and persists `"preferredAudioLanguage": "none"` in the profile-scoped store.

Closes #186
