### PR TITLE
fix(discover): show addons with optional search extras in Discovery

### DIFF
--- a/js/ui/screens/search/discoverScreen.js
+++ b/js/ui/screens/search/discoverScreen.js
@@ -337,7 +337,9 @@ export const DiscoverScreen = {
     this.catalogs = [];
     addons.forEach((addon) => {
       addon.catalogs.forEach((catalog) => {
-        const isSearchOnly = (catalog.extra || []).some((extra) => extra?.name === "search");
+        const isSearchOnly = (catalog.extra || []).some(
+          (extra) => extra?.name === "search" && Boolean(extra?.isRequired)
+        );
         if (isSearchOnly) return;
         const type = String(catalog.apiType || "").trim();
         if (!type) return;


### PR DESCRIPTION
## Problem

The Discovery screen excluded any catalog that declared a `search` extra, even when that extra was optional (the catalog still supports genre browsing without a search term). Addons that support both genre browsing and search, such as NexoTV, were completely hidden from the Discovery section.

## Root cause

`loadCatalogsAndContent()` in `discoverScreen.js` used:
```js
const isSearchOnly = (catalog.extra || []).some((extra) => extra?.name === "search");
```
This matches any catalog that even mentions "search" in its extras, regardless of whether search is required.

The home screen's `homeCatalogs.js` correctly uses `isRequired` to decide whether a catalog belongs on the home screen vs. discover. The discover screen should apply the equivalent check.

## Fix

Changed the filter to only exclude catalogs where the search extra is explicitly marked as required:
```js
const isSearchOnly = (catalog.extra || []).some(
  (extra) => extra?.name === "search" && Boolean(extra?.isRequired)
);
```

Catalogs that support optional search (can be browsed by genre without a query) are now correctly shown in Discovery.

Closes #212