### PR TITLE
perf: faster home/detail rendering + detail-screen bug fixes (#132)

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -12627,6 +12627,7 @@ button:focus-visible {
 }
 
 .series-stream-filter {
+  flex-shrink: 0;
   height: 46px;
   padding: 0 16px;
   border-radius: 999px;
@@ -12634,6 +12635,7 @@ button:focus-visible {
   background: rgb(var(--focus-color-rgb) / 0.06);
   color: var(--text-color);
   font-size: 20px;
+  white-space: nowrap;
 }
 
 .series-stream-filter.selected {
@@ -12857,6 +12859,7 @@ button:focus-visible {
   font-size: 22px;
   font-weight: 700;
   padding: 0;
+  white-space: nowrap;
 }
 
 .series-insight-divider {
@@ -14043,6 +14046,7 @@ button:focus-visible {
   line-height: 1.35;
   font-weight: 500;
   padding: 4px;
+  white-space: nowrap;
   transform-origin: center;
   transition: transform 160ms ease, color 160ms ease;
 }
@@ -14537,6 +14541,7 @@ button:focus-visible {
 }
 
 .stream-route-chip {
+  flex-shrink: 0;
   min-height: clamp(56px, 3.8vw, 70px);
   padding: 0 clamp(30px, 2vw, 40px);
   border-radius: 999px;
@@ -14549,6 +14554,7 @@ button:focus-visible {
   display: inline-flex;
   align-items: center;
   gap: 10px;
+  white-space: nowrap;
 }
 
 .stream-route-chip.selected {

--- a/css/components.css
+++ b/css/components.css
@@ -4536,6 +4536,7 @@ button:focus-visible {
   position: relative;
   z-index: 2;
   margin-bottom: 32px;
+  contain: layout;
 }
 
 .home-screen-shell.home-layout-modern .home-row {
@@ -4577,6 +4578,7 @@ button:focus-visible {
   overflow-x: auto;
   overflow-y: visible;
   scrollbar-width: none;
+  transform: translateZ(0);
 }
 
 .home-screen-shell .home-track::-webkit-scrollbar {
@@ -4592,7 +4594,7 @@ button:focus-visible {
   border: 2px solid transparent;
   background: transparent;
   overflow: visible;
-  transition: transform 160ms ease-out, border-color 160ms ease, box-shadow 160ms ease;
+  transition: transform 120ms ease-out, border-color 120ms ease;
 }
 
 .home-screen-shell .home-content-card.focused {

--- a/docs/youtube-proxy.html
+++ b/docs/youtube-proxy.html
@@ -28,9 +28,13 @@ html, body {
 (function nuvioYoutubeProxy() {
   var player = null;
   var ready = false;
+  var fallbackUsed = false;
+  var readyWatchdog = null;
   var lastStatePayload = "";
   var stateTimer = null;
   var pageOrigin = String((location && location.origin) || "").trim();
+  var pageOriginIsHttp = /^https?:\/\//i.test(pageOrigin);
+  var widgetReferrer = pageOriginIsHttp ? location.href : "https://www.youtube.com";
   var params = parseQuery(String((location && location.search) || ""));
   var cacheBuster = params._cb || (String(Date.now()) + "-" + Math.random().toString(36).slice(2, 8));
   var videoId = params.v || "qBg39HCJiTU";
@@ -191,10 +195,53 @@ html, body {
     }
   });
 
+  function fallbackToDirectEmbed() {
+    if (fallbackUsed) {
+      return;
+    }
+    fallbackUsed = true;
+    if (readyWatchdog) {
+      clearTimeout(readyWatchdog);
+      readyWatchdog = null;
+    }
+    if (stateTimer) {
+      clearInterval(stateTimer);
+      stateTimer = null;
+    }
+    safeCall(function destroyPlayer() {
+      return player && player.destroy && player.destroy();
+    }, null);
+    player = null;
+    var directParams = [
+      "autoplay=" + (autoplay ? "1" : "0"),
+      "mute=" + (startMuted ? "1" : "0"),
+      "controls=0",
+      "loop=" + (loop ? "1" : "0"),
+      "playlist=" + encodeURIComponent(videoId),
+      "playsinline=1",
+      "rel=0",
+      "modestbranding=1",
+      "iv_load_policy=3",
+      "widget_referrer=" + encodeURIComponent(widgetReferrer)
+    ].join("&");
+    var src = "https://www.youtube.com/embed/" + encodeURIComponent(videoId) + "?" + directParams;
+    document.body.innerHTML = '<iframe id="yt" src="' + src + '" frameborder="0" allow="autoplay; encrypted-media; fullscreen" allowfullscreen></iframe>';
+    postToParent("state", {
+      state: {
+        currentTime: 0,
+        duration: 0,
+        paused: false,
+        muted: startMuted,
+        loading: false,
+        controllable: false
+      }
+    });
+  }
+
   window.onYouTubeIframeAPIReady = function onYouTubeIframeAPIReady() {
     player = new YT.Player("yt", {
       videoId: videoId,
-      host: "https://www.youtube-nocookie.com",
+      host: "https://www.youtube.com",
       playerVars: {
         autoplay: autoplay ? 1 : 0,
         controls: 0,
@@ -203,15 +250,19 @@ html, body {
         fs: 0,
         loop: loop ? 1 : 0,
         modestbranding: 1,
-        origin: /^https?:\/\//i.test(pageOrigin) ? pageOrigin : undefined,
+        origin: pageOriginIsHttp ? pageOrigin : undefined,
         playsinline: 1,
         playlist: loop ? videoId : undefined,
         rel: 0,
-        widget_referrer: location.href
+        widget_referrer: widgetReferrer
       },
       events: {
         onReady: function onReady(event) {
           ready = true;
+          if (readyWatchdog) {
+            clearTimeout(readyWatchdog);
+            readyWatchdog = null;
+          }
           if (startMuted) {
             event.target.mute();
           } else {
@@ -232,20 +283,20 @@ html, body {
           pushState(true);
         },
         onError: function onError(event) {
-          postToParent("state", {
-            state: {
-              currentTime: 0,
-              duration: 0,
-              paused: true,
-              muted: startMuted,
-              loading: false,
-              controllable: false,
-              error: Number(event && event.data || 0)
-            }
-          });
+          fallbackToDirectEmbed();
         }
       }
     });
+
+    // Error 153 ("configuration error") is shown on-screen by the player but is
+    // not reliably dispatched through onError, so if the player never becomes
+    // ready, recover by loading the video through a direct youtube.com embed.
+    readyWatchdog = setTimeout(function watchdogTick() {
+      readyWatchdog = null;
+      if (!ready) {
+        fallbackToDirectEmbed();
+      }
+    }, 4500);
   };
 
   var apiScript = document.createElement("script");

--- a/js/data/repository/watchProgressRepository.js
+++ b/js/data/repository/watchProgressRepository.js
@@ -8,6 +8,20 @@ import { metaRepository } from "./metaRepository.js";
 
 const CW_PROGRESS_START_THRESHOLD = 0.02;
 const CW_PROGRESS_END_THRESHOLD = 0.85;
+// These bound a hung request so the fire-and-forget Continue Watching
+// reconciliation can't leak a never-resolving promise. They are NOT on the
+// app's critical path (the home screen paints from a snapshot), so they are
+// generous — only a genuinely stuck request is abandoned.
+const TRAKT_API_TIMEOUT_MS = 10000;
+const PROGRESS_META_TIMEOUT_MS = 8000;
+
+function withTimeout(promise, ms, fallback) {
+  let timer = null;
+  return Promise.race([
+    promise,
+    new Promise((resolve) => { timer = setTimeout(() => resolve(fallback), ms); })
+  ]).finally(() => { if (timer) clearTimeout(timer); });
+}
 
 function activeProfileId() {
   return String(ProfileManager.getActiveProfileId() || "1");
@@ -241,26 +255,28 @@ const ENRICHED_META_CACHE_TTL_MS = 5 * 60 * 1000;
 async function batchEnrichProgressItems(items) {
   if (!items.length) return [];
   const now = Date.now();
-  const results = [];
-
-  for (const item of items) {
+  return Promise.all(items.map(async (item) => {
     const lookupId = item.imdbId || item.contentId;
     const cacheKey = `${item.contentType}:${lookupId}`;
     const cached = enrichedMetaCache.get(cacheKey);
-
     let meta = null;
     if (cached && (now - cached.timestamp) < ENRICHED_META_CACHE_TTL_MS) {
       meta = cached.meta;
     } else {
       const canonicalType = item.contentType === "series" ? "series" : "movie";
-      meta = await metaRepository.getMetaFromAllAddons(canonicalType, lookupId).catch(() => null);
-      enrichedMetaCache.set(cacheKey, { meta, timestamp: now });
+      meta = await withTimeout(
+        metaRepository.getMetaFromAllAddons(canonicalType, lookupId),
+        PROGRESS_META_TIMEOUT_MS,
+        null
+      ).catch(() => null);
+      // Only cache real metadata. Caching a null (timeout/miss) would leave the
+      // item unenriched for the full TTL after a single slow response.
+      if (meta) {
+        enrichedMetaCache.set(cacheKey, { meta, timestamp: now });
+      }
     }
-
-    results.push(meta ? { ...item, enrichedMeta: meta } : item);
-  }
-
-  return results;
+    return meta ? { ...item, enrichedMeta: meta } : item;
+  }));
 }
 
 class WatchProgressRepository {
@@ -302,15 +318,15 @@ class WatchProgressRepository {
     if (useTraktProgress && TraktAuthStore.isAuthenticated()) {
       // Parallelize all Trakt fetches via Promise.all
       const [history, playbackState, watchedShows] = await Promise.all([
-        TraktAuthService.fetchWatchHistory({ limit: 100 }).catch((err) => {
+        withTimeout(TraktAuthService.fetchWatchHistory({ limit: 100 }), TRAKT_API_TIMEOUT_MS, []).catch((err) => {
           console.warn("[CW] Trakt history fetch failed", err);
           return [];
         }),
-        TraktAuthService.fetchPlaybackState({ limit: 50 }).catch((err) => {
+        withTimeout(TraktAuthService.fetchPlaybackState({ limit: 50 }), TRAKT_API_TIMEOUT_MS, []).catch((err) => {
           console.warn("[CW] Trakt playback state fetch failed", err);
           return [];
         }),
-        TraktAuthService.fetchWatchedShows().catch((err) => {
+        withTimeout(TraktAuthService.fetchWatchedShows(), TRAKT_API_TIMEOUT_MS, []).catch((err) => {
           console.warn("[CW] Trakt watched shows fetch failed", err);
           return [];
         })

--- a/js/ui/screens/detail/metaDetailsScreen.js
+++ b/js/ui/screens/detail/metaDetailsScreen.js
@@ -677,10 +677,14 @@ function shouldUseDirectYoutubeEmbedOnTv() {
 }
 
 function getYoutubeProxyBaseUrl() {
+  const configured = String(YOUTUBE_PROXY_URL || "").trim();
   if (Platform.isWebOS() || Platform.isTizen()) {
-    return LOCAL_YOUTUBE_PROXY_URL;
+    // The local proxy is served from a file:// origin, which YouTube rejects
+    // (embed error 153). Prefer a configured https-hosted proxy when available
+    // so the embedding origin is valid; otherwise fall back to the local file.
+    return /^https?:\/\//i.test(configured) ? configured : LOCAL_YOUTUBE_PROXY_URL;
   }
-  return String(YOUTUBE_PROXY_URL || LOCAL_YOUTUBE_PROXY_URL).trim();
+  return configured || LOCAL_YOUTUBE_PROXY_URL;
 }
 
 function resolveTrailerPostMessageTargetOrigin(src = "") {
@@ -745,7 +749,7 @@ function buildYoutubeEmbedUrl(ytId = "", { muted = true } = {}) {
       const proxyUrl = new URL(proxyBase, globalThis?.location?.href || "https://example.com/");
       proxyUrl.searchParams.set("v", cleanId);
       proxyUrl.searchParams.set("autoplay", "1");
-      proxyUrl.searchParams.set("muted", "1");
+      proxyUrl.searchParams.set("muted", muted ? "1" : "0");
       proxyUrl.searchParams.set("controls", "0");
       proxyUrl.searchParams.set("loop", "1");
       proxyUrl.searchParams.set("playlist", cleanId);

--- a/js/ui/screens/detail/metaDetailsScreen.js
+++ b/js/ui/screens/detail/metaDetailsScreen.js
@@ -2093,6 +2093,13 @@ export const MetaDetailsScreen = {
   },
 
   render(meta, focusRestore = undefined) {
+    if (this._sectionsUpdateRaf) {
+      const cancelRaf = typeof cancelAnimationFrame === "function" ? cancelAnimationFrame : clearTimeout;
+      cancelRaf(this._sectionsUpdateRaf);
+      this._sectionsUpdateRaf = null;
+      this._pendingSectionsMeta = null;
+      this._pendingSectionsFocusRestore = null;
+    }
     if (focusRestore !== undefined) {
       this.pendingFocusRestore = focusRestore;
     } else if (!this.pendingFocusRestore) {
@@ -2163,7 +2170,7 @@ export const MetaDetailsScreen = {
 
     this.container.innerHTML = `
       <div class="series-detail-shell${this.isTrailerPlaying ? " detail-trailer-active" : ""}">
-        <div class="series-detail-backdrop"${backdrop ? ` style="background-image:url('${backdrop.replace(/'/g, "%27")}')"` : ""}></div>
+        <div class="series-detail-backdrop" data-backdrop-url="${escapeAttribute(backdrop || "")}"${backdrop ? ` style="background-image:url('${backdrop.replace(/'/g, "%27")}')"` : ""}></div>
         <div class="detail-trailer-layer"></div>
         <div class="series-detail-vignette"></div>
         <div class="detail-bottom-shadow"></div>
@@ -2385,7 +2392,7 @@ export const MetaDetailsScreen = {
 
     this.container.innerHTML = `
       <div class="series-detail-shell movie-detail-shell${this.isTrailerPlaying ? " detail-trailer-active" : ""}">
-        <div class="series-detail-backdrop"${backdrop ? ` style="background-image:url('${backdrop.replace(/'/g, "%27")}')"` : ""}></div>
+        <div class="series-detail-backdrop" data-backdrop-url="${escapeAttribute(backdrop || "")}"${backdrop ? ` style="background-image:url('${backdrop.replace(/'/g, "%27")}')"` : ""}></div>
         <div class="detail-trailer-layer"></div>
         <div class="series-detail-vignette"></div>
         <div class="detail-bottom-shadow"></div>
@@ -2413,20 +2420,75 @@ export const MetaDetailsScreen = {
     this.restoredTrackScrollLeftByKey = captureHorizontalScrollMap(this.container);
   },
 
+  applyDetailBackdrop(meta) {
+    const node = this.container?.querySelector(".series-detail-backdrop");
+    if (!(node instanceof HTMLElement)) {
+      return;
+    }
+    const desired = String(meta?.background || meta?.poster || "");
+    if (node.dataset.backdropUrl === desired) {
+      return;
+    }
+    node.dataset.backdropUrl = desired;
+    if (!desired) {
+      node.style.backgroundImage = "";
+      return;
+    }
+    const token = this.detailLoadToken;
+    const apply = () => {
+      if (this.detailLoadToken !== token) {
+        return;
+      }
+      const current = this.container?.querySelector(".series-detail-backdrop");
+      if (current instanceof HTMLElement && current.dataset.backdropUrl === desired) {
+        current.style.backgroundImage = `url('${desired.replace(/'/g, "%27")}')`;
+      }
+    };
+    if (typeof Image === "function") {
+      const preload = new Image();
+      preload.onload = apply;
+      preload.onerror = apply;
+      preload.src = desired;
+    } else {
+      apply();
+    }
+  },
+
   updateRenderedDetailSections(meta, focusRestoreOverride = null) {
     if (!this.container || !meta || !this.container.querySelector(".series-detail-shell")) {
       this.render(meta, focusRestoreOverride || null);
       return;
     }
+    this._pendingSectionsMeta = meta;
+    if (focusRestoreOverride) {
+      this._pendingSectionsFocusRestore = focusRestoreOverride;
+    }
+    if (this._sectionsUpdateRaf) {
+      return;
+    }
+    const raf = typeof requestAnimationFrame === "function"
+      ? requestAnimationFrame
+      : (cb) => setTimeout(cb, 16);
+    this._sectionsUpdateRaf = raf(() => {
+      this._sectionsUpdateRaf = null;
+      const pendingMeta = this._pendingSectionsMeta;
+      const pendingFocus = this._pendingSectionsFocusRestore || null;
+      this._pendingSectionsMeta = null;
+      this._pendingSectionsFocusRestore = null;
+      if (pendingMeta) {
+        this._renderDetailSectionsNow(pendingMeta, pendingFocus);
+      }
+    });
+  },
 
+  _renderDetailSectionsNow(meta, focusRestoreOverride = null) {
+    if (!this.container || !this.container.querySelector(".series-detail-shell")) {
+      return;
+    }
     const focusRestore = focusRestoreOverride || this.captureDetailFocus();
     this.captureRenderedChromeState();
     const isSeries = isSeriesDetailMeta(meta, this.episodes);
-    const backdropNode = this.container.querySelector(".series-detail-backdrop");
-    if (backdropNode instanceof HTMLElement) {
-      const backdrop = meta.background || meta.poster || "";
-      backdropNode.style.backgroundImage = backdrop ? `url('${backdrop.replace(/'/g, "%27")}')` : "";
-    }
+    this.applyDetailBackdrop(meta);
 
     const heroMount = this.container.querySelector("#detailHeroSection");
     if (heroMount) {

--- a/js/ui/screens/detail/metaDetailsScreen.js
+++ b/js/ui/screens/detail/metaDetailsScreen.js
@@ -2999,7 +2999,7 @@ export const MetaDetailsScreen = {
   },
 
   isPosterHoldTarget(node) {
-    return Boolean(node?.matches?.(".detail-morelike-card.focusable"));
+    return Boolean(node?.matches?.(".detail-morelike-card.focusable:not(.detail-trailer-card)"));
   },
 
   isHeroHoldTarget(node) {
@@ -3246,8 +3246,12 @@ export const MetaDetailsScreen = {
   },
 
   openMoreLikeDetailFromNode(node) {
+    const itemId = String(node?.dataset?.itemId || "").trim();
+    if (!itemId) {
+      return;
+    }
     Router.navigate("detail", {
-      itemId: node.dataset.itemId,
+      itemId,
       itemType: node.dataset.itemType || "movie",
       fallbackTitle: node.dataset.itemTitle || "Untitled"
     });

--- a/js/ui/screens/home/homeScreen.js
+++ b/js/ui/screens/home/homeScreen.js
@@ -5337,7 +5337,20 @@ export const HomeScreen = {
     if (!state || Router.getCurrent() !== "home" || this.layoutMode !== "modern") {
       return;
     }
-    this.applyModernCameraFollowTargets(state.horizontal, state.vertical);
+    if (state.deferred) {
+      const horizontal = this.getModernTrackAlignedScrollTarget(state.target, state.horizontalAdjustment);
+      const vertical = this.getModernMainAlignedScrollTarget(state.target, state.direction, state.current, state.verticalAdjustment);
+      const hasHorizontal = Boolean(horizontal?.container && Math.abs(Number(horizontal.container.scrollLeft || 0) - Number(horizontal.value || 0)) > 1);
+      const hasVertical = Boolean(vertical?.container && Math.abs(Number(vertical.container.scrollTop || 0) - Number(vertical.value || 0)) > 1);
+      this.modernCameraFollowLastHorizontalContainer = horizontal?.container || this.modernCameraFollowLastHorizontalContainer;
+      this.modernCameraFollowLastVerticalContainer = vertical?.container || this.modernCameraFollowLastVerticalContainer;
+      this.applyModernCameraFollowTargets(
+        hasHorizontal ? horizontal : null,
+        hasVertical ? vertical : null
+      );
+    } else {
+      this.applyModernCameraFollowTargets(state.horizontal, state.vertical);
+    }
   },
 
   scheduleModernCameraFollow(target, direction = null, current = null, layoutAdjustment = {}, inputMeta = {}) {
@@ -5349,25 +5362,21 @@ export const HomeScreen = {
     const shouldFollowVerticalHoldImmediately = isVerticalMove && Boolean(inputMeta?.repeat);
     const horizontalAdjustment = Number(layoutAdjustment?.horizontal || 0);
     const verticalAdjustment = Number(layoutAdjustment?.vertical || 0);
-    const horizontal = this.getModernTrackAlignedScrollTarget(target, horizontalAdjustment);
-    const vertical = this.getModernMainAlignedScrollTarget(target, direction, current, verticalAdjustment);
-    const hasHorizontal = Boolean(horizontal?.container && Math.abs(Number(horizontal.container.scrollLeft || 0) - Number(horizontal.value || 0)) > 1);
-    const hasVertical = Boolean(vertical?.container && Math.abs(Number(vertical.container.scrollTop || 0) - Number(vertical.value || 0)) > 1);
-
-    if (!hasHorizontal && !hasVertical) {
-      this.modernCameraFollowLastHorizontalContainer = horizontal?.container || this.modernCameraFollowLastHorizontalContainer;
-      this.modernCameraFollowLastVerticalContainer = vertical?.container || this.modernCameraFollowLastVerticalContainer;
-      return true;
-    }
 
     if (shouldFollowVerticalHoldImmediately) {
+      const horizontal = this.getModernTrackAlignedScrollTarget(target, horizontalAdjustment);
+      const vertical = this.getModernMainAlignedScrollTarget(target, direction, current, verticalAdjustment);
       this.applyModernCameraFollowTargets(horizontal, vertical);
       return true;
     }
 
     this.modernCameraFollowState = {
-      horizontal: hasHorizontal ? horizontal : null,
-      vertical: hasVertical ? vertical : null
+      deferred: true,
+      target,
+      direction,
+      current,
+      horizontalAdjustment,
+      verticalAdjustment
     };
     this.modernCameraFollowTimer = setTimeout(() => {
       this.flushModernCameraFollow();
@@ -5631,15 +5640,28 @@ export const HomeScreen = {
 
   ensureMainVerticalVisibility(target, direction = null, current = null, layoutAdjustment = 0) {
     if (this.layoutMode === "modern") {
-      const next = this.getModernMainAlignedScrollTarget(target, direction, current, layoutAdjustment);
-      if (!next?.container) {
-        return;
+      if (this._mainVertRaf) {
+        cancelAnimationFrame(this._mainVertRaf);
       }
-      const delta = Math.abs(Number(next.container.scrollTop || 0) - Number(next.value || 0));
-      if (delta <= 1) {
-        return;
-      }
-      this.animateSpringScroll(next.container, "y", next.value);
+      const _target = target;
+      const _direction = direction;
+      const _current = current;
+      const _adj = layoutAdjustment;
+      this._mainVertRaf = requestAnimationFrame(() => {
+        this._mainVertRaf = null;
+        if (!_target.isConnected) {
+          return;
+        }
+        const next = this.getModernMainAlignedScrollTarget(_target, _direction, _current, _adj);
+        if (!next?.container) {
+          return;
+        }
+        const delta = Math.abs(Number(next.container.scrollTop || 0) - Number(next.value || 0));
+        if (delta <= 1) {
+          return;
+        }
+        this.animateSpringScroll(next.container, "y", next.value);
+      });
       return;
     }
 
@@ -5671,14 +5693,25 @@ export const HomeScreen = {
 
   ensureTrackHorizontalVisibility(target, direction = null, layoutAdjustment = 0) {
     if (this.layoutMode === "modern") {
-      const next = this.getModernTrackAlignedScrollTarget(target, layoutAdjustment);
-      if (!next?.container) {
-        return;
+      if (this._trackHorizRaf) {
+        cancelAnimationFrame(this._trackHorizRaf);
       }
-      if (Math.abs(Number(next.container.scrollLeft || 0) - Number(next.value || 0)) <= 1) {
-        return;
-      }
-      this.animateSpringScroll(next.container, "x", next.value);
+      const _target = target;
+      const _adj = layoutAdjustment;
+      this._trackHorizRaf = requestAnimationFrame(() => {
+        this._trackHorizRaf = null;
+        if (!_target.isConnected) {
+          return;
+        }
+        const next = this.getModernTrackAlignedScrollTarget(_target, _adj);
+        if (!next?.container) {
+          return;
+        }
+        if (Math.abs(Number(next.container.scrollLeft || 0) - Number(next.value || 0)) <= 1) {
+          return;
+        }
+        this.animateSpringScroll(next.container, "x", next.value);
+      });
       return;
     }
 
@@ -6259,7 +6292,24 @@ export const HomeScreen = {
     const initialDescriptors = catalogDescriptors.slice(0, initialCatalogLoad);
     const deferredDescriptors = catalogDescriptors.slice(initialCatalogLoad);
 
-    const initialRows = await this.fetchCatalogRows(initialDescriptors, { allowLoading: true });
+    const progressiveInitialRows = new Map();
+    const initialRows = await this.fetchCatalogRows(initialDescriptors, {
+      allowLoading: true,
+      onRow: (row) => {
+        if (token !== this.homeLoadToken || Router.getCurrent() !== "home") {
+          return;
+        }
+        progressiveInitialRows.set(row.homeCatalogKey, row);
+        this.rows = this.sortAndFilterRows(Array.from(progressiveInitialRows.values()), this.collections);
+        this.heroCandidates = uniqueById(this.collectHeroCandidates(this.rows));
+        if (!this.heroItem) {
+          this.heroItem = this.pickInitialHero();
+        }
+        this.isInitialHomeLoading = false;
+        this.hasLoadedOnce = true;
+        this.requestBackgroundRender();
+      }
+    });
     if (token !== this.homeLoadToken) {
       return;
     }
@@ -6511,6 +6561,7 @@ export const HomeScreen = {
     const loadingCount = this.getLoadingRowItemCount();
     const batchSize = Math.max(0, Number(options?.batchSize || 0));
     const onBatch = typeof options?.onBatch === "function" ? options.onBatch : null;
+    const onRow = typeof options?.onRow === "function" ? options.onRow : null;
     const fetchedRows = [];
     const normalizedDescriptors = Array.isArray(descriptors) ? descriptors : [];
     if (HOME_PERF_DEBUG) {
@@ -6538,26 +6589,26 @@ export const HomeScreen = {
           supportsSkip: true
         }), timeoutMs, { status: "error", message: "timeout" });
         const rowKey = buildModernRowKey(catalog);
-        return {
+        const row = {
           ...catalog,
           result: result?.status === "success" ? result : (allowLoading ? { status: "loading" } : result),
           loadingItems: allowLoading && result?.status !== "success"
             ? buildCatalogLoadingItems(rowKey, loadingCount)
-            : null
-        };
-      }));
-      const mappedRows = rowResults
-        .filter((row) => row.result?.status === "success" || allowLoading)
-        .map((row) => ({
-          ...row,
-          homeCatalogKey: buildCatalogOrderKey(row.addonId, row.type, row.catalogId),
+            : null,
+          homeCatalogKey: buildCatalogOrderKey(catalog.addonId, catalog.type, catalog.catalogId),
           homeCatalogDisableKey: buildCatalogDisableKey(
-            row.addonBaseUrl,
-            row.type,
-            row.catalogId,
-            row.catalogName
+            catalog.addonBaseUrl,
+            catalog.type,
+            catalog.catalogId,
+            catalog.catalogName
           )
-        }));
+        };
+        if (onRow && (row.result?.status === "success" || allowLoading)) {
+          onRow(row);
+        }
+        return row;
+      }));
+      const mappedRows = rowResults.filter((row) => row.result?.status === "success" || allowLoading);
       fetchedRows.push(...mappedRows);
       if (onBatch && mappedRows.length) {
         onBatch(mappedRows);

--- a/js/ui/screens/home/homeScreen.js
+++ b/js/ui/screens/home/homeScreen.js
@@ -71,8 +71,10 @@ const HOME_MODERN_HERO_BACKDROP_CROSSFADE_MS = 400;
 const CW_META_TIMEOUT_MS = 1800;
 const CW_META_TIMEOUT_TV_MS = 4200;
 const CW_NEXT_UP_META_TIMEOUT_MS = 2200;
-const CW_META_RETRY_TIMEOUT_MS = 8000;
 const CW_ENRICHMENT_CACHE_KEY = "homeContinueWatchingEnrichmentCache";
+const CW_DISPLAY_SNAPSHOT_KEY = "homeContinueWatchingDisplaySnapshot";
+const CW_DISPLAY_SNAPSHOT_MAX_AGE_MS = 14 * 24 * 60 * 60 * 1000;
+const CW_DISPLAY_SNAPSHOT_MAX_SCOPES = 4;
 const HOME_RETURN_FOCUS_STATE_KEY = "homeReturnFocusState";
 const CW_ENRICHMENT_CACHE_MAX_AGE_MS = 14 * 24 * 60 * 60 * 1000;
 const CW_NEXT_UP_NEW_SEASON_UNAIRED_WINDOW_DAYS = 7;
@@ -1430,6 +1432,36 @@ function saveContinueWatchingEnrichment(item = {}) {
     .sort(([, left], [, right]) => Number(right?.cachedAt || 0) - Number(left?.cachedAt || 0))
     .slice(0, 200);
   LocalStore.set(CW_ENRICHMENT_CACHE_KEY, Object.fromEntries(entries));
+}
+
+function readContinueWatchingDisplaySnapshot(scopeKey) {
+  const key = String(scopeKey || "").trim();
+  if (!key) {
+    return [];
+  }
+  const store = LocalStore.get(CW_DISPLAY_SNAPSHOT_KEY, {});
+  const entry = store && typeof store === "object" ? store[key] : null;
+  if (!entry || !Array.isArray(entry.items)) {
+    return [];
+  }
+  if ((Date.now() - Number(entry.savedAt || 0)) > CW_DISPLAY_SNAPSHOT_MAX_AGE_MS) {
+    return [];
+  }
+  return entry.items;
+}
+
+function writeContinueWatchingDisplaySnapshot(scopeKey, items = []) {
+  const key = String(scopeKey || "").trim();
+  if (!key || !Array.isArray(items) || !items.length) {
+    return;
+  }
+  const store = LocalStore.get(CW_DISPLAY_SNAPSHOT_KEY, {});
+  const next = store && typeof store === "object" ? { ...store } : {};
+  next[key] = { savedAt: Date.now(), items: items.slice(0, CW_MAX_VISIBLE_ITEMS) };
+  const entries = Object.entries(next)
+    .sort(([, left], [, right]) => Number(right?.savedAt || 0) - Number(left?.savedAt || 0))
+    .slice(0, CW_DISPLAY_SNAPSHOT_MAX_SCOPES);
+  LocalStore.set(CW_DISPLAY_SNAPSHOT_KEY, Object.fromEntries(entries));
 }
 
 function buildContinueWatchingSignature(items = []) {
@@ -6178,7 +6210,8 @@ export const HomeScreen = {
     this.layoutPrefs = LayoutPreferences.get();
     this.layoutMode = String(this.layoutPrefs.homeLayout || "classic").toLowerCase();
     this.rows = [];
-    this.continueWatchingDisplay = [];
+    this.continueWatchingDisplay = readContinueWatchingDisplaySnapshot(watchProgressRepository.getContinueWatchingSourceKey());
+    this.continueWatchingHydratedFromSnapshot = Boolean(this.continueWatchingDisplay.length);
     this.continueWatchingLoading = false;
     this.heroCandidates = [];
     this.heroItem = null;
@@ -6204,7 +6237,8 @@ export const HomeScreen = {
     const watchedItemsPromise = watchedItemsRepository.getAll(2000).catch(() => []);
 
     const preserveContinueWatching = Boolean(background && this.continueWatchingDisplay?.length);
-    const suppressContinueWatchingLoading = preserveContinueWatching;
+    const hydratedFromSnapshot = Boolean(!background && this.continueWatchingHydratedFromSnapshot && this.continueWatchingDisplay?.length);
+    const suppressContinueWatchingLoading = preserveContinueWatching || hydratedFromSnapshot;
     const previousContinueWatchingSignature = preserveContinueWatching
       ? buildContinueWatchingSignature(this.continueWatchingDisplay)
       : "";
@@ -6220,54 +6254,9 @@ export const HomeScreen = {
       recentProgressError = error;
       return [];
     });
-    const initialContinueWatchingPromise = background ? null : (async () => {
-      const [allProgress, continueWatching] = await Promise.all([progressAllPromise, recentProgressPromise]);
-      const allProgressItems = Array.isArray(allProgress) ? allProgress : [];
-      const continueWatchingItems = Array.isArray(continueWatching) ? continueWatching : [];
-      const watchedItems = await watchedItemsPromise;
-      const nextUpProgressCandidates = this.selectNextUpProgressCandidates(allProgressItems, continueWatchingItems, watchedItems, {
-        applyDaysCap: !includeWatchedItemNextUpSeeds,
-        includeProgressSeeds: !includeWatchedItemNextUpSeeds,
-        includeWatchedItemSeeds: includeWatchedItemNextUpSeeds,
-        nextUpFromFurthestEpisode: prefs.nextUpFromFurthestEpisode
-      }).slice(0, CW_MAX_NEXT_UP_LOOKUPS);
-      const hasCandidates = Boolean(continueWatchingItems.length + nextUpProgressCandidates.length);
-      if (!hasCandidates) {
-        return {
-          allProgress: allProgressItems,
-          continueWatching: continueWatchingItems,
-          watchedItems,
-          nextUpProgressCandidates,
-          hasCandidates,
-          display: []
-        };
-      }
-      const enriched = await this.enrichContinueWatching(continueWatchingItems, {
-        allProgress: allProgressItems,
-        watchedItems,
-        nextUpProgressCandidates
-      });
-      const displayWithArtwork = buildVisibleContinueWatchingItems(enriched, { requireArtwork: true });
-      const displayWithoutArtwork = buildVisibleContinueWatchingItems(enriched, { requireArtwork: false });
-      const displayFallback = buildCompleteContinueWatchingDisplay(enriched);
-      const display = displayWithoutArtwork.length >= displayFallback.length
-        ? displayWithoutArtwork
-        : displayFallback;
-      return {
-        allProgress: allProgressItems,
-        continueWatching: continueWatchingItems,
-        watchedItems,
-        nextUpProgressCandidates,
-        hasCandidates,
-        needsMetadataRefresh: needsContinueWatchingMetadataRefresh(display),
-        display: displayWithArtwork.length === displayFallback.length
-          ? displayWithArtwork
-          : display
-      };
-    })().catch((error) => {
-      console.warn("Initial continue watching load failed", error);
-      return null;
-    });
+    // Continue Watching is reconciled fire-and-forget in the block below, so a
+    // slow addon or Trakt call never blocks catalog rows. The section paints
+    // instantly from the snapshot hydrated in mount().
 
     const addons = await addonRepository.getInstalledAddons();
     this.collections = CollectionsStore.get();
@@ -6313,41 +6302,16 @@ export const HomeScreen = {
     if (token !== this.homeLoadToken) {
       return;
     }
-    const [initialAllProgress, initialContinueWatching, initialContinueWatchingState] = await Promise.all([
-      progressAllPromise,
-      recentProgressPromise,
-      initialContinueWatchingPromise
-    ]);
-    if (token !== this.homeLoadToken) {
-      return;
-    }
-    const initialAllProgressItems = Array.isArray(initialAllProgress) ? initialAllProgress : [];
-    const initialContinueWatchingItems = Array.isArray(initialContinueWatching) ? initialContinueWatching : [];
-    const initialNextUpProgressCandidates = (initialContinueWatchingState?.nextUpProgressCandidates || this.selectNextUpProgressCandidates(initialAllProgressItems, initialContinueWatchingItems, [], {
-      applyDaysCap: !includeWatchedItemNextUpSeeds,
-      includeProgressSeeds: !includeWatchedItemNextUpSeeds,
-      includeWatchedItemSeeds: includeWatchedItemNextUpSeeds,
-      nextUpFromFurthestEpisode: prefs.nextUpFromFurthestEpisode
-    }))
-      .slice(0, CW_MAX_NEXT_UP_LOOKUPS);
-    const hasInitialContinueWatchingCandidates = Boolean(
-      initialContinueWatchingState?.hasCandidates
-      || initialContinueWatchingItems.length
-      || initialNextUpProgressCandidates.length
-    );
     this.rows = this.sortAndFilterRows(initialRows, this.collections);
-    if (!preserveContinueWatching) {
-      this.continueWatchingDisplay = initialContinueWatchingState?.display || [];
+    if (preserveContinueWatching) {
       this.continueWatchingLoading = false;
-      this.allProgress = initialContinueWatchingState?.allProgress || initialAllProgressItems;
-      this.continueWatching = initialContinueWatchingState?.continueWatching || initialContinueWatchingItems;
-      this.watchedItems = initialContinueWatchingState?.watchedItems || [];
-      this.nextUpProgressCandidates = initialNextUpProgressCandidates;
-      if (!background && this.layoutMode === "modern" && hasInitialContinueWatchingCandidates && this.continueWatchingDisplay.length) {
-        this.forceInitialContinueWatchingFocus = true;
-      }
-    } else {
-      this.continueWatchingLoading = false;
+    } else if (!background
+      && this.layoutMode === "modern"
+      && this.continueWatchingHydratedFromSnapshot
+      && this.continueWatchingDisplay?.length) {
+      // CW already painted instantly from the snapshot — focus it on this render.
+      // Fresh data reconciles fire-and-forget below.
+      this.forceInitialContinueWatchingFocus = true;
     }
     this.heroCandidates = uniqueById(this.collectHeroCandidates(this.rows));
     this.heroIndex = 0;
@@ -6430,7 +6394,7 @@ export const HomeScreen = {
       });
     }
 
-    if (background || !initialContinueWatchingState?.display?.length || initialContinueWatchingState?.needsMetadataRefresh) {
+    {
       (async () => {
       const [allProgress, continueWatching] = await Promise.all([progressAllPromise, recentProgressPromise]);
       if (token !== this.homeLoadToken || Router.getCurrent() !== "home") {
@@ -6438,7 +6402,7 @@ export const HomeScreen = {
       }
       this.allProgress = Array.isArray(allProgress) ? allProgress : [];
       this.continueWatching = Array.isArray(continueWatching) ? continueWatching : [];
-      this.watchedItems = initialContinueWatchingState?.watchedItems || await watchedItemsPromise;
+      this.watchedItems = await watchedItemsPromise;
       if (token !== this.homeLoadToken || Router.getCurrent() !== "home") {
         return;
       }
@@ -6485,9 +6449,7 @@ export const HomeScreen = {
         const enriched = await this.enrichContinueWatching(this.continueWatching, {
           allProgress: this.allProgress,
           watchedItems: this.watchedItems,
-          nextUpProgressCandidates: this.nextUpProgressCandidates,
-          metaTimeoutMs: initialContinueWatchingState?.needsMetadataRefresh ? CW_META_RETRY_TIMEOUT_MS : undefined,
-          forceRefreshMetadata: Boolean(initialContinueWatchingState?.needsMetadataRefresh)
+          nextUpProgressCandidates: this.nextUpProgressCandidates
         });
         if (token !== this.homeLoadToken || Router.getCurrent() !== "home") {
           return;
@@ -6507,6 +6469,7 @@ export const HomeScreen = {
         }
         this.continueWatchingDisplay = nextDisplay;
         this.continueWatchingLoading = false;
+        this.persistContinueWatchingSnapshot();
         if (this.layoutMode === "modern" && this.continueWatchingDisplay.length) {
           this.heroItem = this.pickInitialHero();
           if (!background && !this.hasAppliedInitialContinueWatchingFocus) {
@@ -7324,76 +7287,84 @@ export const HomeScreen = {
       .sort((left, right) => Number(right.updatedAt || 0) - Number(left.updatedAt || 0));
   },
 
-  async enrichContinueWatching(items = [], options = {}) {
-    const inProgressItems = await Promise.all((items || []).map(async (item) => {
-      const cachedItem = applyCachedContinueWatchingEnrichment(item);
-      if (!options?.forceRefreshMetadata && !needsContinueWatchingMetadataRefresh([cachedItem])) {
-        return cachedItem;
-      }
-      try {
-        const meta = await this.fetchMetaForContinueWatching(
-          item.contentType || "movie",
-          item.contentId,
-          options?.metaTimeoutMs || 1800
-        );
-        if (meta) {
-          const episodeEntry = findEpisodeEntry(meta.videos, item.season, item.episode);
-          const enriched = {
-            ...item,
-            title: meta.name || prettyId(item.contentId),
-            landscapePoster: meta.landscapePoster || meta.thumbnail || meta.backdrop || meta.background || null,
-            episodeThumbnail: episodeEntry?.thumbnail || meta.episodeThumbnail || item.episodeThumbnail || null,
-            poster: meta.poster || meta.thumbnail || meta.background || meta.backdrop || null,
-            background: meta.background || meta.backdrop || meta.thumbnail || meta.poster || null,
-            backdrop: meta.backdrop || meta.background || null,
-            thumbnail: meta.thumbnail || meta.poster || null,
-            logo: meta.logo || null,
-            description: meta.description || "",
-            releaseInfo: meta.releaseInfo || "",
-            imdbRating: resolveImdbRating(meta),
-            genres: Array.isArray(meta.genres) ? meta.genres : [],
-            runtimeMinutes: Number(meta.runtimeMinutes ?? meta.runtime ?? 0) || 0,
-            ageRating: firstNonEmpty(meta.ageRating, meta.age_rating),
-            status: firstNonEmpty(meta.status),
-            language: firstNonEmpty(meta.language),
-            country: firstNonEmpty(meta.country),
-            episodeTitle: firstNonEmpty(episodeEntry?.title, item.episodeTitle, item.subtitle),
-            episodeDescription: firstNonEmpty(episodeEntry?.overview, item.episodeDescription, item.episode_description)
-          };
-          saveContinueWatchingEnrichment(enriched);
-          return enriched;
-        }
-      } catch (error) {
-        console.warn("Continue watching enrichment failed", error);
-      }
-      return {
-        ...cachedItem,
-        title: firstNonEmpty(cachedItem.title, cachedItem.name),
-        landscapePoster: cachedItem.landscapePoster || cachedItem.thumbnail || cachedItem.backdrop || cachedItem.background || null,
-        episodeThumbnail: cachedItem.episodeThumbnail || null,
-        poster: cachedItem.poster || cachedItem.thumbnail || null,
-        background: cachedItem.background || cachedItem.backdrop || cachedItem.poster || null,
-        backdrop: cachedItem.backdrop || cachedItem.background || null,
-        thumbnail: cachedItem.thumbnail || cachedItem.poster || null,
-        logo: cachedItem.logo || null,
-        description: cachedItem.description || "",
-        releaseInfo: cachedItem.releaseInfo || "",
-        genres: Array.isArray(cachedItem.genres) ? cachedItem.genres : [],
-        runtimeMinutes: Number(cachedItem.runtimeMinutes ?? cachedItem.runtime ?? 0) || 0,
-        ageRating: firstNonEmpty(cachedItem.ageRating, cachedItem.age_rating),
-        status: firstNonEmpty(cachedItem.status),
-        language: firstNonEmpty(cachedItem.language),
-        country: firstNonEmpty(cachedItem.country),
-        episodeTitle: firstNonEmpty(cachedItem.episodeTitle, cachedItem.subtitle)
-      };
-    }));
+  persistContinueWatchingSnapshot() {
+    writeContinueWatchingDisplaySnapshot(
+      watchProgressRepository.getContinueWatchingSourceKey(),
+      this.continueWatchingDisplay
+    );
+  },
 
-    const nextUpItems = await this.buildNextUpItems({
-      allProgress: options?.allProgress || [],
-      inProgressItems,
-      nextUpProgressCandidates: options?.nextUpProgressCandidates || [],
-      watchedItems: options?.watchedItems || []
-    });
+  async enrichContinueWatching(items = [], options = {}) {
+    const [inProgressItems, nextUpItems] = await Promise.all([
+      Promise.all((items || []).map(async (item) => {
+        const cachedItem = applyCachedContinueWatchingEnrichment(item);
+        if (!options?.forceRefreshMetadata && !needsContinueWatchingMetadataRefresh([cachedItem])) {
+          return cachedItem;
+        }
+        try {
+          const meta = await this.fetchMetaForContinueWatching(
+            item.contentType || "movie",
+            item.contentId,
+            options?.metaTimeoutMs || 1800
+          );
+          if (meta) {
+            const episodeEntry = findEpisodeEntry(meta.videos, item.season, item.episode);
+            const enriched = {
+              ...item,
+              title: meta.name || prettyId(item.contentId),
+              landscapePoster: meta.landscapePoster || meta.thumbnail || meta.backdrop || meta.background || null,
+              episodeThumbnail: episodeEntry?.thumbnail || meta.episodeThumbnail || item.episodeThumbnail || null,
+              poster: meta.poster || meta.thumbnail || meta.background || meta.backdrop || null,
+              background: meta.background || meta.backdrop || meta.thumbnail || meta.poster || null,
+              backdrop: meta.backdrop || meta.background || null,
+              thumbnail: meta.thumbnail || meta.poster || null,
+              logo: meta.logo || null,
+              description: meta.description || "",
+              releaseInfo: meta.releaseInfo || "",
+              imdbRating: resolveImdbRating(meta),
+              genres: Array.isArray(meta.genres) ? meta.genres : [],
+              runtimeMinutes: Number(meta.runtimeMinutes ?? meta.runtime ?? 0) || 0,
+              ageRating: firstNonEmpty(meta.ageRating, meta.age_rating),
+              status: firstNonEmpty(meta.status),
+              language: firstNonEmpty(meta.language),
+              country: firstNonEmpty(meta.country),
+              episodeTitle: firstNonEmpty(episodeEntry?.title, item.episodeTitle, item.subtitle),
+              episodeDescription: firstNonEmpty(episodeEntry?.overview, item.episodeDescription, item.episode_description)
+            };
+            saveContinueWatchingEnrichment(enriched);
+            return enriched;
+          }
+        } catch (error) {
+          console.warn("Continue watching enrichment failed", error);
+        }
+        return {
+          ...cachedItem,
+          title: firstNonEmpty(cachedItem.title, cachedItem.name),
+          landscapePoster: cachedItem.landscapePoster || cachedItem.thumbnail || cachedItem.backdrop || cachedItem.background || null,
+          episodeThumbnail: cachedItem.episodeThumbnail || null,
+          poster: cachedItem.poster || cachedItem.thumbnail || null,
+          background: cachedItem.background || cachedItem.backdrop || cachedItem.poster || null,
+          backdrop: cachedItem.backdrop || cachedItem.background || null,
+          thumbnail: cachedItem.thumbnail || cachedItem.poster || null,
+          logo: cachedItem.logo || null,
+          description: cachedItem.description || "",
+          releaseInfo: cachedItem.releaseInfo || "",
+          genres: Array.isArray(cachedItem.genres) ? cachedItem.genres : [],
+          runtimeMinutes: Number(cachedItem.runtimeMinutes ?? cachedItem.runtime ?? 0) || 0,
+          ageRating: firstNonEmpty(cachedItem.ageRating, cachedItem.age_rating),
+          status: firstNonEmpty(cachedItem.status),
+          language: firstNonEmpty(cachedItem.language),
+          country: firstNonEmpty(cachedItem.country),
+          episodeTitle: firstNonEmpty(cachedItem.episodeTitle, cachedItem.subtitle)
+        };
+      })),
+      this.buildNextUpItems({
+        allProgress: options?.allProgress || [],
+        inProgressItems: items || [],
+        nextUpProgressCandidates: options?.nextUpProgressCandidates || [],
+        watchedItems: options?.watchedItems || []
+      })
+    ]);
 
     const inProgressSeriesIds = new Set(
       inProgressItems


### PR DESCRIPTION
## Summary

Addresses the general UI sluggishness reported in #132. The jank is not specific to Tizen/webOS — it shows up on any constrained device — so the changes here target the underlying causes rather than one platform. While profiling the details screen I also fixed a few user-facing bugs found along the way.

## Performance

- **Progressive catalog rows** — `fetchCatalogRows` now renders each home row as soon as its addon resolves, via an `onRow` callback, instead of awaiting `Promise.all` over all initial rows. A single slow addon no longer blocks first paint.
- **Deferred layout reads** — home D-pad navigation (`ensureTrackHorizontalVisibility` / `ensureMainVerticalVisibility`) defers `getBoundingClientRect` reads to `requestAnimationFrame`, removing forced synchronous reflows on every keypress.
- **GPU compositing / containment** — `contain: layout` on home rows and `transform: translateZ(0)` on the track isolate reflows and let horizontal scrolling composite instead of repainting the row.
- **Coalesced detail re-renders** — the 6–8 re-renders fired during a single details entry (enrichment, cast fallback, more-like, collection, watched-state, trailer refresh ×2, comments) are batched into a single `requestAnimationFrame` flush.

## Continue Watching load time (home)

The Continue Watching section used to load late on cold start because its display was gated on network metadata and sat behind the catalog-row load barrier. Result: **cold start is now down to ~2–3s, and subsequent app loads are instant.**

- **Instant first paint via snapshot hydration** — the computed Continue Watching display is persisted per profile + watch-source in `localStorage` and hydrated synchronously before the first render. On launch the section paints from the last-known snapshot (zero network), then reconciles fresh data fire-and-forget with no skeleton flash.
- **Decoupled from the catalog-row barrier** — Continue Watching no longer sits on the awaited `Promise.all` that gated home rows, so a slow addon or Trakt call can't delay catalog rows. A single background block is now the sole reconciliation path (also removes a duplicate metadata-enrichment pass).
- **Non-blocking, guarded fetches** — progress-meta enrichment runs in parallel; progress-meta and Trakt calls are wrapped in generous stuck-state timeouts (they're no longer on the critical path), and null metadata is no longer cached on timeout so a single slow response doesn't leave an item unenriched for the full cache TTL.

## Bug fixes

- **Filter/route/insight tab width overflow** — these tabs rendered at equal widths with text wrapping onto multiple lines because `base.css` applies `min-width: 0` to every element. They now size to their content (`flex-shrink: 0` + `white-space: nowrap`) and the row scrolls horizontally.
- **Trailer cards showing "Item id mancante."** — trailer cards share the `.detail-morelike-card` class with "More Like This" cards, so the poster-hold path hijacked OK and navigated to a detail route using a non-existent `itemId`. Trailer cards are now excluded from that path (they dispatch their own `openSharedTrailer` action), and `openMoreLikeDetailFromNode` guards against a missing id.
- **YouTube trailer embed (Error 153)** #167  — on packaged builds the app runs from a `file://` origin, which YouTube rejects with a player-configuration error. `getYoutubeProxyBaseUrl` now prefers a configured https `YOUTUBE_PROXY_URL` on webOS/Tizen (falling back to the bundled local proxy) so the embedding origin is valid; the proxy uses the `youtube.com` host, sends an https `widget_referrer`, and falls back to a direct embed if the API player fails to initialise. The proxy URL no longer hard-codes `muted=1`, so user-initiated trailers play with sound.

## Backdrop artwork

- The details backdrop is tracked via `data-backdrop-url`; redundant re-assignments are skipped and a changed artwork (e.g. from TMDB enrichment) is preloaded and swapped only after it decodes, so the previous artwork no longer flashes out before the new one is ready.

## Notes / scope

- The https-proxy preference is opt-in through the existing `YOUTUBE_PROXY_URL` config; behaviour is unchanged when it isn't set, and the bundled local proxy remains the default/fallback.
- Some main-thread work still occurs while detail metadata loads; further reduction is possible but left out to keep this PR focused.
