### PR TITLE
fix(settings): can't move left/right in the Continue Watching window picker

### DIFF
--- a/js/ui/screens/settings/settingsScreen.js
+++ b/js/ui/screens/settings/settingsScreen.js
@@ -1590,7 +1590,10 @@ export const SettingsScreen = {
       onSelect,
       returnFocusKey,
       dialogClassName,
-      optionRenderer
+      optionRenderer,
+      // Grid dialogs lay options out in 2 columns; everything else is a single
+      // column. Used by the dpad handler so left/right can move between columns.
+      optionColumns: String(dialogClassName || "").includes("settings-trakt-grid-dialog") ? 2 : 1
     };
     const selectedIndex = this.optionDialog.options.findIndex((option) => String(option.id) === String(selectedId));
     this.dialogFocusIndex = clamp(selectedIndex >= 0 ? selectedIndex : 0, 0, Math.max(0, this.optionDialog.options.length - 1));
@@ -4292,20 +4295,25 @@ export const SettingsScreen = {
     }
 
     if (this.optionDialog) {
-      if (code === 38 || code === 40) {
+      if (code === 38 || code === 40 || code === 37 || code === 39) {
         event?.preventDefault?.();
-        const delta = code === 38 ? -1 : 1;
-        this.dialogFocusIndex = clamp(
-          this.dialogFocusIndex + delta,
-          0,
-          Math.max(0, this.optionDialog.options.length - 1)
-        );
-        this.applyFocus();
-        return;
-      }
-
-      if (code === 37 || code === 39) {
-        event?.preventDefault?.();
+        const count = this.optionDialog.options.length;
+        const cols = Math.max(1, Number(this.optionDialog.optionColumns || 1));
+        const index = this.dialogFocusIndex;
+        let next = index;
+        if (code === 38) {
+          next = index - cols;
+        } else if (code === 40) {
+          next = index + cols;
+        } else if (code === 37) {
+          if (index % cols > 0) next = index - 1;
+        } else if (code === 39) {
+          if (index % cols < cols - 1 && index + 1 < count) next = index + 1;
+        }
+        if (next >= 0 && next < count && next !== index) {
+          this.dialogFocusIndex = next;
+          this.applyFocus();
+        }
         return;
       }
     }


### PR DESCRIPTION
Fixes #187

The Continue Watching Window picker (and any 2-column option dialog) renders its options in a 2-column grid, but the dpad handler only moved up/down by one and ignored left/right entirely. So you couldn't cross from the left column to the right with the dpad - only the Magic Remote pointer worked.

Made the option-dialog dpad handler grid-aware: up/down move by the column count, left/right move between columns. Single-column dialogs (column count 1) behave exactly as before - left/right stay no-ops, up/down move by one.

Tested the navigation math across the 7-item 2-column grid (every transition, including the edges where there's no neighbour) and confirmed single-column dialogs like the audio language picker still navigate the same as before.