### PR TITLE
feat(stream): remember last played stream per content item

### DIFF
--- a/js/data/local/streamPreferencesStore.js
+++ b/js/data/local/streamPreferencesStore.js
@@ -1,0 +1,73 @@
+import { LocalStore } from "../../core/storage/localStore.js";
+import { ProfileManager } from "../../core/profile/profileManager.js";
+
+const KEY = "streamPreferences";
+const MAX_ENTRIES = 500;
+
+function activeProfileId() {
+  return String(ProfileManager.getActiveProfileId() || "1");
+}
+
+function buildContentKey(contentId, videoId) {
+  const cid = String(contentId || "").trim();
+  const vid = String(videoId || "").trim();
+  return vid && vid !== cid ? `${cid}::${vid}` : cid;
+}
+
+function readAll() {
+  const raw = LocalStore.get(KEY, {});
+  return raw && typeof raw === "object" ? raw : {};
+}
+
+function writeAll(next) {
+  LocalStore.set(KEY, next && typeof next === "object" ? next : {});
+}
+
+function readForProfile(profileId = activeProfileId()) {
+  const pid = String(profileId || "1");
+  const all = readAll();
+  const prefs = all[pid];
+  return prefs && typeof prefs === "object" ? prefs : {};
+}
+
+function writeForProfile(profileId, prefs) {
+  const pid = String(profileId || "1");
+  const all = readAll();
+  all[pid] = prefs;
+  writeAll(all);
+}
+
+export const StreamPreferencesStore = {
+
+  get(contentId, videoId, profileId = activeProfileId()) {
+    const key = buildContentKey(contentId, videoId);
+    if (!key) {
+      return null;
+    }
+    return String(readForProfile(profileId)[key] || "") || null;
+  },
+
+  set(contentId, videoId, streamId, profileId = activeProfileId()) {
+    const key = buildContentKey(contentId, videoId);
+    const sid = String(streamId || "").trim();
+    if (!key || !sid) {
+      return;
+    }
+    const prefs = readForProfile(profileId);
+    // Remove this key if already present so the rebuild moves it to the front.
+    delete prefs[key];
+    // Enforce the cap by evicting the oldest entries. Existing keys are stored
+    // newest-first, so the oldest entries live at the end of the list.
+    const keys = Object.keys(prefs);
+    while (keys.length >= MAX_ENTRIES) {
+      delete prefs[keys.pop()];
+    }
+    // Rebuild with the just-used key first (most recently used).
+    const next = { [key]: sid };
+    for (const k of keys) {
+      next[k] = prefs[k];
+    }
+    writeForProfile(profileId, next);
+  }
+
+};

--- a/js/data/local/streamPreferencesStore.js
+++ b/js/data/local/streamPreferencesStore.js
@@ -23,17 +23,21 @@ function writeAll(next) {
   LocalStore.set(KEY, next && typeof next === "object" ? next : {});
 }
 
-function readForProfile(profileId = activeProfileId()) {
-  const pid = String(profileId || "1");
+// Entries are stored as an explicit newest-first array so ordering never relies
+// on JavaScript object key iteration: a numeric-looking content id used as an
+// object key would otherwise be reordered ahead of string keys and corrupt the
+// cap eviction.
+function readEntries(profileId = activeProfileId()) {
   const all = readAll();
-  const prefs = all[pid];
-  return prefs && typeof prefs === "object" ? prefs : {};
+  const list = all[String(profileId || "1")];
+  return Array.isArray(list)
+    ? list.filter((entry) => entry && typeof entry === "object" && entry.key)
+    : [];
 }
 
-function writeForProfile(profileId, prefs) {
-  const pid = String(profileId || "1");
+function writeEntries(profileId, entries) {
   const all = readAll();
-  all[pid] = prefs;
+  all[String(profileId || "1")] = entries;
   writeAll(all);
 }
 
@@ -44,7 +48,8 @@ export const StreamPreferencesStore = {
     if (!key) {
       return null;
     }
-    return String(readForProfile(profileId)[key] || "") || null;
+    const entry = readEntries(profileId).find((item) => item.key === key);
+    return entry ? (String(entry.streamId || "") || null) : null;
   },
 
   set(contentId, videoId, streamId, profileId = activeProfileId()) {
@@ -53,21 +58,13 @@ export const StreamPreferencesStore = {
     if (!key || !sid) {
       return;
     }
-    const prefs = readForProfile(profileId);
-    // Remove this key if already present so the rebuild moves it to the front.
-    delete prefs[key];
-    // Enforce the cap by evicting the oldest entries. Existing keys are stored
-    // newest-first, so the oldest entries live at the end of the list.
-    const keys = Object.keys(prefs);
-    while (keys.length >= MAX_ENTRIES) {
-      delete prefs[keys.pop()];
+    const entries = readEntries(profileId).filter((item) => item.key !== key);
+    // Newest first; drop the oldest entries once the cap is exceeded.
+    entries.unshift({ key, streamId: sid });
+    if (entries.length > MAX_ENTRIES) {
+      entries.length = MAX_ENTRIES;
     }
-    // Rebuild with the just-used key first (most recently used).
-    const next = { [key]: sid };
-    for (const k of keys) {
-      next[k] = prefs[k];
-    }
-    writeForProfile(profileId, next);
+    writeEntries(profileId, entries);
   }
 
 };

--- a/js/ui/screens/detail/metaDetailsScreen.js
+++ b/js/ui/screens/detail/metaDetailsScreen.js
@@ -25,6 +25,7 @@ import {
   posterItemFromNode,
   PosterOptionsDialogController
 } from "../../components/posterOptionsMenu.js";
+import { StreamPreferencesStore } from "../../../data/local/streamPreferencesStore.js";
 import {
   WATCH_PROGRESS_COMPLETED_THRESHOLD,
   getWatchProgressFraction,
@@ -5286,6 +5287,7 @@ export const MetaDetailsScreen = {
       parentalWarnings: this.meta?.parentalWarnings || null,
       parentalGuide: this.meta?.parentalGuide || null,
       videoId: episode.id,
+      preferredStreamId: StreamPreferencesStore.get(this.params?.itemId, episode.id) || null,
       season: episode.season,
       episode: episode.episode,
       episodeTitle: episode.title || "",
@@ -5321,6 +5323,7 @@ export const MetaDetailsScreen = {
       parentalWarnings: this.meta?.parentalWarnings || null,
       parentalGuide: this.meta?.parentalGuide || null,
       videoId: this.params?.itemId || null,
+      preferredStreamId: StreamPreferencesStore.get(this.params?.itemId, this.params?.itemId) || null,
       episodes: [],
       ...extraParams
     });

--- a/js/ui/screens/player/playerScreen.js
+++ b/js/ui/screens/player/playerScreen.js
@@ -22,6 +22,7 @@ import { TraktScrobbleService } from "../../../data/repository/traktScrobbleServ
 import { WebOsEngineFsResolver } from "../../../core/p2p/webosEngineFsResolver.js";
 import { TizenStreamingServerResolver } from "../../../core/p2p/tizenStreamingServerResolver.js";
 import { requestWebOsCompanionService, subscribeWebOsCompanionService } from "../../../platform/webos/webosCompanionService.js";
+import { StreamPreferencesStore } from "../../../data/local/streamPreferencesStore.js";
 
 const CLOCK_FORMATTER_CACHE = new Map();
 const LANGUAGE_DISPLAY_NAME_CACHE = new Map();
@@ -1611,6 +1612,17 @@ export const PlayerScreen = {
     ));
     if (this.currentStreamIndex < 0) {
       this.currentStreamIndex = 0;
+    }
+    // Remember the stream that actually plays so the stream list can focus it on
+    // the next visit. Only persist when the caller provided a real candidate list
+    // (this skips trailers and synthetic single-url playback).
+    if (Array.isArray(params.streamCandidates) && params.streamCandidates.length) {
+      const playingStreamCandidate = this.streamCandidates[this.currentStreamIndex] || null;
+      const prefContentId = String(params?.itemId || "").trim();
+      const prefVideoId = String(params?.videoId || params?.itemId || "").trim();
+      if (playingStreamCandidate?.id && prefContentId) {
+        StreamPreferencesStore.set(prefContentId, prefVideoId, playingStreamCandidate.id);
+      }
     }
     this.activePlaybackSourceContext = this.getPlaybackSourceContext(
       preferredStreamCandidate || initialStreamCandidate || this.streamCandidates[this.currentStreamIndex] || null

--- a/js/ui/screens/stream/streamScreen.js
+++ b/js/ui/screens/stream/streamScreen.js
@@ -1574,7 +1574,13 @@ export const StreamScreen = {
       ));
       this.loading = false;
       if (this.streams.length) {
-        this.focusState = { zone: "card", index: clamp(Number(this.focusState?.index || 0), 0, this.streams.length - 1) };
+        const preferred = String(this.params?.preferredStreamId || "").trim();
+        let initialIndex = 0;
+        if (preferred) {
+          const prefIdx = this.getFilteredStreams().findIndex((s) => String(s?.id || "") === preferred);
+          if (prefIdx >= 0) { initialIndex = prefIdx; }
+        }
+        this.focusState = { zone: "card", index: clamp(initialIndex, 0, this.streams.length - 1) };
       } else {
         this.focusState = { zone: "filter", index: 0 };
       }

--- a/js/ui/screens/stream/streamScreen.js
+++ b/js/ui/screens/stream/streamScreen.js
@@ -1574,13 +1574,15 @@ export const StreamScreen = {
       ));
       this.loading = false;
       if (this.streams.length) {
+        const visibleStreams = this.getFilteredStreams();
+        const maxCardIndex = Math.max(0, visibleStreams.length - 1);
+        let initialIndex = clamp(Number(this.focusState?.index || 0), 0, maxCardIndex);
         const preferred = String(this.params?.preferredStreamId || "").trim();
-        let initialIndex = 0;
         if (preferred) {
-          const prefIdx = this.getFilteredStreams().findIndex((s) => String(s?.id || "") === preferred);
+          const prefIdx = visibleStreams.findIndex((s) => String(s?.id || "") === preferred);
           if (prefIdx >= 0) { initialIndex = prefIdx; }
         }
-        this.focusState = { zone: "card", index: clamp(initialIndex, 0, this.streams.length - 1) };
+        this.focusState = { zone: "card", index: clamp(initialIndex, 0, maxCardIndex) };
       } else {
         this.focusState = { zone: "filter", index: 0 };
       }


### PR DESCRIPTION
## Problem

When a user selects a stream source for a movie or episode, the app forgets that choice on the next visit. Every session requires re-picking the same source from the stream list, which is tedious on a TV remote (issue #203).

## Solution

Added a lightweight per-profile local preference store (`streamPreferencesStore.js`) that records the last stream id used per content item (keyed by contentId and videoId). It follows the same profile-scoped LocalStore pattern already used by `continueWatchingPreferences.js`, and is capped at 500 entries with the oldest evicted first.

Flow:
1. When playback starts, the player saves the id of the stream that actually plays (the candidate resolved at `currentStreamIndex`). It only saves when the caller provided a real candidate list, so trailers and synthetic single-url playback are skipped.
2. When the detail screen navigates to the stream screen (for both movies and episodes), the saved id is passed as `preferredStreamId`.
3. The stream screen focuses the matching stream card after loading.

Advisory behavior: if the saved stream id is not found in the current list (the addon changed its ids, or the stream was removed), the stream screen falls back to the first card as before. No errors are surfaced to the user.

Rebased on the latest main (0.2.6).

Closes #203
