### PR TITLE
fix: resolve TV issues #230–#233 (subtitles, resume, webOS relaunch, addon sync)

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -9101,6 +9101,15 @@ button:focus-visible {
   color: var(--addons-text-tertiary);
 }
 
+.addons-sync-status {
+  margin: 8px 0 0;
+  font-size: 18px;
+  line-height: 26px;
+  letter-spacing: 0.2px;
+  color: var(--addons-text-tertiary);
+  opacity: 0.85;
+}
+
 .addons-install-card {
   border-radius: 24px;
   background: var(--addons-card);

--- a/js/app.js
+++ b/js/app.js
@@ -165,15 +165,23 @@ async function setupWebOsAppLifecycle() {
     return;
   }
   // webOS keeps the app resident when it is backgrounded (e.g. the user presses
-  // Home instead of exiting from the in-app menu). Relaunching the icon then
-  // fires `webOSRelaunch` on the existing JS context instead of reloading the
-  // page. With no handler the resident instance could stay on a stale/blank
-  // frame and ignore the remote, so the app looked impossible to reopen until a
-  // TV reboot (issue #233). Re-mounting the active route re-renders the UI and
-  // restores focus.
+  // the TV Home button). Bringing the app back to the foreground fires a launch
+  // event on the existing JS context instead of reloading the page. Without a
+  // handler the resident instance stays on a stale frame and ignores the remote,
+  // making the app impossible to reopen until a TV reboot (issue #233).
+  //
+  // Which event fires depends on webOS version:
+  //   webOS 5+  → webOSRelaunch
+  //   webOS 4   → webOSLaunch  (also fires on the initial launch — guarded below)
+  //   some builds → neither; the WebView is just unfrozen (visibilitychange only)
   let recovering = false;
   const recover = async () => {
     if (recovering || !appShellRendered) {
+      return;
+    }
+    const current = Router.getCurrent();
+    // No route yet → still in initial bootstrap, not a relaunch.
+    if (!current) {
       return;
     }
     recovering = true;
@@ -181,12 +189,12 @@ async function setupWebOsAppLifecycle() {
       if (document.body) {
         document.body.style.removeProperty("display");
       }
-      const current = Router.getCurrent();
-      // Player/stream routes own transient playback state; send a relaunch to a
-      // safe, fully re-mountable screen instead of trying to rebuild them.
+      // Player/stream routes own transient playback state; recover to a safe
+      // fully re-mountable screen instead.
       const isTransientRoute = current === "player" || current === "stream";
-      const target = current && !isTransientRoute ? current : "home";
-      await Router.navigate(target, target === current ? Router.currentParams || {} : {}, {
+      const target = isTransientRoute ? "home" : current;
+      const params = target === current ? Router.currentParams || {} : {};
+      await Router.navigate(target, params, {
         replaceHistory: true,
         skipStackPush: true
       });
@@ -196,8 +204,24 @@ async function setupWebOsAppLifecycle() {
       recovering = false;
     }
   };
+
   document.addEventListener("webOSRelaunch", () => {
     void recover();
+  });
+
+  // webOS 4.x and earlier fire webOSLaunch instead of webOSRelaunch when
+  // bringing a backgrounded app to the foreground. The !current guard above
+  // skips the initial-launch invocation so we don't double-navigate on startup.
+  document.addEventListener("webOSLaunch", () => {
+    void recover();
+  });
+
+  // Some webOS builds just unfreeze the WebView without firing any named launch
+  // event — visibilitychange is the only signal available in those cases.
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "visible") {
+      void recover();
+    }
   });
 }
 

--- a/js/app.js
+++ b/js/app.js
@@ -100,19 +100,13 @@ function supportsAspectRatio() {
 }
 
 function applyPerformanceMode() {
-  const constrained =
-    Platform.isWebOS() || Platform.isTizen() || isLowEndDevice();
-  const webOsMajorVersion = Platform.isWebOS()
-    ? Number(Platform.getWebOsMajorVersion() || 0)
-    : 0;
+  const constrained = Platform.isWebOS() || Platform.isTizen() || isLowEndDevice();
+  const webOsMajorVersion = Platform.isWebOS() ? Number(Platform.getWebOsMajorVersion() || 0) : 0;
   const legacyWebOs = webOsMajorVersion > 0 && webOsMajorVersion <= 6;
   const legacyTizen = Platform.isTizen();
   const flexGapUnsupported = !supportsFlexGap();
   const aspectRatioUnsupported = !supportsAspectRatio();
-  document.documentElement.classList.toggle(
-    "performance-constrained",
-    constrained,
-  );
+  document.documentElement.classList.toggle("performance-constrained", constrained);
   document.body.classList.toggle("performance-constrained", constrained);
   document.documentElement.classList.toggle("legacy-webos", legacyWebOs);
   document.body.classList.toggle("legacy-webos", legacyWebOs);
@@ -120,18 +114,13 @@ function applyPerformanceMode() {
   document.body.classList.toggle("legacy-tizen", legacyTizen);
   document.documentElement.classList.toggle("no-flex-gap", flexGapUnsupported);
   document.body.classList.toggle("no-flex-gap", flexGapUnsupported);
-  document.documentElement.classList.toggle(
-    "no-aspect-ratio",
-    aspectRatioUnsupported,
-  );
+  document.documentElement.classList.toggle("no-aspect-ratio", aspectRatioUnsupported);
   document.body.classList.toggle("no-aspect-ratio", aspectRatioUnsupported);
 }
 
 function isAddonRemoteMode() {
   try {
-    return (
-      new URLSearchParams(window.location.search).get("addonsRemote") === "1"
-    );
+    return new URLSearchParams(window.location.search).get("addonsRemote") === "1";
   } catch {
     return false;
   }
@@ -143,14 +132,10 @@ async function shouldShowProfileSelection() {
   const activeProfileId = ProfileManager.getActiveProfileId();
   const pinStates = await ProfileSyncService.pullProfileLockStates();
   const activeProfileHasPin = Boolean(
-    pinStates?.[String(activeProfileId)] ||
-    pinStates?.[Number(activeProfileId)],
+    pinStates?.[String(activeProfileId)] || pinStates?.[Number(activeProfileId)]
   );
 
-  return (
-    !hasSelectedProfileThisSession &&
-    (profiles.length > 1 || activeProfileHasPin)
-  );
+  return !hasSelectedProfileThisSession && (profiles.length > 1 || activeProfileHasPin);
 }
 
 async function routeAfterAuthentication() {
@@ -164,9 +149,7 @@ async function routeAfterAuthentication() {
   const profiles = await ProfileManager.getProfiles();
   const activeProfileId = ProfileManager.getActiveProfileId();
   const activeProfile =
-    profiles.find(
-      (profile) => String(profile.id) === String(activeProfileId),
-    ) ||
+    profiles.find((profile) => String(profile.id) === String(activeProfileId)) ||
     profiles[0] ||
     null;
   if (activeProfile) {
@@ -175,6 +158,47 @@ async function routeAfterAuthentication() {
     await ProfileSettingsSyncService.pull(activeProfile.id);
   }
   Router.navigate("home");
+}
+
+async function setupWebOsAppLifecycle() {
+  if (!Platform.isWebOS()) {
+    return;
+  }
+  // webOS keeps the app resident when it is backgrounded (e.g. the user presses
+  // Home instead of exiting from the in-app menu). Relaunching the icon then
+  // fires `webOSRelaunch` on the existing JS context instead of reloading the
+  // page. With no handler the resident instance could stay on a stale/blank
+  // frame and ignore the remote, so the app looked impossible to reopen until a
+  // TV reboot (issue #233). Re-mounting the active route re-renders the UI and
+  // restores focus.
+  let recovering = false;
+  const recover = async () => {
+    if (recovering || !appShellRendered) {
+      return;
+    }
+    recovering = true;
+    try {
+      if (document.body) {
+        document.body.style.removeProperty("display");
+      }
+      const current = Router.getCurrent();
+      // Player/stream routes own transient playback state; send a relaunch to a
+      // safe, fully re-mountable screen instead of trying to rebuild them.
+      const isTransientRoute = current === "player" || current === "stream";
+      const target = current && !isTransientRoute ? current : "home";
+      await Router.navigate(target, target === current ? Router.currentParams || {} : {}, {
+        replaceHistory: true,
+        skipStackPush: true
+      });
+    } catch (error) {
+      console.warn("webOS relaunch recovery failed", error);
+    } finally {
+      recovering = false;
+    }
+  };
+  document.addEventListener("webOSRelaunch", () => {
+    void recover();
+  });
 }
 
 async function bootstrapApp() {
@@ -188,6 +212,7 @@ async function bootstrapApp() {
   PlayerController.init();
 
   FocusEngine.init();
+  setupWebOsAppLifecycle();
 
   ThemeManager.apply();
   I18n.apply();
@@ -202,9 +227,7 @@ async function bootstrapApp() {
     if (state === AuthState.SIGNED_OUT) {
       StartupSyncService.stop();
       hasSelectedProfileThisSession = false;
-      const shouldBypassQr = Boolean(
-        LocalStore.get(GUEST_QR_BYPASS_KEY, false),
-      );
+      const shouldBypassQr = Boolean(LocalStore.get(GUEST_QR_BYPASS_KEY, false));
       if (isSignedOutRouteAllowed()) {
         return;
       }
@@ -216,15 +239,15 @@ async function bootstrapApp() {
             {},
             {
               replaceHistory: true,
-              skipStackPush: true,
-            },
+              skipStackPush: true
+            }
           );
         }
         return;
       }
       const hasSeenQr = LocalStore.get("hasSeenAuthQrOnFirstLaunch");
       Router.navigate("authQrSignIn", {
-        onboardingMode: !hasSeenQr,
+        onboardingMode: !hasSeenQr
       });
     }
 
@@ -250,20 +273,16 @@ if (document.readyState === "loading") {
   document.addEventListener(
     "DOMContentLoaded",
     () => {
-      const bootstrap = isAddonRemoteMode()
-        ? bootstrapAddonRemoteMode
-        : bootstrapApp;
+      const bootstrap = isAddonRemoteMode() ? bootstrapAddonRemoteMode : bootstrapApp;
       bootstrap().catch((error) => {
         console.error("App bootstrap failed", error);
         renderFatalError(error);
       });
     },
-    { once: true },
+    { once: true }
   );
 } else {
-  const bootstrap = isAddonRemoteMode()
-    ? bootstrapAddonRemoteMode
-    : bootstrapApp;
+  const bootstrap = isAddonRemoteMode() ? bootstrapAddonRemoteMode : bootstrapApp;
   bootstrap().catch((error) => {
     console.error("App bootstrap failed", error);
     renderFatalError(error);

--- a/js/core/player/playerController.js
+++ b/js/core/player/playerController.js
@@ -28,7 +28,6 @@ function isValidAvPlayTrackSelectionState(state) {
 }
 
 export const PlayerController = {
-
   video: null,
   isPlaying: false,
   currentItemId: null,
@@ -84,12 +83,17 @@ export const PlayerController = {
     if (name === "aborterror") {
       return true;
     }
-    return message.includes("interrupted by a new load request")
-      || message.includes("the play() request was interrupted");
+    return (
+      message.includes("interrupted by a new load request") ||
+      message.includes("the play() request was interrupted")
+    );
   },
 
   normalizeMimeType(mimeType) {
-    return String(mimeType || "").toLowerCase().split(";")[0].trim();
+    return String(mimeType || "")
+      .toLowerCase()
+      .split(";")[0]
+      .trim();
   },
 
   normalizePlaybackSourceType(sourceType) {
@@ -123,9 +127,9 @@ export const PlayerController = {
       return null;
     }
     if (
-      this.isLikelyHlsMimeType(normalized)
-      || this.isLikelyDashMimeType(normalized)
-      || this.isLikelySmoothStreamingMimeType(normalized)
+      this.isLikelyHlsMimeType(normalized) ||
+      this.isLikelyDashMimeType(normalized) ||
+      this.isLikelySmoothStreamingMimeType(normalized)
     ) {
       return normalized;
     }
@@ -141,11 +145,11 @@ export const PlayerController = {
     const inferByPath = (pathname = "", search = null) => {
       const path = String(pathname || "").toLowerCase();
       const formatHint = String(
-        search?.get?.("format")
-        || search?.get?.("type")
-        || search?.get?.("mime")
-        || search?.get?.("output")
-        || ""
+        search?.get?.("format") ||
+          search?.get?.("type") ||
+          search?.get?.("mime") ||
+          search?.get?.("output") ||
+          ""
       ).toLowerCase();
       if (path.endsWith(".m3u8")) {
         return "application/vnd.apple.mpegurl";
@@ -165,7 +169,9 @@ export const PlayerController = {
       if (path.includes("/playlist")) {
         return "application/vnd.apple.mpegurl";
       }
-      const extensionMatch = path.match(/\.(mp4|m4v|mov|webm|mkv|avi|wmv|ts|m2ts|mpg|mpeg|3gp|mp3|aac|flac)(?=($|[/?#&]))/i);
+      const extensionMatch = path.match(
+        /\.(mp4|m4v|mov|webm|mkv|avi|wmv|ts|m2ts|mpg|mpeg|3gp|mp3|aac|flac)(?=($|[/?#&]))/i
+      );
       if (extensionMatch) {
         const extension = String(extensionMatch[1] || "").toLowerCase();
         const directMimeMap = {
@@ -200,10 +206,12 @@ export const PlayerController = {
 
   isLikelyHlsMimeType(mimeType) {
     const normalized = this.normalizeMimeType(mimeType);
-    return normalized === "application/vnd.apple.mpegurl"
-      || normalized === "application/x-mpegurl"
-      || normalized === "audio/mpegurl"
-      || normalized === "audio/x-mpegurl";
+    return (
+      normalized === "application/vnd.apple.mpegurl" ||
+      normalized === "application/x-mpegurl" ||
+      normalized === "audio/mpegurl" ||
+      normalized === "audio/x-mpegurl"
+    );
   },
 
   isLikelyDashMimeType(mimeType) {
@@ -228,9 +236,11 @@ export const PlayerController = {
 
   isUnsupportedSourceError(error) {
     const message = String(error?.message || "").toLowerCase();
-    return message.includes("no supported source")
-      || message.includes("no supported sources")
-      || message.includes("not supported");
+    return (
+      message.includes("no supported source") ||
+      message.includes("no supported sources") ||
+      message.includes("not supported")
+    );
   },
 
   getPlatformAvplayEngine() {
@@ -258,7 +268,9 @@ export const PlayerController = {
       return "";
     }
     try {
-      return String(avplay.getState?.() || "").trim().toUpperCase();
+      return String(avplay.getState?.() || "")
+        .trim()
+        .toUpperCase();
     } catch (_) {
       return "";
     }
@@ -293,20 +305,22 @@ export const PlayerController = {
       parameters: {
         configNames: ["tv.model.edidType"]
       }
-    }).then((result) => {
-      const edidType = String(result?.configs?.["tv.model.edidType"] || "").toLowerCase();
-      if (edidType.includes("dts")) {
-        this.webosUnsupportedAudioCodecs.delete("dts");
-      }
-      if (edidType.includes("truehd")) {
-        this.webosUnsupportedAudioCodecs.delete("truehd");
-      }
-      return {
+    })
+      .then((result) => {
+        const edidType = String(result?.configs?.["tv.model.edidType"] || "").toLowerCase();
+        if (edidType.includes("dts")) {
+          this.webosUnsupportedAudioCodecs.delete("dts");
+        }
+        if (edidType.includes("truehd")) {
+          this.webosUnsupportedAudioCodecs.delete("truehd");
+        }
+        return {
+          unsupportedAudioCodecs: this.getWebOsUnsupportedAudioCodecs()
+        };
+      })
+      .catch(() => ({
         unsupportedAudioCodecs: this.getWebOsUnsupportedAudioCodecs()
-      };
-    }).catch(() => ({
-      unsupportedAudioCodecs: this.getWebOsUnsupportedAudioCodecs()
-    }));
+      }));
 
     return this.webosDeviceInfoPromise;
   },
@@ -318,7 +332,10 @@ export const PlayerController = {
   getWebOsUnsupportedAudioPenalty(text = "") {
     const normalizedText = String(text || "").toLowerCase();
     let penalty = 0;
-    if (this.webosUnsupportedAudioCodecs.has("dts") && /\b(dts-hd|dts:x|dts)\b/.test(normalizedText)) {
+    if (
+      this.webosUnsupportedAudioCodecs.has("dts") &&
+      /\b(dts-hd|dts:x|dts)\b/.test(normalizedText)
+    ) {
       penalty -= 45;
     }
     if (this.webosUnsupportedAudioCodecs.has("truehd") && /\btruehd\b/.test(normalizedText)) {
@@ -344,7 +361,11 @@ export const PlayerController = {
       // Ignore decode failures.
     }
 
-    return probes.some((value) => /\.(mkv|mp4|m4v|mov|webm|avi|wmv|ts|m2ts|mpg|mpeg|3gp)(?=($|[/?#&]))/i.test(String(value || "")));
+    return probes.some((value) =>
+      /\.(mkv|mp4|m4v|mov|webm|avi|wmv|ts|m2ts|mpg|mpeg|3gp)(?=($|[/?#&]))/i.test(
+        String(value || "")
+      )
+    );
   },
 
   isUsingAvPlay() {
@@ -357,13 +378,14 @@ export const PlayerController = {
     }
 
     try {
-      const event = typeof CustomEvent === "function"
-        ? new CustomEvent(eventName, { detail: detail || null })
-        : (() => {
-          const legacyEvent = document.createEvent("CustomEvent");
-          legacyEvent.initCustomEvent(eventName, false, false, detail || null);
-          return legacyEvent;
-        })();
+      const event =
+        typeof CustomEvent === "function"
+          ? new CustomEvent(eventName, { detail: detail || null })
+          : (() => {
+              const legacyEvent = document.createEvent("CustomEvent");
+              legacyEvent.initCustomEvent(eventName, false, false, detail || null);
+              return legacyEvent;
+            })();
       this.video.dispatchEvent(event);
     } catch (_) {
       // Ignore synthetic event failures.
@@ -453,7 +475,10 @@ export const PlayerController = {
       const gated = Boolean(this.startupAudioGateActive);
       this.video.muted = gated;
       this.video.defaultMuted = gated;
-      if (!gated && (!Number.isFinite(Number(this.video.volume)) || Number(this.video.volume) <= 0)) {
+      if (
+        !gated &&
+        (!Number.isFinite(Number(this.video.volume)) || Number(this.video.volume) <= 0)
+      ) {
         this.video.volume = 1;
       }
     } catch (_) {
@@ -500,11 +525,13 @@ export const PlayerController = {
       return playPromise;
     }
     if (playPromise && typeof playPromise.then === "function") {
-      playPromise.then(() => {
-        this.pauseNativePlaybackForStartupGate();
-      }).catch(() => {
-        // The normal playback-start rejection handler reports real failures.
-      });
+      playPromise
+        .then(() => {
+          this.pauseNativePlaybackForStartupGate();
+        })
+        .catch(() => {
+          // The normal playback-start rejection handler reports real failures.
+        });
       return playPromise;
     }
     this.pauseNativePlaybackForStartupGate();
@@ -563,19 +590,24 @@ export const PlayerController = {
           this.applyPendingAvPlayAudioTrackSelection();
         }, delayMs);
       });
-      setTimeout(() => {
-        if (!this.isUsingAvPlay()) {
-          return;
-        }
-        this.applyPendingAvPlayAudioTrackSelection();
-        if (syncTracks) {
-          this.syncAvPlayTrackInfo({ force: true });
-          this.emitVideoEvent("avplaytrackschanged", { playbackEngine: this.playbackEngine });
-        }
-      }, syncTracks ? 500 : 300);
+      setTimeout(
+        () => {
+          if (!this.isUsingAvPlay()) {
+            return;
+          }
+          this.applyPendingAvPlayAudioTrackSelection();
+          if (syncTracks) {
+            this.syncAvPlayTrackInfo({ force: true });
+            this.emitVideoEvent("avplaytrackschanged", { playbackEngine: this.playbackEngine });
+          }
+        },
+        syncTracks ? 500 : 300
+      );
       return true;
     } catch (error) {
-      this.lastPlaybackErrorCode = this.mapAvPlayErrorToMediaCode(error?.name || error?.message || error);
+      this.lastPlaybackErrorCode = this.mapAvPlayErrorToMediaCode(
+        error?.name || error?.message || error
+      );
       this.isPlaying = false;
       this.emitVideoEvent("error", {
         playbackEngine: this.playbackEngine,
@@ -626,7 +658,9 @@ export const PlayerController = {
   },
 
   normalizeAvPlayTrackType(typeValue) {
-    const type = String(typeValue || "").trim().toUpperCase();
+    const type = String(typeValue || "")
+      .trim()
+      .toUpperCase();
     if (type === "AUDIO" || type === "TEXT" || type === "SUBTITLE" || type === "VIDEO") {
       return type;
     }
@@ -645,24 +679,20 @@ export const PlayerController = {
   pickAvPlayTrackLabel(track = {}, trackIndex = 0, prefix = "Track") {
     const extraInfo = this.parseAvPlayExtraInfo(track.extra_info || track.extraInfo || null) || {};
     return String(
-      track.name
-      || track.label
-      || extraInfo.name
-      || extraInfo.label
-      || extraInfo.track_lang
-      || extraInfo.language
-      || `${prefix} ${trackIndex + 1}`
+      track.name ||
+        track.label ||
+        extraInfo.name ||
+        extraInfo.label ||
+        extraInfo.track_lang ||
+        extraInfo.language ||
+        `${prefix} ${trackIndex + 1}`
     ).trim();
   },
 
   pickAvPlayTrackLanguage(track = {}) {
     const extraInfo = this.parseAvPlayExtraInfo(track.extra_info || track.extraInfo || null) || {};
     return String(
-      track.language
-      || track.lang
-      || extraInfo.track_lang
-      || extraInfo.language
-      || ""
+      track.language || track.lang || extraInfo.track_lang || extraInfo.language || ""
     ).trim();
   },
 
@@ -697,7 +727,7 @@ export const PlayerController = {
 
     const force = Boolean(options?.force);
     const now = Date.now();
-    if (!force && (now - Number(this.avplayTrackSyncAt || 0)) < 220) {
+    if (!force && now - Number(this.avplayTrackSyncAt || 0) < 220) {
       return;
     }
     this.avplayTrackSyncAt = now;
@@ -720,8 +750,12 @@ export const PlayerController = {
       }
     })();
 
-    const currentAudio = currentTracks.find((track) => this.normalizeAvPlayTrackType(track?.type) === "AUDIO");
-    const currentText = currentTracks.find((track) => this.normalizeAvPlayTrackType(track?.type) === "TEXT");
+    const currentAudio = currentTracks.find(
+      (track) => this.normalizeAvPlayTrackType(track?.type) === "AUDIO"
+    );
+    const currentText = currentTracks.find(
+      (track) => this.normalizeAvPlayTrackType(track?.type) === "TEXT"
+    );
     const selectedAudioIndex = Number(currentAudio?.index);
     const selectedTextIndex = Number(currentText?.index);
 
@@ -730,11 +764,9 @@ export const PlayerController = {
       .map((track, index) => {
         const trackIndex = Number(track?.index);
         const normalizedTrackIndex = Number.isFinite(trackIndex) ? trackIndex : -1;
-        const extraInfo = this.parseAvPlayExtraInfo(track.extra_info || track.extraInfo || null) || {};
-        const forcedValue = this.pickAvPlayExtraValue(extraInfo, [
-          "forced",
-          "is_forced"
-        ]);
+        const extraInfo =
+          this.parseAvPlayExtraInfo(track.extra_info || track.extraInfo || null) || {};
+        const forcedValue = this.pickAvPlayExtraValue(extraInfo, ["forced", "is_forced"]);
         return {
           id: `avplay-audio-${normalizedTrackIndex}`,
           label: this.pickAvPlayTrackLabel(track, index, "Track"),
@@ -764,18 +796,19 @@ export const PlayerController = {
           avplayAudioOrdinalIndex: index
         };
       })
-      .filter((track) => Number.isFinite(Number(track?.avplayTrackIndex)) && Number(track.avplayTrackIndex) >= 0);
+      .filter(
+        (track) =>
+          Number.isFinite(Number(track?.avplayTrackIndex)) && Number(track.avplayTrackIndex) >= 0
+      );
 
     this.avplaySubtitleTracks = totalTracks
       .filter((track) => this.normalizeAvPlayTrackType(track?.type) === "TEXT")
       .map((track, index) => {
         const trackIndex = Number(track?.index);
         const normalizedTrackIndex = Number.isFinite(trackIndex) ? trackIndex : index;
-        const extraInfo = this.parseAvPlayExtraInfo(track.extra_info || track.extraInfo || null) || {};
-        const forcedValue = this.pickAvPlayExtraValue(extraInfo, [
-          "forced",
-          "is_forced"
-        ]);
+        const extraInfo =
+          this.parseAvPlayExtraInfo(track.extra_info || track.extraInfo || null) || {};
+        const forcedValue = this.pickAvPlayExtraValue(extraInfo, ["forced", "is_forced"]);
         return {
           id: `avplay-sub-${normalizedTrackIndex}`,
           label: this.pickAvPlayTrackLabel(track, index, "Subtitle"),
@@ -798,9 +831,10 @@ export const PlayerController = {
     }
 
     const desiredAudioIndex = Number(this.desiredAvPlayAudioTrackIndex);
-    const desiredAudioActive = Number.isFinite(desiredAudioIndex)
-      && desiredAudioIndex >= 0
-      && Date.now() < Number(this.desiredAvPlayAudioTrackUntil || 0);
+    const desiredAudioActive =
+      Number.isFinite(desiredAudioIndex) &&
+      desiredAudioIndex >= 0 &&
+      Date.now() < Number(this.desiredAvPlayAudioTrackUntil || 0);
     const resolvedSelectedAudioIndex = this.resolveAvPlayAudioTrackIndex(selectedAudioIndex);
 
     if (desiredAudioActive) {
@@ -810,7 +844,10 @@ export const PlayerController = {
       this.pendingAvPlayAudioTrackIndex = -1;
       this.desiredAvPlayAudioTrackIndex = -1;
       this.desiredAvPlayAudioTrackUntil = 0;
-    } else if (Number.isFinite(this.pendingAvPlayAudioTrackIndex) && this.pendingAvPlayAudioTrackIndex >= 0) {
+    } else if (
+      Number.isFinite(this.pendingAvPlayAudioTrackIndex) &&
+      this.pendingAvPlayAudioTrackIndex >= 0
+    ) {
       this.selectedAvPlayAudioTrackIndex = this.pendingAvPlayAudioTrackIndex;
     } else if (this.avplayAudioTracks.length && this.selectedAvPlayAudioTrackIndex < 0) {
       this.selectedAvPlayAudioTrackIndex = this.avplayAudioTracks[0].avplayTrackIndex;
@@ -834,7 +871,9 @@ export const PlayerController = {
   },
 
   getSelectedAvPlayAudioTrackIndex() {
-    return Number.isFinite(this.selectedAvPlayAudioTrackIndex) ? this.selectedAvPlayAudioTrackIndex : -1;
+    return Number.isFinite(this.selectedAvPlayAudioTrackIndex)
+      ? this.selectedAvPlayAudioTrackIndex
+      : -1;
   },
 
   resolveAvPlayAudioTrackIndex(trackIndex) {
@@ -842,7 +881,9 @@ export const PlayerController = {
     if (!Number.isFinite(targetIndex) || targetIndex < 0) {
       return -1;
     }
-    const exact = this.avplayAudioTracks.find((track) => Number(track?.avplayTrackIndex) === targetIndex);
+    const exact = this.avplayAudioTracks.find(
+      (track) => Number(track?.avplayTrackIndex) === targetIndex
+    );
     if (exact) {
       return Number(exact.avplayTrackIndex);
     }
@@ -854,7 +895,9 @@ export const PlayerController = {
     if (!Number.isFinite(targetIndex) || targetIndex < 0) {
       return -1;
     }
-    const track = this.avplayAudioTracks.find((entry) => Number(entry?.avplayTrackIndex) === targetIndex);
+    const track = this.avplayAudioTracks.find(
+      (entry) => Number(entry?.avplayTrackIndex) === targetIndex
+    );
     return track ? Number(track.avplayTrackIndex) : -1;
   },
 
@@ -877,7 +920,12 @@ export const PlayerController = {
   trySelectAvPlayAudioTrackIndex(trackIndex, { nudge = false } = {}) {
     const avplay = this.getAvPlay();
     const targetIndex = Number(trackIndex);
-    if (!avplay || typeof avplay.setSelectTrack !== "function" || !Number.isFinite(targetIndex) || targetIndex < 0) {
+    if (
+      !avplay ||
+      typeof avplay.setSelectTrack !== "function" ||
+      !Number.isFinite(targetIndex) ||
+      targetIndex < 0
+    ) {
       return false;
     }
     const state = this.getAvPlayState();
@@ -931,7 +979,9 @@ export const PlayerController = {
   },
 
   getSelectedAvPlaySubtitleTrackIndex() {
-    return Number.isFinite(this.selectedAvPlaySubtitleTrackIndex) ? this.selectedAvPlaySubtitleTrackIndex : -1;
+    return Number.isFinite(this.selectedAvPlaySubtitleTrackIndex)
+      ? this.selectedAvPlaySubtitleTrackIndex
+      : -1;
   },
 
   getSelectedWebOsEmbeddedAudioTrackIndex() {
@@ -985,7 +1035,11 @@ export const PlayerController = {
     }
 
     try {
-      if (!this.trySelectAvPlayAudioTrackIndex(selectionIndex, { nudge: state === "PLAYING" || state === "PAUSED" })) {
+      if (
+        !this.trySelectAvPlayAudioTrackIndex(selectionIndex, {
+          nudge: state === "PLAYING" || state === "PAUSED"
+        })
+      ) {
         throw new Error("setSelectTrack failed");
       }
       this.pendingAvPlayAudioTrackIndex = -1;
@@ -1024,12 +1078,16 @@ export const PlayerController = {
   applyPendingAvPlayAudioTrackSelection() {
     const pendingIndex = Number(this.pendingAvPlayAudioTrackIndex);
     const desiredIndex = Number(this.desiredAvPlayAudioTrackIndex);
-    const desiredActive = Number.isFinite(desiredIndex)
-      && desiredIndex >= 0
-      && Date.now() < Number(this.desiredAvPlayAudioTrackUntil || 0);
-    const targetIndex = Number.isFinite(pendingIndex) && pendingIndex >= 0
-      ? pendingIndex
-      : (desiredActive ? desiredIndex : -1);
+    const desiredActive =
+      Number.isFinite(desiredIndex) &&
+      desiredIndex >= 0 &&
+      Date.now() < Number(this.desiredAvPlayAudioTrackUntil || 0);
+    const targetIndex =
+      Number.isFinite(pendingIndex) && pendingIndex >= 0
+        ? pendingIndex
+        : desiredActive
+          ? desiredIndex
+          : -1;
     const canonicalIndex = this.resolveAvPlayAudioTrackIndex(targetIndex);
     if (!this.isUsingAvPlay() || !Number.isFinite(canonicalIndex) || canonicalIndex < 0) {
       return false;
@@ -1048,7 +1106,11 @@ export const PlayerController = {
     try {
       if (!this.retryAvPlayAudioTrackSelection(canonicalIndex, { nudge: true })) {
         const selectionIndex = this.getAvPlayAudioTrackSelectionIndex(canonicalIndex);
-        if (!this.trySelectAvPlayAudioTrackIndex(selectionIndex, { nudge: state === "PLAYING" || state === "PAUSED" })) {
+        if (
+          !this.trySelectAvPlayAudioTrackIndex(selectionIndex, {
+            nudge: state === "PLAYING" || state === "PAUSED"
+          })
+        ) {
           throw new Error("setSelectTrack failed");
         }
       }
@@ -1072,7 +1134,10 @@ export const PlayerController = {
       return;
     }
     try {
-      const currentMs = Math.max(0, Number(avplay.getCurrentTime?.() || this.avplayCurrentTimeMs || 0));
+      const currentMs = Math.max(
+        0,
+        Number(avplay.getCurrentTime?.() || this.avplayCurrentTimeMs || 0)
+      );
       if (Number.isFinite(currentMs) && currentMs > 0) {
         avplay.seekTo(Math.max(0, currentMs - 1));
       }
@@ -1109,12 +1174,10 @@ export const PlayerController = {
       return false;
     }
 
-    try {
-      avplay.setSilentSubtitle?.(false);
-    } catch (_) {
-      // Ignore subtitle unmute failures.
-    }
-
+    // Tizen AVPlay requires the track to be selected BEFORE unmuting subtitles.
+    // Unmuting first (the previous order) left the chosen track unapplied on
+    // several firmware versions, so subtitles never rendered and the menu
+    // reverted to whatever track was actually active (issue #231).
     try {
       avplay.setSelectTrack?.("TEXT", targetIndex);
     } catch (_) {
@@ -1123,6 +1186,12 @@ export const PlayerController = {
       } catch (_) {
         return false;
       }
+    }
+
+    try {
+      avplay.setSilentSubtitle?.(false);
+    } catch (_) {
+      // Ignore subtitle unmute failures.
     }
 
     this.selectedAvPlaySubtitleTrackIndex = targetIndex;
@@ -1171,11 +1240,13 @@ export const PlayerController = {
     } catch (_) {
       streams = [];
     }
-    const videoTrack = streams.find((track) => this.normalizeAvPlayTrackType(track?.type) === "VIDEO") || null;
+    const videoTrack =
+      streams.find((track) => this.normalizeAvPlayTrackType(track?.type) === "VIDEO") || null;
     if (!videoTrack) {
       return null;
     }
-    const extraInfo = this.parseAvPlayExtraInfo(videoTrack.extra_info || videoTrack.extraInfo || null) || {};
+    const extraInfo =
+      this.parseAvPlayExtraInfo(videoTrack.extra_info || videoTrack.extraInfo || null) || {};
     const widthCandidates = [
       videoTrack.width,
       videoTrack.Width,
@@ -1194,15 +1265,17 @@ export const PlayerController = {
       extraInfo.videoHeight,
       extraInfo.video_height
     ];
-    let width = widthCandidates.map(Number).find((value) => Number.isFinite(value) && value > 0) || 0;
-    let height = heightCandidates.map(Number).find((value) => Number.isFinite(value) && value > 0) || 0;
+    let width =
+      widthCandidates.map(Number).find((value) => Number.isFinite(value) && value > 0) || 0;
+    let height =
+      heightCandidates.map(Number).find((value) => Number.isFinite(value) && value > 0) || 0;
     if (!width || !height) {
       const resolutionText = String(
-        videoTrack.resolution
-        || videoTrack.Resolution
-        || extraInfo.resolution
-        || extraInfo.Resolution
-        || ""
+        videoTrack.resolution ||
+          videoTrack.Resolution ||
+          extraInfo.resolution ||
+          extraInfo.Resolution ||
+          ""
       );
       const match = resolutionText.match(/(\d{2,5})\s*[xX]\s*(\d{2,5})/);
       if (match) {
@@ -1218,7 +1291,11 @@ export const PlayerController = {
     if (!errorText) {
       return 4;
     }
-    if (errorText.includes("network") || errorText.includes("connection") || errorText.includes("timeout")) {
+    if (
+      errorText.includes("network") ||
+      errorText.includes("connection") ||
+      errorText.includes("timeout")
+    ) {
       return 2;
     }
     if (errorText.includes("decode")) {
@@ -1228,12 +1305,18 @@ export const PlayerController = {
   },
 
   getPlayerViewportSize() {
-    const playerRect = this.video?.parentElement?.getBoundingClientRect?.()
-      || document.getElementById("player")?.getBoundingClientRect?.()
-      || null;
+    const playerRect =
+      this.video?.parentElement?.getBoundingClientRect?.() ||
+      document.getElementById("player")?.getBoundingClientRect?.() ||
+      null;
     const playerWidth = Number(playerRect?.width || 0);
     const playerHeight = Number(playerRect?.height || 0);
-    if (Number.isFinite(playerWidth) && playerWidth > 0 && Number.isFinite(playerHeight) && playerHeight > 0) {
+    if (
+      Number.isFinite(playerWidth) &&
+      playerWidth > 0 &&
+      Number.isFinite(playerHeight) &&
+      playerHeight > 0
+    ) {
       return {
         width: Math.max(1, Math.round(playerWidth)),
         height: Math.max(1, Math.round(playerHeight))
@@ -1247,10 +1330,12 @@ export const PlayerController = {
     const visualViewportHeight = Number(globalThis.visualViewport?.height || 0);
     const screenWidth = Number(globalThis.screen?.width || 0);
     const screenHeight = Number(globalThis.screen?.height || 0);
-    const width = [windowWidth, documentWidth, visualViewportWidth, screenWidth]
-      .find((value) => Number.isFinite(value) && value > 0);
-    const height = [windowHeight, documentHeight, visualViewportHeight, screenHeight]
-      .find((value) => Number.isFinite(value) && value > 0);
+    const width = [windowWidth, documentWidth, visualViewportWidth, screenWidth].find(
+      (value) => Number.isFinite(value) && value > 0
+    );
+    const height = [windowHeight, documentHeight, visualViewportHeight, screenHeight].find(
+      (value) => Number.isFinite(value) && value > 0
+    );
     return {
       width: Math.max(1, Math.round(width || 1920)),
       height: Math.max(1, Math.round(height || 1080))
@@ -1263,10 +1348,12 @@ export const PlayerController = {
     const documentHeight = Number(document.documentElement?.clientHeight || 0);
     const windowWidth = Number(window.innerWidth || 0);
     const windowHeight = Number(window.innerHeight || 0);
-    const widthCandidates = [playerSize.width, documentWidth, windowWidth]
-      .filter((value) => Number.isFinite(value) && value > 0);
-    const heightCandidates = [playerSize.height, documentHeight, windowHeight]
-      .filter((value) => Number.isFinite(value) && value > 0);
+    const widthCandidates = [playerSize.width, documentWidth, windowWidth].filter(
+      (value) => Number.isFinite(value) && value > 0
+    );
+    const heightCandidates = [playerSize.height, documentHeight, windowHeight].filter(
+      (value) => Number.isFinite(value) && value > 0
+    );
     return {
       width: Math.max(1, Math.round(widthCandidates[0] || 1920)),
       height: Math.max(1, Math.round(heightCandidates[0] || 1080))
@@ -1401,10 +1488,18 @@ export const PlayerController = {
     }
 
     const headers = requestHeaders && typeof requestHeaders === "object" ? requestHeaders : {};
-    const cookieHeader = Object.entries(headers)
-      .find(([key]) => String(key || "").trim().toLowerCase() === "cookie")?.[1];
-    const userAgentHeader = Object.entries(headers)
-      .find(([key]) => String(key || "").trim().toLowerCase() === "user-agent")?.[1];
+    const cookieHeader = Object.entries(headers).find(
+      ([key]) =>
+        String(key || "")
+          .trim()
+          .toLowerCase() === "cookie"
+    )?.[1];
+    const userAgentHeader = Object.entries(headers).find(
+      ([key]) =>
+        String(key || "")
+          .trim()
+          .toLowerCase() === "user-agent"
+    )?.[1];
 
     try {
       if (cookieHeader) {
@@ -1421,14 +1516,18 @@ export const PlayerController = {
       // Ignore unsupported AVPlay header properties.
     }
     const normalizedSourceType = String(sourceType || "").trim();
-    const isAdaptiveSource = this.isLikelyHlsMimeType(normalizedSourceType)
-      || this.isLikelyDashMimeType(normalizedSourceType)
-      || this.isLikelySmoothStreamingMimeType(normalizedSourceType);
+    const isAdaptiveSource =
+      this.isLikelyHlsMimeType(normalizedSourceType) ||
+      this.isLikelyDashMimeType(normalizedSourceType) ||
+      this.isLikelySmoothStreamingMimeType(normalizedSourceType);
     if (!isAdaptiveSource) {
       return;
     }
     try {
-      avplay.setStreamingProperty("ADAPTIVE_INFO", "STARTBITRATE=HIGHEST|FIXED_MAX_RESOLUTION=3840X2160");
+      avplay.setStreamingProperty(
+        "ADAPTIVE_INFO",
+        "STARTBITRATE=HIGHEST|FIXED_MAX_RESOLUTION=3840X2160"
+      );
     } catch (_) {
       // Ignore adaptive hints on older firmware.
     }
@@ -1454,10 +1553,11 @@ export const PlayerController = {
     this.avplayDurationMs = 0;
     this.lastPlaybackErrorCode = 0;
     this.playbackEngine = this.getPlatformAvplayEngineName();
-    const avplaySourceType = sourceType
-      || this.currentPlaybackMediaSourceType
-      || this.resolveRuntimeSourceType(this.guessMediaMimeType(url))
-      || null;
+    const avplaySourceType =
+      sourceType ||
+      this.currentPlaybackMediaSourceType ||
+      this.resolveRuntimeSourceType(this.guessMediaMimeType(url)) ||
+      null;
 
     this.emitVideoEvent("waiting", { playbackEngine: this.playbackEngine });
 
@@ -1465,7 +1565,9 @@ export const PlayerController = {
       avplay.open(this.avplayUrl);
       this.configureAvPlayForSource(requestHeaders, avplaySourceType);
     } catch (error) {
-      this.lastPlaybackErrorCode = this.mapAvPlayErrorToMediaCode(error?.name || error?.message || error);
+      this.lastPlaybackErrorCode = this.mapAvPlayErrorToMediaCode(
+        error?.name || error?.message || error
+      );
       this.teardownAvPlay();
       this.playbackEngine = "none";
       return false;
@@ -1496,7 +1598,10 @@ export const PlayerController = {
           this.refreshAvPlayTimeline();
           const completedDurationMs = Number(this.avplayDurationMs || 0);
           if (Number.isFinite(completedDurationMs) && completedDurationMs > 0) {
-            this.avplayCurrentTimeMs = Math.max(Number(this.avplayCurrentTimeMs || 0), completedDurationMs);
+            this.avplayCurrentTimeMs = Math.max(
+              Number(this.avplayCurrentTimeMs || 0),
+              completedDurationMs
+            );
           }
           this.emitVideoEvent("ended", { playbackEngine: this.playbackEngine });
           try {
@@ -1655,7 +1760,9 @@ export const PlayerController = {
   },
 
   forceAvPlayFallbackForCurrentSource(reason = "fallback") {
-    const url = String(this.currentPlaybackUrl || this.video?.currentSrc || this.video?.src || "").trim();
+    const url = String(
+      this.currentPlaybackUrl || this.video?.currentSrc || this.video?.src || ""
+    ).trim();
     if (!url || this.avplayFallbackAttempts.has(url) || !this.canUseAvPlay()) {
       return false;
     }
@@ -1706,11 +1813,15 @@ export const PlayerController = {
   },
 
   isLivePlaybackItemType(itemType = this.currentItemType) {
-    const normalized = String(itemType || "").trim().toLowerCase();
-    return normalized === "channel"
-      || normalized === "live"
-      || normalized === "tvchannel"
-      || normalized === "stream";
+    const normalized = String(itemType || "")
+      .trim()
+      .toLowerCase();
+    return (
+      normalized === "channel" ||
+      normalized === "live" ||
+      normalized === "tvchannel" ||
+      normalized === "stream"
+    );
   },
 
   getPlaybackEngineCandidates(url, sourceType = null, itemType = this.currentItemType) {
@@ -1810,7 +1921,11 @@ export const PlayerController = {
     return candidates;
   },
 
-  getAlternativePlaybackEngine(url = this.currentPlaybackUrl, sourceType = this.currentPlaybackMediaSourceType, itemType = this.currentItemType) {
+  getAlternativePlaybackEngine(
+    url = this.currentPlaybackUrl,
+    sourceType = this.currentPlaybackMediaSourceType,
+    itemType = this.currentItemType
+  ) {
     const normalizedUrl = String(url || "").trim();
     if (!normalizedUrl) {
       return null;
@@ -1818,7 +1933,11 @@ export const PlayerController = {
     const attemptedEngines = this.getAttemptedPlaybackEngines(normalizedUrl);
     const currentEngine = String(this.playbackEngine || "").trim();
     const candidates = this.getPlaybackEngineCandidates(normalizedUrl, sourceType, itemType);
-    return candidates.find((candidate) => candidate !== currentEngine && !attemptedEngines.has(candidate)) || null;
+    return (
+      candidates.find(
+        (candidate) => candidate !== currentEngine && !attemptedEngines.has(candidate)
+      ) || null
+    );
   },
 
   isEngineFsPlaybackUrl(url = "") {
@@ -1839,12 +1958,18 @@ export const PlayerController = {
       smoothStreaming: supports("application/vnd.ms-sstr+xml"),
       mp4: supports("video/mp4"),
       mp4H264: supports('video/mp4; codecs="avc1.4d401f,mp4a.40.2"'),
-      mp4Hevc: supports('video/mp4; codecs="hvc1.1.6.L93.B0,mp4a.40.2"') || supports('video/mp4; codecs="hev1.1.6.L93.B0,mp4a.40.2"'),
-      mp4HevcMain10: supports('video/mp4; codecs="hvc1.2.4.L153.B0,mp4a.40.2"') || supports('video/mp4; codecs="hev1.2.4.L153.B0,mp4a.40.2"'),
+      mp4Hevc:
+        supports('video/mp4; codecs="hvc1.1.6.L93.B0,mp4a.40.2"') ||
+        supports('video/mp4; codecs="hev1.1.6.L93.B0,mp4a.40.2"'),
+      mp4HevcMain10:
+        supports('video/mp4; codecs="hvc1.2.4.L153.B0,mp4a.40.2"') ||
+        supports('video/mp4; codecs="hev1.2.4.L153.B0,mp4a.40.2"'),
       mp4Av1: supports('video/mp4; codecs="av01.0.08M.08,mp4a.40.2"'),
       webmVp9: supports('video/webm; codecs="vp9,opus"'),
       webm: supports("video/webm"),
-      mkvH264: supports('video/x-matroska; codecs="avc1.4d401f,mp4a.40.2"') || supports("video/x-matroska"),
+      mkvH264:
+        supports('video/x-matroska; codecs="avc1.4d401f,mp4a.40.2"') ||
+        supports("video/x-matroska"),
       quicktime: supports("video/quicktime"),
       mpegTs: supports("video/mp2t"),
       audioAac: supports('audio/mp4; codecs="mp4a.40.2"'),
@@ -1852,7 +1977,9 @@ export const PlayerController = {
       audioFlac: supports("audio/flac"),
       audioAc3: supports('audio/mp4; codecs="ac-3"') || supports('audio/mp4; codecs="dac3"'),
       audioEac3: supports('audio/mp4; codecs="ec-3"') || supports('audio/mp4; codecs="dec3"'),
-      dolbyVision: supports('video/mp4; codecs="dvh1.05.06,ec-3"') || supports('video/mp4; codecs="dvhe.05.06,ec-3"')
+      dolbyVision:
+        supports('video/mp4; codecs="dvh1.05.06,ec-3"') ||
+        supports('video/mp4; codecs="dvhe.05.06,ec-3"')
     };
     capabilities.hdrLikely = capabilities.mp4HevcMain10 || capabilities.mp4Av1;
     capabilities.atmosLikely = capabilities.audioEac3;
@@ -1893,12 +2020,11 @@ export const PlayerController = {
 
   applyNativeSource(url, mimeType = null, engineName = "native-file") {
     const normalizedMimeType = this.normalizeMimeType(mimeType);
-    const sourceMimeType = Platform.isWebOS() && (
-      this.isEngineFsPlaybackUrl(url)
-      || normalizedMimeType === "video/x-matroska"
-    )
-      ? null
-      : mimeType;
+    const sourceMimeType =
+      Platform.isWebOS() &&
+      (this.isEngineFsPlaybackUrl(url) || normalizedMimeType === "video/x-matroska")
+        ? null
+        : mimeType;
     if (!nativeVideoEngine.load(this.video, url, sourceMimeType)) {
       return false;
     }
@@ -1926,7 +2052,9 @@ export const PlayerController = {
   },
 
   shouldForwardHeaderToHls(name) {
-    const lower = String(name || "").trim().toLowerCase();
+    const lower = String(name || "")
+      .trim()
+      .toLowerCase();
     if (!lower) {
       return false;
     }
@@ -2008,7 +2136,7 @@ export const PlayerController = {
     candidates.forEach((level, index) => {
       const height = Number(level?.height || 0);
       const bitrate = Number(level?.bitrate || level?.attrs?.BANDWIDTH || 0);
-      const score = (height * 1000000000) + bitrate;
+      const score = height * 1000000000 + bitrate;
       if (score > selectedScore) {
         selectedScore = score;
         selectedIndex = index;
@@ -2151,11 +2279,13 @@ export const PlayerController = {
       Hls.Events.SUBTITLE_TRACKS_UPDATED,
       Hls.Events.SUBTITLE_TRACK_SWITCH,
       Hls.Events.SUBTITLE_TRACK_LOADED
-    ].filter(Boolean).forEach((eventName) => {
-      hls.on(eventName, () => {
-        this.emitVideoEvent("hlstrackschanged", { playbackEngine: "hls.js" });
+    ]
+      .filter(Boolean)
+      .forEach((eventName) => {
+        hls.on(eventName, () => {
+          this.emitVideoEvent("hlstrackschanged", { playbackEngine: "hls.js" });
+        });
       });
-    });
 
     this.video.removeAttribute("src");
     hls.attachMedia(this.video);
@@ -2194,15 +2324,20 @@ export const PlayerController = {
       };
       const emitDashError = (event = {}) => {
         const errorText = String(
-          event?.error?.message
-          || event?.event?.message
-          || event?.message
-          || ""
+          event?.error?.message || event?.event?.message || event?.message || ""
         ).toLowerCase();
         let mediaErrorCode = 4;
-        if (errorText.includes("network") || errorText.includes("download") || errorText.includes("manifest")) {
+        if (
+          errorText.includes("network") ||
+          errorText.includes("download") ||
+          errorText.includes("manifest")
+        ) {
           mediaErrorCode = 2;
-        } else if (errorText.includes("decode") || errorText.includes("mediasource") || errorText.includes("append")) {
+        } else if (
+          errorText.includes("decode") ||
+          errorText.includes("mediasource") ||
+          errorText.includes("append")
+        ) {
           mediaErrorCode = 3;
         }
         this.lastPlaybackErrorCode = mediaErrorCode;
@@ -2273,7 +2408,10 @@ export const PlayerController = {
     }
     const currentId = String(current?.id ?? "");
     const currentLang = String(current?.lang ?? "");
-    return tracks.findIndex((track) => String(track?.id ?? "") === currentId && String(track?.language ?? "") === currentLang);
+    return tracks.findIndex(
+      (track) =>
+        String(track?.id ?? "") === currentId && String(track?.language ?? "") === currentLang
+    );
   },
 
   setDashAudioTrack(index) {
@@ -2326,7 +2464,10 @@ export const PlayerController = {
     }
     const currentId = String(current?.id ?? "");
     const currentLang = String(current?.lang ?? "");
-    return tracks.findIndex((track) => String(track?.id ?? "") === currentId && String(track?.language ?? "") === currentLang);
+    return tracks.findIndex(
+      (track) =>
+        String(track?.id ?? "") === currentId && String(track?.language ?? "") === currentLang
+    );
   },
 
   setDashTextTrack(index) {
@@ -2414,7 +2555,8 @@ export const PlayerController = {
       return false;
     }
     const targetIndex = Number(index);
-    const audioTrackList = this.video.audioTracks || this.video.webkitAudioTracks || this.video.mozAudioTracks || null;
+    const audioTrackList =
+      this.video.audioTracks || this.video.webkitAudioTracks || this.video.mozAudioTracks || null;
     let tracks = [];
     if (audioTrackList) {
       try {
@@ -2473,9 +2615,8 @@ export const PlayerController = {
 
     const targetIndex = Number(trackIndex);
     const selectedIndex = Number(selectedTrackIndex);
-    const storedSelectedIndex = Number.isFinite(selectedIndex) && selectedIndex >= 0
-      ? selectedIndex
-      : targetIndex;
+    const storedSelectedIndex =
+      Number.isFinite(selectedIndex) && selectedIndex >= 0 ? selectedIndex : targetIndex;
     if (!Number.isFinite(targetIndex) || targetIndex < 0) {
       this.selectedWebOsEmbeddedAudioTrackIndex = -1;
       return false;
@@ -2494,7 +2635,11 @@ export const PlayerController = {
         // Ignore Luna audio track selection failures.
       });
 
-      const audioTrackList = this.video?.audioTracks || this.video?.webkitAudioTracks || this.video?.mozAudioTracks || null;
+      const audioTrackList =
+        this.video?.audioTracks ||
+        this.video?.webkitAudioTracks ||
+        this.video?.mozAudioTracks ||
+        null;
       if (!audioTrackList) {
         return;
       }
@@ -2539,14 +2684,16 @@ export const PlayerController = {
       return true;
     }
 
-    this.waitForNativeMediaId().then((resolvedMediaId) => {
-      if (Number(this.selectedWebOsEmbeddedAudioTrackIndex) !== storedSelectedIndex) {
-        return;
-      }
-      applySelection(resolvedMediaId);
-    }).catch(() => {
-      // Ignore media-id lookup failures.
-    });
+    this.waitForNativeMediaId()
+      .then((resolvedMediaId) => {
+        if (Number(this.selectedWebOsEmbeddedAudioTrackIndex) !== storedSelectedIndex) {
+          return;
+        }
+        applySelection(resolvedMediaId);
+      })
+      .catch(() => {
+        // Ignore media-id lookup failures.
+      });
 
     return true;
   },
@@ -2556,7 +2703,8 @@ export const PlayerController = {
       return false;
     }
     const targetIndex = Number(index);
-    const textTrackList = this.video.textTracks || this.video.webkitTextTracks || this.video.mozTextTracks || null;
+    const textTrackList =
+      this.video.textTracks || this.video.webkitTextTracks || this.video.mozTextTracks || null;
     let tracks = [];
     if (textTrackList) {
       try {
@@ -2676,19 +2824,26 @@ export const PlayerController = {
       return true;
     }
 
-    this.waitForNativeMediaId().then((resolvedMediaId) => {
-      if (Number(this.selectedWebOsEmbeddedSubtitleTrackIndex) !== targetIndex) {
-        return;
-      }
-      applySelection(resolvedMediaId);
-    }).catch(() => {
-      // Ignore media-id lookup failures.
-    });
+    this.waitForNativeMediaId()
+      .then((resolvedMediaId) => {
+        if (Number(this.selectedWebOsEmbeddedSubtitleTrackIndex) !== targetIndex) {
+          return;
+        }
+        applySelection(resolvedMediaId);
+      })
+      .catch(() => {
+        // Ignore media-id lookup failures.
+      });
 
     return true;
   },
 
-  attemptVideoPlay({ warningLabel = "Playback start rejected", onRejected = null, beforePlay = null, playToken = null } = {}) {
+  attemptVideoPlay({
+    warningLabel = "Playback start rejected",
+    onRejected = null,
+    beforePlay = null,
+    playToken = null
+  } = {}) {
     if (!this.video) {
       return;
     }
@@ -2757,7 +2912,10 @@ export const PlayerController = {
     if (!normalizedSourceType) {
       return;
     }
-    if (this.isLikelyHlsMimeType(normalizedSourceType) || this.isLikelyDashMimeType(normalizedSourceType)) {
+    if (
+      this.isLikelyHlsMimeType(normalizedSourceType) ||
+      this.isLikelyDashMimeType(normalizedSourceType)
+    ) {
       await loadStreamingLibs();
     }
   },
@@ -2782,9 +2940,8 @@ export const PlayerController = {
       this.isPlaying = false;
       const context = this.createProgressContext();
       const durationMs = Math.floor(this.getDurationSeconds() * 1000);
-      const completedMs = durationMs > 0
-        ? durationMs
-        : Math.floor(this.getCurrentTimeSeconds() * 1000);
+      const completedMs =
+        durationMs > 0 ? durationMs : Math.floor(this.getCurrentTimeSeconds() * 1000);
       this.flushProgress(completedMs, durationMs > 0 ? durationMs : completedMs, false, context);
     });
 
@@ -2813,32 +2970,38 @@ export const PlayerController = {
     });
 
     this.video.addEventListener("playing", () => {
-      const audioTrackList = this.video?.audioTracks || this.video?.webkitAudioTracks || this.video?.mozAudioTracks;
+      const audioTrackList =
+        this.video?.audioTracks || this.video?.webkitAudioTracks || this.video?.mozAudioTracks;
       const audioTrackCount = Number(audioTrackList?.length || 0);
-      const probeUrl = String(this.currentPlaybackUrl || this.video?.currentSrc || this.video?.src || "").trim();
+      const probeUrl = String(
+        this.currentPlaybackUrl || this.video?.currentSrc || this.video?.src || ""
+      ).trim();
       const isDirectFile = this.isLikelyDirectFileUrl(probeUrl);
       if (
-        this.isUsingNativePlayback()
-        && isDirectFile
-        && audioTrackCount <= 0
-        && Platform.isWebOS()
-        && this.canUseAvPlay()
+        this.isUsingNativePlayback() &&
+        isDirectFile &&
+        audioTrackCount <= 0 &&
+        Platform.isWebOS() &&
+        this.canUseAvPlay()
       ) {
         this.forceAvPlayFallbackForCurrentSource("native_playing_no_audio_tracks");
       }
     });
 
     this.video.addEventListener("loadedmetadata", () => {
-      const audioTrackList = this.video?.audioTracks || this.video?.webkitAudioTracks || this.video?.mozAudioTracks;
+      const audioTrackList =
+        this.video?.audioTracks || this.video?.webkitAudioTracks || this.video?.mozAudioTracks;
       const audioTrackCount = Number(audioTrackList?.length || 0);
-      const probeUrl = String(this.currentPlaybackUrl || this.video?.currentSrc || this.video?.src || "").trim();
+      const probeUrl = String(
+        this.currentPlaybackUrl || this.video?.currentSrc || this.video?.src || ""
+      ).trim();
       const isDirectFile = this.isLikelyDirectFileUrl(probeUrl);
       if (
-        this.isUsingNativePlayback()
-        && isDirectFile
-        && audioTrackCount <= 0
-        && Platform.isWebOS()
-        && this.canUseAvPlay()
+        this.isUsingNativePlayback() &&
+        isDirectFile &&
+        audioTrackCount <= 0 &&
+        Platform.isWebOS() &&
+        this.canUseAvPlay()
       ) {
         this.forceAvPlayFallbackForCurrentSource("native_no_audio_tracks");
       }
@@ -2860,7 +3023,24 @@ export const PlayerController = {
     }
   },
 
-  async play(url, { itemId = null, itemType = "movie", videoId = null, season = null, episode = null, title = null, poster = null, background = null, episodeTitle = null, requestHeaders = {}, mediaSourceType = null, forceEngine = null } = {}) {
+  async play(
+    url,
+    {
+      itemId = null,
+      itemType = "movie",
+      videoId = null,
+      season = null,
+      episode = null,
+      title = null,
+      poster = null,
+      background = null,
+      episodeTitle = null,
+      requestHeaders = {},
+      mediaSourceType = null,
+      forceEngine = null,
+      streamIdentity = null
+    } = {}
+  ) {
     if (!this.video) return;
 
     await this.flushCurrentProgress({ allowCloudSync: false });
@@ -2876,6 +3056,7 @@ export const PlayerController = {
     this.currentItemPoster = poster || null;
     this.currentItemBackground = background || null;
     this.currentEpisodeTitle = episodeTitle || null;
+    this.currentStreamIdentity = streamIdentity || null;
     this.currentPlaybackUrl = String(url || "").trim();
     this.currentPlaybackHeaders = { ...(requestHeaders || {}) };
     this.currentPlaybackMediaSourceType = this.resolveRuntimeSourceType(mediaSourceType);
@@ -2883,10 +3064,16 @@ export const PlayerController = {
     const playToken = Number(this.playRequestToken || 0) + 1;
     this.playRequestToken = playToken;
 
-    const sourceType = this.currentPlaybackMediaSourceType || this.resolveRuntimeSourceType(this.guessMediaMimeType(url)) || null;
+    const sourceType =
+      this.currentPlaybackMediaSourceType ||
+      this.resolveRuntimeSourceType(this.guessMediaMimeType(url)) ||
+      null;
     const preferredEngine = forceEngine || this.choosePlaybackEngine(url, sourceType, itemType);
     await this.ensureAdaptiveLibrariesForSource(sourceType, preferredEngine);
-    if (Number(this.playRequestToken || 0) !== playToken || String(this.currentPlaybackUrl || "") !== String(url || "").trim()) {
+    if (
+      Number(this.playRequestToken || 0) !== playToken ||
+      String(this.currentPlaybackUrl || "") !== String(url || "").trim()
+    ) {
       return;
     }
     try {
@@ -2894,9 +3081,10 @@ export const PlayerController = {
       const isEngineFsUrl = /\/([0-9a-f]{40})\/\d+(?:\/|$)/i.test(parsedUrl.pathname);
       if (isEngineFsUrl) {
         const host = parsedUrl.hostname;
-        const baseUrlKind = host === "127.0.0.1" || host === "localhost" || host === "::1"
-          ? "local-service"
-          : "public-service";
+        const baseUrlKind =
+          host === "127.0.0.1" || host === "localhost" || host === "::1"
+            ? "local-service"
+            : "public-service";
         logEngineFsDebug("PlayerController: EngineFS playback selected", {
           baseUrlKind,
           playbackUrl: String(url || ""),
@@ -3010,11 +3198,16 @@ export const PlayerController = {
       this.attemptVideoPlay({
         warningLabel: "Playback start rejected",
         playToken,
-        beforePlay: () => isWebOsEngineFsPlayback
-          ? this.prepareWebOsEngineFsPlayback()
-          : this.waitForNativeMediaId(),
+        beforePlay: () =>
+          isWebOsEngineFsPlayback
+            ? this.prepareWebOsEngineFsPlayback()
+            : this.waitForNativeMediaId(),
         onRejected: (error) => {
-          if (!this.isUnsupportedSourceError(error) || !this.canUseAvPlay() || !this.isLikelyDirectFileUrl(url)) {
+          if (
+            !this.isUnsupportedSourceError(error) ||
+            !this.canUseAvPlay() ||
+            !this.isLikelyDirectFileUrl(url)
+          ) {
             return false;
           }
           const fallbackStarted = this.playWithAvPlay(url, requestHeaders, sourceType);
@@ -3093,7 +3286,9 @@ export const PlayerController = {
           this.applyPendingAvPlayAudioTrackSelection();
         }, 300);
       } catch (error) {
-        this.lastPlaybackErrorCode = this.mapAvPlayErrorToMediaCode(error?.name || error?.message || error);
+        this.lastPlaybackErrorCode = this.mapAvPlayErrorToMediaCode(
+          error?.name || error?.message || error
+        );
         console.warn("Playback resume rejected", error);
       }
       return;
@@ -3134,6 +3329,7 @@ export const PlayerController = {
     this.currentItemPoster = null;
     this.currentItemBackground = null;
     this.currentEpisodeTitle = null;
+    this.currentStreamIdentity = null;
     this.currentPlaybackUrl = "";
     this.currentPlaybackHeaders = {};
     this.currentPlaybackMediaSourceType = null;
@@ -3160,7 +3356,8 @@ export const PlayerController = {
       title: this.currentItemTitle || null,
       poster: this.currentItemPoster || null,
       background: this.currentItemBackground || null,
-      episodeTitle: this.currentEpisodeTitle || null
+      episodeTitle: this.currentEpisodeTitle || null,
+      streamIdentity: this.currentStreamIdentity || null
     };
   },
 
@@ -3187,7 +3384,10 @@ export const PlayerController = {
     this.lastProgressSnapshot = {
       key: this.buildProgressSnapshotKey(active),
       positionMs: Math.max(0, Math.trunc(safePosition)),
-      durationMs: Number.isFinite(safeDuration) && safeDuration > 0 ? Math.max(0, Math.trunc(safeDuration)) : 0,
+      durationMs:
+        Number.isFinite(safeDuration) && safeDuration > 0
+          ? Math.max(0, Math.trunc(safeDuration))
+          : 0,
       updatedAt: Date.now()
     };
   },
@@ -3213,27 +3413,31 @@ export const PlayerController = {
     const snapshot = this.getRecordedProgressSnapshot(context);
     const currentPositionMs = Math.floor(this.getCurrentTimeSeconds() * 1000);
     const currentDurationMs = Math.floor(this.getDurationSeconds() * 1000);
-    const positionMs = Number.isFinite(currentPositionMs) && currentPositionMs > 0
-      ? currentPositionMs
-      : Number(snapshot?.positionMs || 0);
-    const durationMs = Number.isFinite(currentDurationMs) && currentDurationMs > 0
-      ? currentDurationMs
-      : Number(snapshot?.durationMs || 0);
+    const positionMs =
+      Number.isFinite(currentPositionMs) && currentPositionMs > 0
+        ? currentPositionMs
+        : Number(snapshot?.positionMs || 0);
+    const durationMs =
+      Number.isFinite(currentDurationMs) && currentDurationMs > 0
+        ? currentDurationMs
+        : Number(snapshot?.durationMs || 0);
 
-    await this.flushProgress(
-      positionMs,
-      durationMs,
-      false,
-      context,
-      { allowCloudSync: allowCloudSync && !forceCloudSync }
-    );
+    await this.flushProgress(positionMs, durationMs, false, context, {
+      allowCloudSync: allowCloudSync && !forceCloudSync
+    });
     if (forceCloudSync) {
       await this.pushProgressIfDue(true);
     }
     return true;
   },
 
-  async flushProgress(positionMs, durationMs, clear = false, context = null, { allowCloudSync = true } = {}) {
+  async flushProgress(
+    positionMs,
+    durationMs,
+    clear = false,
+    context = null,
+    { allowCloudSync = true } = {}
+  ) {
     const active = context || this.createProgressContext();
     if (!active?.itemId) {
       return;
@@ -3242,9 +3446,9 @@ export const PlayerController = {
     const safePosition = Number(positionMs || 0);
     const safeDuration = Number(durationMs || 0);
     const hasFiniteDuration = Number.isFinite(safeDuration) && safeDuration > 0;
-    const hasReachedMinimumSyncPosition = Number.isFinite(safePosition)
-      && safePosition >= MIN_PROGRESS_SYNC_DURATION_MS;
-    const isCompleted = hasFiniteDuration && safePosition / safeDuration >= 0.90;
+    const hasReachedMinimumSyncPosition =
+      Number.isFinite(safePosition) && safePosition >= MIN_PROGRESS_SYNC_DURATION_MS;
+    const isCompleted = hasFiniteDuration && safePosition / safeDuration >= 0.9;
     if (safePosition > 0) {
       this.recordProgressSnapshot(safePosition, safeDuration, active);
     }
@@ -3280,8 +3484,12 @@ export const PlayerController = {
           poster: active.poster || null,
           background: active.background || null,
           episodeTitle: active.episodeTitle || null,
-          positionMs: hasFiniteDuration ? Math.max(0, Math.trunc(safeDuration)) : Math.max(0, Math.trunc(safePosition)),
-          durationMs: hasFiniteDuration ? Math.max(0, Math.trunc(safeDuration)) : Math.max(0, Math.trunc(safePosition))
+          positionMs: hasFiniteDuration
+            ? Math.max(0, Math.trunc(safeDuration))
+            : Math.max(0, Math.trunc(safePosition)),
+          durationMs: hasFiniteDuration
+            ? Math.max(0, Math.trunc(safeDuration))
+            : Math.max(0, Math.trunc(safePosition))
         });
       } else {
         await watchProgressRepository.removeProgress(active.itemId, active.videoId || null);
@@ -3306,6 +3514,9 @@ export const PlayerController = {
       poster: active.poster || null,
       background: active.background || null,
       episodeTitle: active.episodeTitle || null,
+      // Persist which stream was playing so Continue Watching can resume the
+      // same source instead of re-opening the stream picker (issue #232).
+      streamIdentity: active.streamIdentity || null,
       positionMs: Math.max(0, Math.trunc(safePosition)),
       durationMs: hasFiniteDuration ? Math.max(0, Math.trunc(safeDuration)) : 0
     });
@@ -3317,7 +3528,7 @@ export const PlayerController = {
 
   pushProgressIfDue(force = false) {
     const now = Date.now();
-    if (!force && (now - Number(this.lastProgressPushAt || 0)) < 30000) {
+    if (!force && now - Number(this.lastProgressPushAt || 0) < 30000) {
       return Promise.resolve(false);
     }
     this.lastProgressPushAt = now;
@@ -3326,5 +3537,4 @@ export const PlayerController = {
       return false;
     });
   }
-
 };

--- a/js/core/profile/librarySyncService.js
+++ b/js/core/profile/librarySyncService.js
@@ -6,6 +6,19 @@ import { ProfileManager } from "./profileManager.js";
 const ADDONS_TABLE = "addons";
 const TABLE = "tv_addons";
 
+// Records the outcome of the most recent pull so the Addons screen can show an
+// on-screen status to TV users who cannot read console logs (issue #230).
+let lastPullStatus = { state: "idle", count: 0, error: null, at: 0 };
+
+function recordPullStatus(state, { count = 0, error = null } = {}) {
+  lastPullStatus = {
+    state,
+    count: Number(count) || 0,
+    error: error ? String(error.message || error) : null,
+    at: Date.now()
+  };
+}
+
 function isMissingResourceError(error) {
   if (!error) {
     return false;
@@ -17,10 +30,12 @@ function isMissingResourceError(error) {
     return true;
   }
   const message = String(error.message || "");
-  return message.includes("PGRST205")
-    || message.includes("PGRST202")
-    || message.includes("Could not find the table")
-    || message.includes("Could not find the function");
+  return (
+    message.includes("PGRST205") ||
+    message.includes("PGRST202") ||
+    message.includes("Could not find the table") ||
+    message.includes("Could not find the function")
+  );
 }
 
 function isOnConflictConstraintError(error) {
@@ -31,8 +46,10 @@ function isOnConflictConstraintError(error) {
     return true;
   }
   const message = String(error.message || "");
-  return message.includes("42P10")
-    || message.includes("no unique or exclusion constraint matching the ON CONFLICT specification");
+  return (
+    message.includes("42P10") ||
+    message.includes("no unique or exclusion constraint matching the ON CONFLICT specification")
+  );
 }
 
 async function resolveProfileId() {
@@ -59,11 +76,12 @@ async function resolveAddonProfileId() {
     const id = Number(profile?.profileIndex || profile?.id || 1);
     return Number.isFinite(id) && Math.trunc(id) === profileId;
   });
-  const usesPrimaryAddons = typeof activeProfile?.usesPrimaryAddons === "boolean"
-    ? activeProfile.usesPrimaryAddons
-    : (typeof activeProfile?.uses_primary_addons === "boolean"
-      ? activeProfile.uses_primary_addons
-      : true);
+  const usesPrimaryAddons =
+    typeof activeProfile?.usesPrimaryAddons === "boolean"
+      ? activeProfile.usesPrimaryAddons
+      : typeof activeProfile?.uses_primary_addons === "boolean"
+        ? activeProfile.uses_primary_addons
+        : true;
 
   return usesPrimaryAddons ? 1 : profileId;
 }
@@ -78,13 +96,14 @@ function extractAddonEntries(rows = []) {
   return (rows || [])
     .map((row) => ({
       url: row?.url || row?.base_url || null,
-      displayName: row?.display_name
-        || row?.displayName
-        || row?.custom_name
-        || row?.customName
-        || row?.alias
-        || row?.name
-        || null,
+      displayName:
+        row?.display_name ||
+        row?.displayName ||
+        row?.custom_name ||
+        row?.customName ||
+        row?.alias ||
+        row?.name ||
+        null,
       name: row?.name || null
     }))
     .filter((entry) => entry.url);
@@ -92,9 +111,7 @@ function extractAddonEntries(rows = []) {
 
 function applyPulledAddons(rows = []) {
   const entries = extractAddonEntries(rows);
-  const urls = entries
-    .map((entry) => entry.url)
-    .filter(Boolean);
+  const urls = entries.map((entry) => entry.url).filter(Boolean);
   addonRepository.setAddonDisplayNameOverrides(
     entries.map((entry) => ({ url: entry.url, name: entry.displayName || entry.name })),
     { replace: true }
@@ -103,10 +120,15 @@ function applyPulledAddons(rows = []) {
 }
 
 export const LibrarySyncService = {
+  getLastPullStatus() {
+    return lastPullStatus;
+  },
 
   async pull() {
+    let readError = null;
     try {
       if (!AuthManager.isAuthenticated) {
+        recordPullStatus("signed-out");
         return [];
       }
       const localUrls = addonRepository.getInstalledAddonUrls();
@@ -122,9 +144,13 @@ export const LibrarySyncService = {
         );
         const addonUrls = applyPulledAddons(addonRows);
         await addonRepository.setAddonOrder(addonUrls, { silent: true });
+        recordPullStatus("ok", { count: addonUrls.length });
         return addonUrls;
       } catch (addonsTableError) {
         addonTableMissing = isMissingResourceError(addonsTableError);
+        if (!addonTableMissing) {
+          readError = addonsTableError;
+        }
         console.warn("Addon sync pull addons-table read failed", addonsTableError);
       }
 
@@ -137,9 +163,13 @@ export const LibrarySyncService = {
         );
         const urls = applyPulledAddons(rows);
         await addonRepository.setAddonOrder(urls, { silent: true });
+        recordPullStatus("ok", { count: urls.length });
         return urls;
       } catch (tvTableError) {
         tvTableMissing = isMissingResourceError(tvTableError);
+        if (!tvTableMissing) {
+          readError = tvTableError;
+        }
         console.warn("Addon sync pull tv-table read failed", tvTableError);
       }
 
@@ -152,17 +182,27 @@ export const LibrarySyncService = {
           );
           const urls = applyPulledAddons(rpcRows);
           await addonRepository.setAddonOrder(urls, { silent: true });
+          recordPullStatus("ok", { count: urls.length });
           return urls;
         } catch (rpcError) {
+          readError = rpcError;
           console.warn("Addon sync pull RPC failed", rpcError);
         }
       }
 
+      // No read succeeded. A genuine network/permission failure is reported as an
+      // error; reaching here cleanly just means the account has no linked addons.
+      if (readError) {
+        recordPullStatus("error", { count: localUrls.length, error: readError });
+      } else {
+        recordPullStatus("ok", { count: localUrls.length });
+      }
       if (localUrls.length) {
         return localUrls;
       }
       return [];
     } catch (error) {
+      recordPullStatus("error", { error });
       console.warn("Library sync pull failed", error);
       return [];
     }
@@ -225,7 +265,10 @@ export const LibrarySyncService = {
           console.warn("Addon sync push addons-table fallback failed", addonsTableError);
           return false;
         }
-        console.warn("Addon sync push addons-table missing, trying tv_addons fallback", addonsTableError);
+        console.warn(
+          "Addon sync push addons-table missing, trying tv_addons fallback",
+          addonsTableError
+        );
       }
 
       const rows = urls.map((baseUrl, index) => ({
@@ -248,5 +291,4 @@ export const LibrarySyncService = {
       return false;
     }
   }
-
 };

--- a/js/ui/screens/detail/metaDetailsScreen.js
+++ b/js/ui/screens/detail/metaDetailsScreen.js
@@ -35,7 +35,7 @@ const DETAIL_PROGRESS_END_THRESHOLD = 0.85;
 const TRAKT_COMMENTS_LIMIT = 100;
 const DETAIL_SCROLL_STIFFNESS = 180;
 const DETAIL_SCROLL_DAMPING_RATIO = 0.95;
-const DETAIL_TAB_FOCUS_TARGET = 0.40;
+const DETAIL_TAB_FOCUS_TARGET = 0.4;
 const DETAIL_ROW_FOCUS_TARGET = 0.33;
 const DETAIL_SCROLL_MAX_FRAME_SECONDS = 0.016;
 const LOCAL_YOUTUBE_PROXY_URL = "youtube-proxy.html";
@@ -101,7 +101,12 @@ function parseSeasonEpisodeFromId(rawId) {
 function resolveSeasonEpisode(video = {}) {
   const fromId = parseSeasonEpisodeFromId(video.id);
   const season = firstNonNegativeInt([video.season, video.seasonNumber, fromId?.season]);
-  const episode = firstNonNegativeInt([video.episode, video.episodeNumber, fromId?.episode, video.number]);
+  const episode = firstNonNegativeInt([
+    video.episode,
+    video.episodeNumber,
+    fromId?.episode,
+    video.number
+  ]);
   // Some addons omit the season entirely for single-season shows and only
   // provide an episode/number; treat those as season 1 instead of discarding
   // the episode. The explicit-0-vs-missing distinction from
@@ -118,11 +123,7 @@ function resolveSeasonEpisode(video = {}) {
 function toEpisodeEntry(video = {}) {
   const { season, episode } = resolveSeasonEpisode(video);
   const runtimeMinutes = Number(
-    video.runtime
-    || video.runtimeMinutes
-    || video.durationMinutes
-    || video.duration
-    || 0
+    video.runtime || video.runtimeMinutes || video.durationMinutes || video.duration || 0
   );
   return {
     id: video.id || "",
@@ -132,9 +133,22 @@ function toEpisodeEntry(video = {}) {
     thumbnail: video.thumbnail || null,
     overview: video.overview || video.description || "",
     runtimeMinutes: Number.isFinite(runtimeMinutes) && runtimeMinutes > 0 ? runtimeMinutes : 0,
-    released: video.released || video.releaseDate || video.release_date || video.firstAired || video.first_aired || video.airDate || video.air_date || "",
+    released:
+      video.released ||
+      video.releaseDate ||
+      video.release_date ||
+      video.firstAired ||
+      video.first_aired ||
+      video.airDate ||
+      video.air_date ||
+      "",
     available: video.available,
-    imdbRating: video.imdbRating ?? video.imdb_score ?? video.ratings?.imdb ?? video.mdbListRatings?.imdb ?? null
+    imdbRating:
+      video.imdbRating ??
+      video.imdb_score ??
+      video.ratings?.imdb ??
+      video.mdbListRatings?.imdb ??
+      null
   };
 }
 
@@ -166,19 +180,25 @@ function detailProgressFraction(progress = {}) {
 }
 
 function isSeriesDetailMeta(meta = {}, episodes = null) {
-  const normalizedType = String(meta?.type || "").trim().toLowerCase();
+  const normalizedType = String(meta?.type || "")
+    .trim()
+    .toLowerCase();
   if (normalizedType === "series") {
     return true;
   }
   if (normalizedType !== "tv") {
     return false;
   }
-  const resolvedEpisodes = Array.isArray(episodes) ? episodes : normalizeEpisodes(meta?.videos || []);
+  const resolvedEpisodes = Array.isArray(episodes)
+    ? episodes
+    : normalizeEpisodes(meta?.videos || []);
   return resolvedEpisodes.length > 0;
 }
 
 function resolvePlayableDetailType(itemType, meta = {}) {
-  const normalizedType = String(itemType || meta?.type || "movie").trim().toLowerCase();
+  const normalizedType = String(itemType || meta?.type || "movie")
+    .trim()
+    .toLowerCase();
   if (normalizedType === "tv") {
     return "tv";
   }
@@ -197,9 +217,16 @@ function resolveMetaImdbId(meta = {}, params = {}) {
     meta?.id,
     params?.itemId
   ];
-  return candidates
-    .map((value) => String(value || "").trim().split(":")[0])
-    .find((value) => /^tt\d+$/i.test(value)) || null;
+  return (
+    candidates
+      .map(
+        (value) =>
+          String(value || "")
+            .trim()
+            .split(":")[0]
+      )
+      .find((value) => /^tt\d+$/i.test(value)) || null
+  );
 }
 
 function extractCast(meta = {}) {
@@ -222,7 +249,11 @@ function extractCast(meta = {}) {
     }
     return raw;
   };
-  const normalizeCastValue = (value) => String(value || "").trim().toLowerCase().replace(/\s+/g, " ");
+  const normalizeCastValue = (value) =>
+    String(value || "")
+      .trim()
+      .toLowerCase()
+      .replace(/\s+/g, " ");
   const selectBetterCastEntry = (current, candidate) => {
     if (!candidate) {
       return current;
@@ -254,14 +285,20 @@ function extractCast(meta = {}) {
         const exactKey = `${normalizedName}|${normalizedCharacter}`;
         exactMatches.set(exactKey, selectBetterCastEntry(exactMatches.get(exactKey), entry));
       }
-      nameMatches.set(normalizedName, selectBetterCastEntry(nameMatches.get(normalizedName), entry));
+      nameMatches.set(
+        normalizedName,
+        selectBetterCastEntry(nameMatches.get(normalizedName), entry)
+      );
     });
 
     return primary.map((entry) => {
       const normalizedName = normalizeCastValue(entry?.name);
       const normalizedCharacter = normalizeCastValue(entry?.character);
-      const exactKey = normalizedName && normalizedCharacter ? `${normalizedName}|${normalizedCharacter}` : "";
-      const match = (exactKey ? exactMatches.get(exactKey) : null) || (normalizedName ? nameMatches.get(normalizedName) : null);
+      const exactKey =
+        normalizedName && normalizedCharacter ? `${normalizedName}|${normalizedCharacter}` : "";
+      const match =
+        (exactKey ? exactMatches.get(exactKey) : null) ||
+        (normalizedName ? nameMatches.get(normalizedName) : null);
       return {
         ...entry,
         character: entry?.character || match?.character || "",
@@ -270,22 +307,21 @@ function extractCast(meta = {}) {
       };
     });
   };
-  const mapCastEntries = (items = [], mapper) => (Array.isArray(items) ? items : [])
-    .map(mapper)
-    .filter((entry) => Boolean(entry?.name));
+  const mapCastEntries = (items = [], mapper) =>
+    (Array.isArray(items) ? items : []).map(mapper).filter((entry) => Boolean(entry?.name));
 
   const members = Array.isArray(meta.castMembers) ? meta.castMembers : [];
   const memberEntries = mapCastEntries(members, (entry) => ({
     name: entry?.name || "",
     character: entry?.character || entry?.role || "",
     photo: toPhoto(
-      entry?.photo
-      || entry?.profilePath
-      || entry?.profile_path
-      || entry?.avatar
-      || entry?.image
-      || entry?.poster
-      || ""
+      entry?.photo ||
+        entry?.profilePath ||
+        entry?.profile_path ||
+        entry?.avatar ||
+        entry?.image ||
+        entry?.poster ||
+        ""
     ),
     tmdbId: entry?.tmdbId || entry?.id || null
   }));
@@ -299,13 +335,13 @@ function extractCast(meta = {}) {
       name: entry?.name || "",
       character: entry?.character || "",
       photo: toPhoto(
-        entry?.photo
-        || entry?.profilePath
-        || entry?.profile_path
-        || entry?.avatar
-        || entry?.image
-        || entry?.poster
-        || ""
+        entry?.photo ||
+          entry?.profilePath ||
+          entry?.profile_path ||
+          entry?.avatar ||
+          entry?.image ||
+          entry?.poster ||
+          ""
       ),
       tmdbId: entry?.tmdbId || entry?.id || null
     };
@@ -316,13 +352,13 @@ function extractCast(meta = {}) {
     name: entry?.name || entry?.character || "",
     character: entry?.character || "",
     photo: toPhoto(
-      entry?.profile_path
-      || entry?.photo
-      || entry?.profilePath
-      || entry?.avatar_path
-      || entry?.avatar
-      || entry?.image
-      || ""
+      entry?.profile_path ||
+        entry?.photo ||
+        entry?.profilePath ||
+        entry?.avatar_path ||
+        entry?.avatar ||
+        entry?.image ||
+        ""
     ),
     tmdbId: entry?.id || null
   }));
@@ -460,9 +496,9 @@ function resolveImdbRating(meta = {}) {
 }
 
 function resolveEpisodeImdbRating(episode = {}, seriesRatingsBySeason = {}) {
-  const seasonRating = seriesRatingsBySeason?.[episode.season]
-    ?.find((entry) => Number(entry?.episode || 0) === Number(episode.episode || 0))
-    ?.rating;
+  const seasonRating = seriesRatingsBySeason?.[episode.season]?.find(
+    (entry) => Number(entry?.episode || 0) === Number(episode.episode || 0)
+  )?.rating;
   if (seasonRating != null && String(seasonRating).trim() !== "") {
     return seasonRating;
   }
@@ -492,7 +528,10 @@ function formatDurationMinutes(totalMinutes) {
 
 function resolveEpisodeRuntimeForSeason(episodes = [], season = null) {
   const seasonNumber = Number(season || 0);
-  const inSeason = episodes.find((episode) => Number(episode.season || 0) === seasonNumber && Number(episode.runtimeMinutes || 0) > 0);
+  const inSeason = episodes.find(
+    (episode) =>
+      Number(episode.season || 0) === seasonNumber && Number(episode.runtimeMinutes || 0) > 0
+  );
   if (inSeason) {
     return Number(inSeason.runtimeMinutes || 0);
   }
@@ -566,11 +605,13 @@ function getAddonBadgeLabel(name = "") {
   if (/torrentio|torbox|torrent/i.test(cleaned)) {
     return "µ";
   }
-  return cleaned
-    .split(/\s+/)
-    .map((part) => part.charAt(0).toUpperCase())
-    .join("")
-    .slice(0, 2) || cleaned.charAt(0).toUpperCase();
+  return (
+    cleaned
+      .split(/\s+/)
+      .map((part) => part.charAt(0).toUpperCase())
+      .join("")
+      .slice(0, 2) || cleaned.charAt(0).toUpperCase()
+  );
 }
 
 function renderStreamAddonIcon(addonName = "") {
@@ -592,7 +633,7 @@ function escapeHtml(value = "") {
     .replaceAll("&", "&amp;")
     .replaceAll("<", "&lt;")
     .replaceAll(">", "&gt;")
-    .replaceAll("\"", "&quot;")
+    .replaceAll('"', "&quot;")
     .replaceAll("'", "&#39;");
 }
 
@@ -701,7 +742,10 @@ function resolveTrailerPostMessageTargetOrigin(src = "") {
 
 function resolveTrailerTrustedProxyOrigin() {
   try {
-    const url = new URL(getYoutubeProxyBaseUrl(), globalThis?.location?.href || "https://example.com/");
+    const url = new URL(
+      getYoutubeProxyBaseUrl(),
+      globalThis?.location?.href || "https://example.com/"
+    );
     if (url.protocol === "http:" || url.protocol === "https:") {
       return url.origin;
     }
@@ -833,12 +877,7 @@ function resolveTrailerSource(meta = {}) {
   ];
   for (const entry of trailerCandidates) {
     const ytId = resolveYoutubeId(
-      entry?.ytId
-      || entry?.youtubeId
-      || entry?.source
-      || entry?.url
-      || entry?.link
-      || ""
+      entry?.ytId || entry?.youtubeId || entry?.source || entry?.url || entry?.link || ""
     );
     if (ytId) {
       const embedUrl = buildYoutubeEmbedUrl(ytId);
@@ -870,24 +909,35 @@ function resolveTrailerSource(meta = {}) {
 function resolveTrailerItems(meta = {}) {
   const candidates = [
     ...(Array.isArray(meta?.trailers) ? meta.trailers : []),
-    ...(Array.isArray(meta?.trailerYtIds) ? meta.trailerYtIds.map((ytId) => ({ ytId, name: "Trailer" })) : [])
+    ...(Array.isArray(meta?.trailerYtIds)
+      ? meta.trailerYtIds.map((ytId) => ({ ytId, name: "Trailer" }))
+      : [])
   ];
   const seen = new Set();
-  return candidates.map((entry) => {
-    const ytId = resolveYoutubeId(typeof entry === "string" ? entry : (entry?.ytId || entry?.youtubeId || entry?.source || entry?.url || entry?.link || ""));
-    if (!ytId || seen.has(ytId)) return null;
-    seen.add(ytId);
-    return {
-      ytId,
-      name: typeof entry === "object" ? (entry.name || entry.type || "Trailer") : "Trailer",
-      type: typeof entry === "object" ? (entry.type || "") : "",
-      lang: typeof entry === "object" ? (entry.lang || entry.language || "") : ""
-    };
-  }).filter(Boolean);
+  return candidates
+    .map((entry) => {
+      const ytId = resolveYoutubeId(
+        typeof entry === "string"
+          ? entry
+          : entry?.ytId || entry?.youtubeId || entry?.source || entry?.url || entry?.link || ""
+      );
+      if (!ytId || seen.has(ytId)) return null;
+      seen.add(ytId);
+      return {
+        ytId,
+        name: typeof entry === "object" ? entry.name || entry.type || "Trailer" : "Trailer",
+        type: typeof entry === "object" ? entry.type || "" : "",
+        lang: typeof entry === "object" ? entry.lang || entry.language || "" : ""
+      };
+    })
+    .filter(Boolean);
 }
 
 function stripTraktSpoilerMarkup(value = "") {
-  return String(value || "").replace(/\[\/?spoiler\]/gi, "").replace(/[\t ]+/g, " ").trim();
+  return String(value || "")
+    .replace(/\[\/?spoiler\]/gi, "")
+    .replace(/[\t ]+/g, " ")
+    .trim();
 }
 
 function containsTraktInlineSpoiler(value = "") {
@@ -916,9 +966,14 @@ function formatEpisodeCardDate(value = "") {
     return "";
   }
   const localDateMatch = raw.match(/^(\d{4})-(\d{2})-(\d{2})(?:$|T)/);
-  const parsed = localDateMatch && !raw.includes("T")
-    ? new Date(Number(localDateMatch[1]), Number(localDateMatch[2]) - 1, Number(localDateMatch[3]))
-    : new Date(raw);
+  const parsed =
+    localDateMatch && !raw.includes("T")
+      ? new Date(
+          Number(localDateMatch[1]),
+          Number(localDateMatch[2]) - 1,
+          Number(localDateMatch[3])
+        )
+      : new Date(raw);
   if (Number.isNaN(parsed.getTime())) {
     return "";
   }
@@ -982,7 +1037,6 @@ function captureHorizontalScrollMap(container) {
 }
 
 export const MetaDetailsScreen = {
-
   getRouteStateKey(params = {}) {
     const itemId = String(params?.itemId || "").trim();
     if (!itemId) {
@@ -1013,7 +1067,9 @@ export const MetaDetailsScreen = {
       movieInsightTab: String(this.movieInsightTab || "cast"),
       commentsPage: Number(this.commentsPage || 0),
       commentsPageCount: Number(this.commentsPageCount || 0),
-      episodeFocusIndexBySeason: this.episodeFocusIndexBySeason ? { ...this.episodeFocusIndexBySeason } : {},
+      episodeFocusIndexBySeason: this.episodeFocusIndexBySeason
+        ? { ...this.episodeFocusIndexBySeason }
+        : {},
       railFocusIndexByKey: this.railFocusIndexByKey ? { ...this.railFocusIndexByKey } : {},
       pendingFocusRestore: this.captureDetailFocus(),
       contentScrollTop: Number(content?.scrollTop || 0),
@@ -1036,32 +1092,51 @@ export const MetaDetailsScreen = {
     this.isMarkedWatched = Boolean(snapshot.isMarkedWatched);
     this.episodes = Array.isArray(snapshot.episodes) ? [...snapshot.episodes] : [];
     this.castItems = Array.isArray(snapshot.castItems) ? [...snapshot.castItems] : [];
-    this.moreLikeThisItems = Array.isArray(snapshot.moreLikeThisItems) ? [...snapshot.moreLikeThisItems] : [];
-    this.collectionItems = Array.isArray(snapshot.collectionItems) ? [...snapshot.collectionItems] : [];
+    this.moreLikeThisItems = Array.isArray(snapshot.moreLikeThisItems)
+      ? [...snapshot.moreLikeThisItems]
+      : [];
+    this.collectionItems = Array.isArray(snapshot.collectionItems)
+      ? [...snapshot.collectionItems]
+      : [];
     this.commentsItems = Array.isArray(snapshot.commentsItems) ? [...snapshot.commentsItems] : [];
     this.collectionName = String(snapshot.collectionName || "");
-    this.seriesRatingsBySeason = snapshot.seriesRatingsBySeason ? { ...snapshot.seriesRatingsBySeason } : {};
-    this.nextEpisodeToWatch = snapshot.nextEpisodeToWatch ? { ...snapshot.nextEpisodeToWatch } : null;
-    this.trailerSource = snapshot.trailerSource ? { ...snapshot.trailerSource } : resolveTrailerSource(this.meta);
+    this.seriesRatingsBySeason = snapshot.seriesRatingsBySeason
+      ? { ...snapshot.seriesRatingsBySeason }
+      : {};
+    this.nextEpisodeToWatch = snapshot.nextEpisodeToWatch
+      ? { ...snapshot.nextEpisodeToWatch }
+      : null;
+    this.trailerSource = snapshot.trailerSource
+      ? { ...snapshot.trailerSource }
+      : resolveTrailerSource(this.meta);
     this.selectedSeason = Number(snapshot.selectedSeason || this.episodes[0]?.season || 1);
     this.selectedRatingSeason = Number(snapshot.selectedRatingSeason || this.selectedSeason || 1);
     this.seriesInsightTab = String(snapshot.seriesInsightTab || "cast");
     this.movieInsightTab = String(snapshot.movieInsightTab || "cast");
     this.commentsPage = Number(snapshot.commentsPage || 0);
     this.commentsPageCount = Number(snapshot.commentsPageCount || 0);
-    this.episodeFocusIndexBySeason = snapshot.episodeFocusIndexBySeason && typeof snapshot.episodeFocusIndexBySeason === "object"
-      ? { ...snapshot.episodeFocusIndexBySeason }
-      : {};
-    this.railFocusIndexByKey = snapshot.railFocusIndexByKey && typeof snapshot.railFocusIndexByKey === "object"
-      ? { ...snapshot.railFocusIndexByKey }
-      : {};
-    this.pendingFocusRestore = snapshot.pendingFocusRestore ? { ...snapshot.pendingFocusRestore } : null;
+    this.episodeFocusIndexBySeason =
+      snapshot.episodeFocusIndexBySeason && typeof snapshot.episodeFocusIndexBySeason === "object"
+        ? { ...snapshot.episodeFocusIndexBySeason }
+        : {};
+    this.railFocusIndexByKey =
+      snapshot.railFocusIndexByKey && typeof snapshot.railFocusIndexByKey === "object"
+        ? { ...snapshot.railFocusIndexByKey }
+        : {};
+    this.pendingFocusRestore = snapshot.pendingFocusRestore
+      ? { ...snapshot.pendingFocusRestore }
+      : null;
     this.restoredContentScrollTop = Number(snapshot.contentScrollTop || 0);
-    this.restoredTrackScrollLeftByKey = snapshot.trackScrollLeftByKey && typeof snapshot.trackScrollLeftByKey === "object"
-      ? { ...snapshot.trackScrollLeftByKey }
-      : {};
-    this.episodeProgressMap = new Map(Array.isArray(snapshot.episodeProgressEntries) ? snapshot.episodeProgressEntries : []);
-    this.watchedEpisodeKeys = new Set(Array.isArray(snapshot.watchedEpisodeKeys) ? snapshot.watchedEpisodeKeys : []);
+    this.restoredTrackScrollLeftByKey =
+      snapshot.trackScrollLeftByKey && typeof snapshot.trackScrollLeftByKey === "object"
+        ? { ...snapshot.trackScrollLeftByKey }
+        : {};
+    this.episodeProgressMap = new Map(
+      Array.isArray(snapshot.episodeProgressEntries) ? snapshot.episodeProgressEntries : []
+    );
+    this.watchedEpisodeKeys = new Set(
+      Array.isArray(snapshot.watchedEpisodeKeys) ? snapshot.watchedEpisodeKeys : []
+    );
     return true;
   },
 
@@ -1123,7 +1198,11 @@ export const MetaDetailsScreen = {
       }
       if (data.type === "state") {
         const nextState = normalizeTrailerProxyStatePayload(data, this.trailerMuted);
-        if (nextState.loading === false || Number(nextState.duration || 0) > 0 || Number(nextState.currentTime || 0) > 0) {
+        if (
+          nextState.loading === false ||
+          Number(nextState.duration || 0) > 0 ||
+          Number(nextState.currentTime || 0) > 0
+        ) {
           this.stopTrailerProxyLoadingTimer();
         }
         this.trailerProxyState = nextState;
@@ -1141,12 +1220,15 @@ export const MetaDetailsScreen = {
     }
     const src = String(this.trailerUiRefs?.frame?.src || this.trailerSource?.embedUrl || "");
     const targetOrigin = resolveTrailerPostMessageTargetOrigin(src);
-    frameWindow.postMessage({
-      source: "nuvio-detail-trailer",
-      type: "command",
-      command: String(command || ""),
-      payload: payload && typeof payload === "object" ? payload : {}
-    }, targetOrigin);
+    frameWindow.postMessage(
+      {
+        source: "nuvio-detail-trailer",
+        type: "command",
+        command: String(command || ""),
+        payload: payload && typeof payload === "object" ? payload : {}
+      },
+      targetOrigin
+    );
     return true;
   },
 
@@ -1280,42 +1362,38 @@ export const MetaDetailsScreen = {
       itemId = canonicalItemId;
     }
 
-    const metaPromise = withTimeout(
-      metaRepository.getMetaFromAllAddons(itemType, itemId),
-      4500,
-      { status: "error", message: "timeout" }
-    );
+    const metaPromise = withTimeout(metaRepository.getMetaFromAllAddons(itemType, itemId), 4500, {
+      status: "error",
+      message: "timeout"
+    });
     const isSavedPromise = savedLibraryRepository.isSaved(itemId);
     const progressPromise = watchProgressRepository.getProgressByContentId(itemId);
     const watchedItemPromise = watchedItemsRepository.isWatched(itemId);
     const allProgressPromise = watchProgressRepository.getAll();
     const allWatchedPromise = watchedItemsRepository.getAll();
 
-    const [
-      metaResult,
-      isSaved,
-      progress,
-      watchedItem,
-      allProgressItems,
-      allWatchedItems
-    ] = await Promise.all([
-      metaPromise,
-      isSavedPromise,
-      progressPromise,
-      watchedItemPromise,
-      allProgressPromise,
-      allWatchedPromise
-    ]);
-    const meta = metaResult.status === "success"
-      ? metaResult.data
-      : { id: itemId, type: itemType, name: fallbackTitle, description: "" };
+    const [metaResult, isSaved, progress, watchedItem, allProgressItems, allWatchedItems] =
+      await Promise.all([
+        metaPromise,
+        isSavedPromise,
+        progressPromise,
+        watchedItemPromise,
+        allProgressPromise,
+        allWatchedPromise
+      ]);
+    const meta =
+      metaResult.status === "success"
+        ? metaResult.data
+        : { id: itemId, type: itemType, name: fallbackTitle, description: "" };
     if (token !== this.detailLoadToken) {
       return;
     }
     this.isSavedInLibrary = isSaved;
     this.isMarkedWatched = Boolean(
-      watchedItem
-      || (progress && Number(progress.durationMs || 0) > 0 && Number(progress.positionMs || 0) >= Number(progress.durationMs || 0))
+      watchedItem ||
+      (progress &&
+        Number(progress.durationMs || 0) > 0 &&
+        Number(progress.positionMs || 0) >= Number(progress.durationMs || 0))
     );
 
     // Fast first paint with base metadata.
@@ -1367,28 +1445,35 @@ export const MetaDetailsScreen = {
       void this.refreshTrailerSource(this.meta, token);
       void this.loadTraktComments({ force: true });
 
-      const tasks = [
-        withTimeout(this.fetchMoreLikeThis(this.meta), 5000, [])
-      ];
+      const tasks = [withTimeout(this.fetchMoreLikeThis(this.meta), 5000, [])];
       if (isSeriesDetailMeta(this.meta, this.episodes)) {
         tasks.push(withTimeout(this.fetchSeriesRatingsBySeason(this.meta), 5000, {}));
         const traktId = this.meta?.ids?.trakt;
         if (traktId) {
           tasks.push(
             withTimeout(
-              detailWatchedEnrichmentService.enrichSeriesWatchedState(this.episodes, this.params?.itemId, traktId),
+              detailWatchedEnrichmentService.enrichSeriesWatchedState(
+                this.episodes,
+                this.params?.itemId,
+                traktId
+              ),
               4500,
               new Map()
             )
           );
         }
       } else {
-        tasks.push(withTimeout(this.fetchMovieCollection(this.meta), 5000, { items: [], name: "" }));
+        tasks.push(
+          withTimeout(this.fetchMovieCollection(this.meta), 5000, { items: [], name: "" })
+        );
         const movieTraktId = this.meta?.ids?.trakt;
         if (movieTraktId) {
           tasks.push(
             withTimeout(
-              detailWatchedEnrichmentService.enrichMovieWatchedState(this.params?.itemId, movieTraktId),
+              detailWatchedEnrichmentService.enrichMovieWatchedState(
+                this.params?.itemId,
+                movieTraktId
+              ),
               4500,
               null
             )
@@ -1451,14 +1536,20 @@ export const MetaDetailsScreen = {
       if (!sourceTitle) {
         return [];
       }
-      const terms = sourceTitle.split(/\s+/).filter((word) => word.length > 2).slice(0, 3).join(" ");
+      const terms = sourceTitle
+        .split(/\s+/)
+        .filter((word) => word.length > 2)
+        .slice(0, 3)
+        .join(" ");
       if (!terms) {
         return [];
       }
 
       const wantedType = isSeriesDetailMeta(meta)
-        ? (meta?.type === "tv" ? "series" : (meta?.type || "movie"))
-        : (meta?.type || "movie");
+        ? meta?.type === "tv"
+          ? "series"
+          : meta?.type || "movie"
+        : meta?.type || "movie";
       const addons = await addonRepository.getInstalledAddons();
       const searchableCatalogs = [];
 
@@ -1479,20 +1570,22 @@ export const MetaDetailsScreen = {
         });
       });
 
-      const responses = await Promise.all(searchableCatalogs.slice(0, 6).map(async (catalog) => {
-        const result = await catalogRepository.getCatalog({
-          addonBaseUrl: catalog.addonBaseUrl,
-          addonId: catalog.addonId,
-          addonName: catalog.addonName,
-          catalogId: catalog.catalogId,
-          catalogName: catalog.catalogName,
-          type: catalog.type,
-          extraArgs: { search: terms },
-          supportsSkip: true,
-          skip: 0
-        });
-        return result?.status === "success" ? (result.data?.items || []) : [];
-      }));
+      const responses = await Promise.all(
+        searchableCatalogs.slice(0, 6).map(async (catalog) => {
+          const result = await catalogRepository.getCatalog({
+            addonBaseUrl: catalog.addonBaseUrl,
+            addonId: catalog.addonId,
+            addonName: catalog.addonName,
+            catalogId: catalog.catalogId,
+            catalogName: catalog.catalogName,
+            type: catalog.type,
+            extraArgs: { search: terms },
+            supportsSkip: true,
+            skip: 0
+          });
+          return result?.status === "success" ? result.data?.items || [] : [];
+        })
+      );
 
       const flat = [];
       responses.forEach((items) => {
@@ -1517,31 +1610,43 @@ export const MetaDetailsScreen = {
   },
 
   getAvailableSeasons(episodes = this.episodes) {
-    return Array.from(new Set((Array.isArray(episodes) ? episodes : [])
-      .map((episode) => Number(episode?.season || 0))
-      .filter((season) => Number.isFinite(season) && season > 0)))
-      .sort((left, right) => left - right);
+    return Array.from(
+      new Set(
+        (Array.isArray(episodes) ? episodes : [])
+          .map((episode) => Number(episode?.season || 0))
+          .filter((season) => Number.isFinite(season) && season > 0)
+      )
+    ).sort((left, right) => left - right);
   },
 
   supportsTraktComments(meta = this.meta) {
-    const type = String(meta?.type || meta?.apiType || this.params?.itemType || "").trim().toLowerCase();
-    return ["movie", "series", "tv", "show"].includes(type) || isSeriesDetailMeta(meta, this.episodes);
+    const type = String(meta?.type || meta?.apiType || this.params?.itemType || "")
+      .trim()
+      .toLowerCase();
+    return (
+      ["movie", "series", "tv", "show"].includes(type) || isSeriesDetailMeta(meta, this.episodes)
+    );
   },
 
   resolveTraktCommentsTarget(meta = this.meta) {
     if (!this.supportsTraktComments(meta)) return null;
     const isEpisode = this.commentsMode === "episode" && this.commentsEpisodeTarget;
-    const directId = resolveMetaImdbId(meta, this.params)
-      || String(meta?.slug || "").trim()
-      || String(meta?.id || this.params?.itemId || "").split(":").find((part) => /^tt\d+$/i.test(part))
-      || String(this.params?.itemId || meta?.id || "").trim();
+    const directId =
+      resolveMetaImdbId(meta, this.params) ||
+      String(meta?.slug || "").trim() ||
+      String(meta?.id || this.params?.itemId || "")
+        .split(":")
+        .find((part) => /^tt\d+$/i.test(part)) ||
+      String(this.params?.itemId || meta?.id || "").trim();
     if (!directId) return null;
     const isSeries = isSeriesDetailMeta(meta, this.episodes);
     if (isEpisode && isSeries) {
       const season = Number(this.commentsEpisodeTarget?.season || 0);
       const episode = Number(this.commentsEpisodeTarget?.episode || 0);
       if (season > 0 && episode > 0) {
-        return { path: `/shows/${encodeURIComponent(directId)}/seasons/${season}/episodes/${episode}/comments/likes` };
+        return {
+          path: `/shows/${encodeURIComponent(directId)}/seasons/${season}/episodes/${episode}/comments/likes`
+        };
       }
     }
     return {
@@ -1558,7 +1663,9 @@ export const MetaDetailsScreen = {
     if (!token) {
       return { items: [], page: 0, pageCount: 0 };
     }
-    const url = new URL(`${String(TRAKT_API_URL || "https://api.trakt.tv").replace(/\/+$/, "")}${target.path}`);
+    const url = new URL(
+      `${String(TRAKT_API_URL || "https://api.trakt.tv").replace(/\/+$/, "")}${target.path}`
+    );
     url.searchParams.set("page", String(page));
     url.searchParams.set("limit", String(TRAKT_COMMENTS_LIMIT));
     const response = await fetch(url.toString(), {
@@ -1598,7 +1705,11 @@ export const MetaDetailsScreen = {
   },
 
   async loadTraktComments({ force = false, append = false } = {}) {
-    if (!TraktSettingsStore.get().showMetaComments || !TraktAuthService.isAuthenticated() || !this.supportsTraktComments(this.meta)) {
+    if (
+      !TraktSettingsStore.get().showMetaComments ||
+      !TraktAuthService.isAuthenticated() ||
+      !this.supportsTraktComments(this.meta)
+    ) {
       this.commentsItems = [];
       this.commentsPage = 0;
       this.commentsPageCount = 0;
@@ -1615,7 +1726,9 @@ export const MetaDetailsScreen = {
     this.updateRenderedDetailSections(this.meta);
     try {
       const result = await this.fetchTraktCommentsPage(page);
-      const existingIds = new Set((append ? this.commentsItems : []).map((item) => Number(item.id || 0)));
+      const existingIds = new Set(
+        (append ? this.commentsItems : []).map((item) => Number(item.id || 0))
+      );
       const nextItems = result.items.filter((item) => !existingIds.has(Number(item.id || 0)));
       this.commentsItems = append ? [...this.commentsItems, ...nextItems] : nextItems;
       this.commentsPage = result.page;
@@ -1650,10 +1763,12 @@ export const MetaDetailsScreen = {
     const season = Number(progress?.season || 0);
     const episode = Number(progress?.episode || 0);
     if (season > 0 && episode > 0) {
-      return this.episodes.find((entry) => (
-        Number(entry?.season || 0) === season
-        && Number(entry?.episode || 0) === episode
-      )) || null;
+      return (
+        this.episodes.find(
+          (entry) =>
+            Number(entry?.season || 0) === season && Number(entry?.episode || 0) === episode
+        ) || null
+      );
     }
     return null;
   },
@@ -1662,14 +1777,13 @@ export const MetaDetailsScreen = {
     if (!episode || !this.episodes?.length) {
       return null;
     }
-    const currentIndex = this.episodes.findIndex((entry) => (
-      String(entry?.id || "") === String(episode?.id || "")
-      || (
-        Number(entry?.season || 0) === Number(episode?.season || 0)
-        && Number(entry?.episode || 0) === Number(episode?.episode || 0)
-      )
-    ));
-    return currentIndex >= 0 ? (this.episodes[currentIndex + 1] || null) : null;
+    const currentIndex = this.episodes.findIndex(
+      (entry) =>
+        String(entry?.id || "") === String(episode?.id || "") ||
+        (Number(entry?.season || 0) === Number(episode?.season || 0) &&
+          Number(entry?.episode || 0) === Number(episode?.episode || 0))
+    );
+    return currentIndex >= 0 ? this.episodes[currentIndex + 1] || null : null;
   },
 
   getLatestSeriesProgress(progress = null, progressItems = []) {
@@ -1687,16 +1801,16 @@ export const MetaDetailsScreen = {
       }
       candidates.push(entry);
     });
-    return candidates
-      .sort((left, right) => Number(right?.updatedAt || 0) - Number(left?.updatedAt || 0))[0] || null;
+    return (
+      candidates.sort(
+        (left, right) => Number(right?.updatedAt || 0) - Number(left?.updatedAt || 0)
+      )[0] || null
+    );
   },
 
   resolvePreferredSeasonFromProgress(progress = null, progressItems = []) {
     const routeSeason = Number(
-      this.params?.preferredSeason
-      ?? this.params?.resumeSeason
-      ?? this.params?.initialSeason
-      ?? 0
+      this.params?.preferredSeason ?? this.params?.resumeSeason ?? this.params?.initialSeason ?? 0
     );
     if (Number.isFinite(routeSeason) && routeSeason > 0) {
       return routeSeason;
@@ -1706,7 +1820,9 @@ export const MetaDetailsScreen = {
     const progressEpisode = this.findEpisodeFromProgress(latestProgress);
     if (progressEpisode) {
       if (detailProgressFraction(latestProgress) >= DETAIL_PROGRESS_END_THRESHOLD) {
-        return Number(this.getNextEpisodeAfter(progressEpisode)?.season || progressEpisode.season || 0);
+        return Number(
+          this.getNextEpisodeAfter(progressEpisode)?.season || progressEpisode.season || 0
+        );
       }
       return Number(progressEpisode.season || 0);
     }
@@ -1741,11 +1857,12 @@ export const MetaDetailsScreen = {
     if (currentEpisode && detailProgressFraction(progress) < DETAIL_PROGRESS_END_THRESHOLD) {
       return currentEpisode;
     }
-    const completedKeys = this.watchedEpisodeKeys instanceof Set
-      ? new Set(this.watchedEpisodeKeys)
-      : new Set();
+    const completedKeys =
+      this.watchedEpisodeKeys instanceof Set ? new Set(this.watchedEpisodeKeys) : new Set();
     if (currentEpisode && detailProgressFraction(progress) >= DETAIL_PROGRESS_END_THRESHOLD) {
-      completedKeys.add(`${Number(currentEpisode.season || 0)}:${Number(currentEpisode.episode || 0)}`);
+      completedKeys.add(
+        `${Number(currentEpisode.season || 0)}:${Number(currentEpisode.episode || 0)}`
+      );
     }
     let latestCompletedIndex = -1;
     this.episodes.forEach((episode, index) => {
@@ -1755,18 +1872,21 @@ export const MetaDetailsScreen = {
       }
     });
     if (latestCompletedIndex >= 0) {
-      return this.episodes[latestCompletedIndex + 1] || this.episodes[latestCompletedIndex] || this.episodes[0];
+      return (
+        this.episodes[latestCompletedIndex + 1] ||
+        this.episodes[latestCompletedIndex] ||
+        this.episodes[0]
+      );
     }
     if (!currentEpisode) {
       return this.episodes[0];
     }
-    const currentIndex = this.episodes.findIndex((episode) => (
-      String(episode?.id || "") === String(currentEpisode?.id || "")
-      || (
-        Number(episode?.season || 0) === Number(currentEpisode?.season || 0)
-        && Number(episode?.episode || 0) === Number(currentEpisode?.episode || 0)
-      )
-    ));
+    const currentIndex = this.episodes.findIndex(
+      (episode) =>
+        String(episode?.id || "") === String(currentEpisode?.id || "") ||
+        (Number(episode?.season || 0) === Number(currentEpisode?.season || 0) &&
+          Number(episode?.episode || 0) === Number(currentEpisode?.episode || 0))
+    );
     return this.episodes[currentIndex + 1] || this.episodes[currentIndex] || this.episodes[0];
   },
 
@@ -1806,7 +1926,8 @@ export const MetaDetailsScreen = {
 
   async fetchMovieCollection(meta = {}) {
     try {
-      const collectionId = meta?.collectionId || meta?.belongsToCollection?.id || meta?.belongs_to_collection?.id;
+      const collectionId =
+        meta?.collectionId || meta?.belongsToCollection?.id || meta?.belongs_to_collection?.id;
       if (!collectionId) {
         return { name: "", items: [] };
       }
@@ -1819,7 +1940,11 @@ export const MetaDetailsScreen = {
         .filter((item) => item.id && item.id !== String(meta.id || ""))
         .slice(0, 18);
       return {
-        name: meta?.collectionName || meta?.belongsToCollection?.name || meta?.belongs_to_collection?.name || "",
+        name:
+          meta?.collectionName ||
+          meta?.belongsToCollection?.name ||
+          meta?.belongs_to_collection?.name ||
+          "",
         items: normalized
       };
     } catch (error) {
@@ -1839,7 +1964,11 @@ export const MetaDetailsScreen = {
     const resumeSeason = Number(this.params?.resumeSeason || 0);
     const resumeEpisode = Number(this.params?.resumeEpisode || 0);
     if (resumeSeason > 0 && resumeEpisode > 0) {
-      const episodeMatch = this.episodes.find((entry) => Number(entry?.season || 0) === resumeSeason && Number(entry?.episode || 0) === resumeEpisode);
+      const episodeMatch = this.episodes.find(
+        (entry) =>
+          Number(entry?.season || 0) === resumeSeason &&
+          Number(entry?.episode || 0) === resumeEpisode
+      );
       if (episodeMatch) {
         return episodeMatch;
       }
@@ -1848,14 +1977,19 @@ export const MetaDetailsScreen = {
   },
 
   maybeAutoOpenContinueWatchingStream() {
-    if (!this.params?.autoOpenContinueWatching || this.autoOpenedContinueWatchingStream || this.isBackNavigation) {
+    if (
+      !this.params?.autoOpenContinueWatching ||
+      this.autoOpenedContinueWatchingStream ||
+      this.isBackNavigation
+    ) {
       return;
     }
     this.autoOpenedContinueWatchingStream = true;
     const extraParams = {
       resumePositionMs: Number(this.params?.resumeProgressMs || 0) || 0,
       returnToDetail: true,
-      continueWatchingBackHome: true
+      continueWatchingBackHome: true,
+      resumeStreamIdentity: this.params?.resumeStreamIdentity || null
     };
     if (isSeriesDetailMeta(this.meta, this.episodes)) {
       const episode = this.findContinueWatchingEpisodeTarget();
@@ -1869,11 +2003,15 @@ export const MetaDetailsScreen = {
 
   navigateBackFromDetail() {
     if (this.params?.returnHomeOnBack) {
-      Router.navigate("home", {}, {
-        isBackNavigation: true,
-        skipStackPush: true,
-        replaceHistory: true
-      });
+      Router.navigate(
+        "home",
+        {},
+        {
+          isBackNavigation: true,
+          skipStackPush: true,
+          replaceHistory: true
+        }
+      );
       return true;
     }
     return false;
@@ -1901,38 +2039,69 @@ export const MetaDetailsScreen = {
 
       return {
         ...meta,
-        name: settings.useBasicInfo ? (enrichment.localizedTitle || meta.name) : meta.name,
-        description: settings.useBasicInfo ? (enrichment.description || meta.description) : meta.description,
-        background: settings.useArtwork ? (enrichment.backdrop || meta.background) : meta.background,
-        poster: settings.useArtwork ? (enrichment.poster || meta.poster) : meta.poster,
-        logo: settings.useArtwork ? (enrichment.logo || meta.logo) : meta.logo,
+        name: settings.useBasicInfo ? enrichment.localizedTitle || meta.name : meta.name,
+        description: settings.useBasicInfo
+          ? enrichment.description || meta.description
+          : meta.description,
+        background: settings.useArtwork ? enrichment.backdrop || meta.background : meta.background,
+        poster: settings.useArtwork ? enrichment.poster || meta.poster : meta.poster,
+        logo: settings.useArtwork ? enrichment.logo || meta.logo : meta.logo,
         genres: settings.useDetails ? mergeGenreLists(meta.genres, enrichment.genres) : meta.genres,
-        releaseInfo: settings.useDetails ? (meta.releaseInfo || enrichment.releaseInfo) : meta.releaseInfo,
-        released: settings.useDetails ? (meta.released || meta.releaseDate || meta.release_date || enrichment.released || null) : (meta.released || meta.releaseDate || meta.release_date || null),
-        runtime: settings.useDetails ? (enrichment.runtime || meta.runtime) : meta.runtime,
-        country: settings.useDetails ? (enrichment.country || meta.country) : meta.country,
-        language: settings.useDetails ? (enrichment.language || meta.language) : meta.language,
+        releaseInfo: settings.useDetails
+          ? meta.releaseInfo || enrichment.releaseInfo
+          : meta.releaseInfo,
+        released: settings.useDetails
+          ? meta.released || meta.releaseDate || meta.release_date || enrichment.released || null
+          : meta.released || meta.releaseDate || meta.release_date || null,
+        runtime: settings.useDetails ? enrichment.runtime || meta.runtime : meta.runtime,
+        country: settings.useDetails ? enrichment.country || meta.country : meta.country,
+        language: settings.useDetails ? enrichment.language || meta.language : meta.language,
         imdbId: enrichment.imdbId || meta.imdbId || meta.imdb_id || null,
-        tmdbRating: typeof enrichment.rating === "number" ? Number(enrichment.rating.toFixed(1)) : (meta.tmdbRating || null),
+        tmdbRating:
+          typeof enrichment.rating === "number"
+            ? Number(enrichment.rating.toFixed(1))
+            : meta.tmdbRating || null,
         credits: enrichment.credits || meta.credits || null,
-        companies: Array.isArray(enrichment.companies) ? enrichment.companies : (meta.companies || []),
+        companies: Array.isArray(enrichment.companies)
+          ? enrichment.companies
+          : meta.companies || [],
         productionCompanies: Array.isArray(enrichment.productionCompanies)
           ? enrichment.productionCompanies
-          : (Array.isArray(meta.productionCompanies) ? meta.productionCompanies : []),
+          : Array.isArray(meta.productionCompanies)
+            ? meta.productionCompanies
+            : [],
         networks: Array.isArray(enrichment.networks)
           ? enrichment.networks
-          : (Array.isArray(meta.networks) ? meta.networks : []),
-        trailers: Array.isArray(meta.trailers) && meta.trailers.length
-          ? meta.trailers
-          : (Array.isArray(enrichment.trailers) ? enrichment.trailers : []),
-        trailerYtIds: Array.isArray(meta.trailerYtIds) && meta.trailerYtIds.length
-          ? meta.trailerYtIds
-          : (Array.isArray(enrichment.trailerYtIds) ? enrichment.trailerYtIds : []),
-        collectionId: enrichment.collectionId || meta.collectionId || meta?.belongsToCollection?.id || meta?.belongs_to_collection?.id || null,
-        collectionName: enrichment.collectionName || meta.collectionName || meta?.belongsToCollection?.name || meta?.belongs_to_collection?.name || "",
+          : Array.isArray(meta.networks)
+            ? meta.networks
+            : [],
+        trailers:
+          Array.isArray(meta.trailers) && meta.trailers.length
+            ? meta.trailers
+            : Array.isArray(enrichment.trailers)
+              ? enrichment.trailers
+              : [],
+        trailerYtIds:
+          Array.isArray(meta.trailerYtIds) && meta.trailerYtIds.length
+            ? meta.trailerYtIds
+            : Array.isArray(enrichment.trailerYtIds)
+              ? enrichment.trailerYtIds
+              : [],
+        collectionId:
+          enrichment.collectionId ||
+          meta.collectionId ||
+          meta?.belongsToCollection?.id ||
+          meta?.belongs_to_collection?.id ||
+          null,
+        collectionName:
+          enrichment.collectionName ||
+          meta.collectionName ||
+          meta?.belongsToCollection?.name ||
+          meta?.belongs_to_collection?.name ||
+          "",
         belongsToCollection: enrichment.collectionId
           ? { id: enrichment.collectionId, name: enrichment.collectionName || "" }
-          : (meta.belongsToCollection || meta.belongs_to_collection || null)
+          : meta.belongsToCollection || meta.belongs_to_collection || null
       };
     } catch (error) {
       console.warn("Meta TMDB enrichment failed", error);
@@ -1953,7 +2122,9 @@ export const MetaDetailsScreen = {
     const type = contentType === "series" || contentType === "tv" ? "tv" : "movie";
     const releaseYear = String(meta?.releaseInfo || "").match(/\b(19|20)\d{2}\b/)?.[0] || "";
     const yearParam = releaseYear
-      ? (type === "tv" ? `&first_air_date_year=${encodeURIComponent(releaseYear)}` : `&year=${encodeURIComponent(releaseYear)}`)
+      ? type === "tv"
+        ? `&first_air_date_year=${encodeURIComponent(releaseYear)}`
+        : `&year=${encodeURIComponent(releaseYear)}`
       : "";
     const url = `${TMDB_BASE_URL}/search/${type}?api_key=${encodeURIComponent(apiKey)}&language=${encodeURIComponent(settings.language || "en-US")}&query=${encodeURIComponent(name)}${yearParam}`;
     const response = await fetch(url);
@@ -1997,15 +2168,21 @@ export const MetaDetailsScreen = {
       if (Object.keys(directRatings || {}).length) {
         return directRatings;
       }
-      const seasons = Array.from(new Set(this.episodes.map((episode) => Number(episode.season || 0)).filter((value) => value > 0)));
-      const entries = await Promise.all(seasons.map(async (season) => {
-        const ratings = await TmdbMetadataService.fetchSeasonRatings({
-          tmdbId,
-          seasonNumber: season,
-          language: TmdbSettingsStore.get().language
-        });
-        return [season, ratings];
-      }));
+      const seasons = Array.from(
+        new Set(
+          this.episodes.map((episode) => Number(episode.season || 0)).filter((value) => value > 0)
+        )
+      );
+      const entries = await Promise.all(
+        seasons.map(async (season) => {
+          const ratings = await TmdbMetadataService.fetchSeasonRatings({
+            tmdbId,
+            seasonNumber: season,
+            language: TmdbSettingsStore.get().language
+          });
+          return [season, ratings];
+        })
+      );
       return Object.fromEntries(entries);
     } catch (error) {
       console.warn("Series ratings enrichment failed", error);
@@ -2095,7 +2272,8 @@ export const MetaDetailsScreen = {
 
   render(meta, focusRestore = undefined) {
     if (this._sectionsUpdateRaf) {
-      const cancelRaf = typeof cancelAnimationFrame === "function" ? cancelAnimationFrame : clearTimeout;
+      const cancelRaf =
+        typeof cancelAnimationFrame === "function" ? cancelAnimationFrame : clearTimeout;
       cancelRaf(this._sectionsUpdateRaf);
       this._sectionsUpdateRaf = null;
       this._pendingSectionsMeta = null;
@@ -2122,14 +2300,16 @@ export const MetaDetailsScreen = {
 
   renderSeriesHeroMarkup(meta) {
     const nextEpisodeLabel = this.getSeriesHeroPlayLabel();
-    const creditLine = Array.isArray(meta.director) && meta.director.length
-      ? meta.director.slice(0, 2).join(", ")
-      : Array.isArray(meta.writer) && meta.writer.length
-        ? meta.writer.slice(0, 2).join(", ")
-        : (meta.director || meta.writer || "");
-    const creditPrefix = Array.isArray(meta.director) && meta.director.length
-      ? t("detail.creator", {}, "Creator")
-      : t("detail.writer", {}, "Writer");
+    const creditLine =
+      Array.isArray(meta.director) && meta.director.length
+        ? meta.director.slice(0, 2).join(", ")
+        : Array.isArray(meta.writer) && meta.writer.length
+          ? meta.writer.slice(0, 2).join(", ")
+          : meta.director || meta.writer || "";
+    const creditPrefix =
+      Array.isArray(meta.director) && meta.director.length
+        ? t("detail.creator", {}, "Creator")
+        : t("detail.writer", {}, "Writer");
     return this.renderHeroSection({
       meta,
       playLabel: nextEpisodeLabel,
@@ -2142,17 +2322,17 @@ export const MetaDetailsScreen = {
   getSeriesHeroPlayLabel() {
     return this.nextEpisodeToWatch
       ? t(
-        "detail.nextEpisodeShort",
-        { season: this.nextEpisodeToWatch.season, episode: this.nextEpisodeToWatch.episode },
-        "Next S{{season}}E{{episode}}"
-      )
+          "detail.nextEpisodeShort",
+          { season: this.nextEpisodeToWatch.season, episode: this.nextEpisodeToWatch.episode },
+          "Next S{{season}}E{{episode}}"
+        )
       : t("detail.play", {}, "Play");
   },
 
   renderMovieHeroMarkup(meta) {
     const directorLine = Array.isArray(meta.director)
       ? meta.director.slice(0, 2).join(", ")
-      : (meta.director || "");
+      : meta.director || "";
     const playableType = resolvePlayableDetailType(this.params?.itemType || meta?.type, meta);
     return this.renderHeroSection({
       meta,
@@ -2199,7 +2379,13 @@ export const MetaDetailsScreen = {
     }
     this.bindDetailChrome();
   },
-  renderHeroSection({ meta, playLabel, creditLine = "", creditPrefix = "", showWatchedButton = false }) {
+  renderHeroSection({
+    meta,
+    playLabel,
+    creditLine = "",
+    creditPrefix = "",
+    showWatchedButton = false
+  }) {
     const logoOrTitle = meta.logo
       ? `<img src="${meta.logo}" class="series-detail-logo" alt="${escapeHtml(meta.name || "logo")}" decoding="async" fetchpriority="high" />`
       : `<h1 class="series-detail-title">${escapeHtml(meta.name || "Untitled")}</h1>`;
@@ -2210,13 +2396,14 @@ export const MetaDetailsScreen = {
       this.trailerSource = trailerSource;
     }
     const trailerButtonEnabled = Boolean(LayoutPreferences.get().detailPageTrailerButtonEnabled);
-    const trailerButton = trailerButtonEnabled && hasTrailerCandidate
-      ? `
+    const trailerButton =
+      trailerButtonEnabled && hasTrailerCandidate
+        ? `
           <button class="series-circle-btn focusable" data-action="toggleTrailer" aria-label="${escapeAttribute(t("detail.playTrailer", {}, "Play trailer"))}">
             ${renderTrailerGlyph()}
           </button>
         `
-      : "";
+        : "";
     return `
       <section class="detail-hero-section">
         <div class="detail-hero-brand">
@@ -2246,13 +2433,25 @@ export const MetaDetailsScreen = {
     const genresText = normalizeGenreList(meta).join(" • ");
     const yearText = formatMovieReleaseDate(meta);
     const imdbValue = resolveImdbRating(meta);
-    const imdbText = imdbValue != null && String(imdbValue).trim() !== "" ? String(imdbValue).replace(",", ".") : "";
-    const runtimeText = String(meta?.runtime || "").trim()
-      || formatRuntimeMinutes(meta?.runtimeMinutes || resolveEpisodeRuntimeForSeason(this.episodes, this.selectedSeason));
-    const countryText = normalizeCountryLabel(Array.isArray(meta?.country) ? meta.country.join(", ") : (meta?.country || ""));
-    const languageText = String(meta?.language || "").trim().toUpperCase();
+    const imdbText =
+      imdbValue != null && String(imdbValue).trim() !== ""
+        ? String(imdbValue).replace(",", ".")
+        : "";
+    const runtimeText =
+      String(meta?.runtime || "").trim() ||
+      formatRuntimeMinutes(
+        meta?.runtimeMinutes || resolveEpisodeRuntimeForSeason(this.episodes, this.selectedSeason)
+      );
+    const countryText = normalizeCountryLabel(
+      Array.isArray(meta?.country) ? meta.country.join(", ") : meta?.country || ""
+    );
+    const languageText = String(meta?.language || "")
+      .trim()
+      .toUpperCase();
     const ageRating = String(meta?.ageRating || "").trim();
-    const status = String(meta?.status || "").trim().toUpperCase();
+    const status = String(meta?.status || "")
+      .trim()
+      .toUpperCase();
     const primaryParts = [
       genresText ? `<span>${escapeHtml(genresText)}</span>` : "",
       yearText ? `<span>${escapeHtml(yearText)}</span>` : "",
@@ -2301,12 +2500,16 @@ export const MetaDetailsScreen = {
     }
     return `
       <div class="detail-ratings-row">
-        ${items.map(([label, icon, value]) => `
+        ${items
+          .map(
+            ([label, icon, value]) => `
           <span class="detail-rating-item">
             <img src="${icon}" alt="${escapeHtml(label)}" />
             <span>${escapeHtml(formatRatingValue(value, { digits: label === "trakt" || label === "tomatoes" ? 0 : 1, stripTrailingZero: label === "trakt" || label === "tomatoes" }))}</span>
           </span>
-        `).join("")}
+        `
+          )
+          .join("")}
       </div>
     `;
   },
@@ -2316,7 +2519,10 @@ export const MetaDetailsScreen = {
       meta.productionCompanies || meta.production_companies || [],
       t("detail.productionCompanies", {}, "Production")
     );
-    const networks = this.renderCompanyLogosSection(meta.networks || [], t("detail.networks", {}, "Network"));
+    const networks = this.renderCompanyLogosSection(
+      meta.networks || [],
+      t("detail.networks", {}, "Network")
+    );
     if (meta.type === "series" || meta.type === "tv") {
       return `${networks}${production}`;
     }
@@ -2342,7 +2548,9 @@ export const MetaDetailsScreen = {
         <div class="card focusable" data-action="openSearch">${t("detail.searchSimilar", {}, "Search Similar")}</div>
         <div class="card focusable" data-action="goBack">${t("common.back", {}, "Back")}</div>
       </div>
-      ${isSeries ? `
+      ${
+        isSeries
+          ? `
       <div class="row">
         <h3>${t("detail.seasons", {}, "Seasons")}</h3>
         <div id="detailSeasons">${seasonButtons}</div>
@@ -2351,19 +2559,29 @@ export const MetaDetailsScreen = {
         <h3>${t("detail.episodes", {}, "Episodes")}</h3>
         <div id="detailEpisodes">${episodeCards}</div>
       </div>
-      ` : ""}
-      ${castCards ? `
+      `
+          : ""
+      }
+      ${
+        castCards
+          ? `
       <div class="row">
         <h3>${t("detail.cast", {}, "Cast")}</h3>
         <div id="detailCast">${castCards}</div>
       </div>
-      ` : ""}
-      ${moreLikeCards ? `
+      `
+          : ""
+      }
+      ${
+        moreLikeCards
+          ? `
       <div class="row">
         <h3>${t("detail.moreLikeThis", {}, "More Like This")}</h3>
         <div id="detailMoreLike">${moreLikeCards}</div>
       </div>
-      ` : ""}
+      `
+          : ""
+      }
       <div class="row">
         <h3>${t("detail.streams", {}, "Streams")} (${streamItems.length})</h3>
         <div id="detailStreams"></div>
@@ -2467,9 +2685,10 @@ export const MetaDetailsScreen = {
     if (this._sectionsUpdateRaf) {
       return;
     }
-    const raf = typeof requestAnimationFrame === "function"
-      ? requestAnimationFrame
-      : (cb) => setTimeout(cb, 16);
+    const raf =
+      typeof requestAnimationFrame === "function"
+        ? requestAnimationFrame
+        : (cb) => setTimeout(cb, 16);
     this._sectionsUpdateRaf = raf(() => {
       this._sectionsUpdateRaf = null;
       const pendingMeta = this._pendingSectionsMeta;
@@ -2493,7 +2712,9 @@ export const MetaDetailsScreen = {
 
     const heroMount = this.container.querySelector("#detailHeroSection");
     if (heroMount) {
-      heroMount.innerHTML = isSeries ? this.renderSeriesHeroMarkup(meta) : this.renderMovieHeroMarkup(meta);
+      heroMount.innerHTML = isSeries
+        ? this.renderSeriesHeroMarkup(meta)
+        : this.renderMovieHeroMarkup(meta);
     }
 
     const seasonMount = this.container.querySelector("#detailSeasonRowMount");
@@ -2508,7 +2729,9 @@ export const MetaDetailsScreen = {
 
     const insightMount = this.container.querySelector("#detailInsightSectionMount");
     if (insightMount) {
-      insightMount.innerHTML = isSeries ? this.renderSeriesInsightSection() : this.renderMovieInsightSection(meta);
+      insightMount.innerHTML = isSeries
+        ? this.renderSeriesInsightSection()
+        : this.renderMovieInsightSection(meta);
     }
 
     const commentsMount = this.container.querySelector("#detailCommentsSectionMount");
@@ -2530,11 +2753,14 @@ export const MetaDetailsScreen = {
     const tabItems = [
       ["cast", t("detail.creatorCast", {}, "Creator and Cast")],
       ["ratings", t("detail.ratings", {}, "Ratings")],
-      ...(this.moreLikeThisItems.length ? [["morelike", t("detail.moreLikeThis", {}, "More Like This")]] : []),
+      ...(this.moreLikeThisItems.length
+        ? [["morelike", t("detail.moreLikeThis", {}, "More Like This")]]
+        : []),
       ...(trailerItems.length ? [["trailer", t("detail_tab_trailer", {}, "Trailer")]] : []),
       ...(this.collectionItems.length ? [["collection", this.collectionName || "Collection"]] : [])
     ];
-    const tabs = tabItems.length > 1 ? this.renderPeopleTabs("movie", this.movieInsightTab, tabItems) : "";
+    const tabs =
+      tabItems.length > 1 ? this.renderPeopleTabs("movie", this.movieInsightTab, tabItems) : "";
     if (this.movieInsightTab === "ratings") {
       const imdbValue = resolveImdbRating(meta);
       const imdb = imdbValue != null && String(imdbValue).trim() !== "" ? String(imdbValue) : "-";
@@ -2592,23 +2818,28 @@ export const MetaDetailsScreen = {
     const tabItems = [
       ["cast", t("detail.creatorCast", {}, "Creator and Cast")],
       ["ratings", t("detail.ratings", {}, "Ratings")],
-      ...(this.moreLikeThisItems.length ? [["morelike", t("detail.moreLikeThis", {}, "More Like This")]] : []),
+      ...(this.moreLikeThisItems.length
+        ? [["morelike", t("detail.moreLikeThis", {}, "More Like This")]]
+        : []),
       ...(trailerItems.length ? [["trailer", t("detail_tab_trailer", {}, "Trailer")]] : []),
       ...(this.collectionItems.length ? [["collection", this.collectionName || "Collection"]] : [])
     ];
-    const tabs = tabItems.length > 1 ? this.renderPeopleTabs("series", this.seriesInsightTab, tabItems) : "";
+    const tabs =
+      tabItems.length > 1 ? this.renderPeopleTabs("series", this.seriesInsightTab, tabItems) : "";
     return `
       <section class="series-insight-section is-switching">
         ${tabs}
-        ${this.seriesInsightTab === "ratings"
-          ? this.renderSeriesRatingsPanel()
-          : this.seriesInsightTab === "collection"
-            ? this.renderPreviewRail(this.collectionItems, "series", "collection:series")
-          : this.seriesInsightTab === "morelike"
-            ? this.renderPreviewRail(this.moreLikeThisItems, "series", "morelike:series")
-          : this.seriesInsightTab === "trailer"
-            ? this.renderTrailerRail(trailerItems, "series")
-            : this.renderSeriesCastTrack("series")}
+        ${
+          this.seriesInsightTab === "ratings"
+            ? this.renderSeriesRatingsPanel()
+            : this.seriesInsightTab === "collection"
+              ? this.renderPreviewRail(this.collectionItems, "series", "collection:series")
+              : this.seriesInsightTab === "morelike"
+                ? this.renderPreviewRail(this.moreLikeThisItems, "series", "morelike:series")
+                : this.seriesInsightTab === "trailer"
+                  ? this.renderTrailerRail(trailerItems, "series")
+                  : this.renderSeriesCastTrack("series")
+        }
       </section>
     `;
   },
@@ -2617,12 +2848,16 @@ export const MetaDetailsScreen = {
     const normalized = items.filter(([, label]) => Boolean(label));
     return `
       <div class="series-insight-tabs" data-scroll-key="people-tabs:${kind}">
-        ${normalized.map(([tab, label], index) => `
+        ${normalized
+          .map(
+            ([tab, label], index) => `
           ${index > 0 ? '<span class="series-insight-divider">|</span>' : ""}
           <button class="series-insight-tab focusable${activeTab === tab ? " selected" : ""}"
                   data-action="${kind === "series" ? "setSeriesInsightTab" : "setMovieInsightTab"}"
                   data-tab="${tab}">${escapeHtml(label)}</button>
-        `).join("")}
+        `
+          )
+          .join("")}
       </div>
     `;
   },
@@ -2632,7 +2867,10 @@ export const MetaDetailsScreen = {
       return `<div class="series-insight-empty">No cast information.</div>`;
     }
     const className = kind === "movie" ? "movie-cast-track" : "series-cast-track";
-    const cards = this.castItems.slice(0, 18).map((person) => `
+    const cards = this.castItems
+      .slice(0, 18)
+      .map(
+        (person) => `
       <article class="movie-cast-card focusable series-cast-card"
                data-action="openCastDetail"
                data-cast-id="${person.tmdbId || ""}"
@@ -2644,12 +2882,17 @@ export const MetaDetailsScreen = {
         <div class="movie-cast-name">${escapeHtml(person.name || "")}</div>
         <div class="movie-cast-role">${escapeHtml(person.character || "")}</div>
       </article>
-    `).join("");
+    `
+      )
+      .join("");
     return `<div class="${className}" data-scroll-key="cast:${kind}">${cards}</div>`;
   },
 
   renderSeriesRatingsPanel() {
-    const seasonKeys = Object.keys(this.seriesRatingsBySeason || {}).map((key) => Number(key)).filter((value) => value > 0).sort((a, b) => a - b);
+    const seasonKeys = Object.keys(this.seriesRatingsBySeason || {})
+      .map((key) => Number(key))
+      .filter((value) => value > 0)
+      .sort((a, b) => a - b);
     if (!seasonKeys.length) {
       return `<div class="series-insight-empty">${escapeHtml(t("detail.ratingsNotAvailable", {}, "Ratings not available."))}</div>`;
     }
@@ -2657,19 +2900,27 @@ export const MetaDetailsScreen = {
       this.selectedRatingSeason = seasonKeys[0];
     }
     const ratings = this.seriesRatingsBySeason?.[this.selectedRatingSeason] || [];
-    const seasonButtons = seasonKeys.map((season) => `
+    const seasonButtons = seasonKeys
+      .map(
+        (season) => `
       <button class="series-rating-season focusable${season === this.selectedRatingSeason ? " selected" : ""}"
               data-action="selectRatingSeason"
               data-season="${season}">S${season}</button>
-    `).join("");
+    `
+      )
+      .join("");
     const chips = ratings.length
-      ? ratings.map((entry) => `
+      ? ratings
+          .map(
+            (entry) => `
           <div class="series-episode-rating-chip focusable ${ratingToneClass(entry.rating)}"
                data-rating-episode="${Number(entry.episode || 0)}">
             <span class="series-episode-rating-ep">E${entry.episode}</span>
             <span class="series-episode-rating-val">${entry.rating != null ? String(entry.rating).replace(".", ".") : "-"}</span>
           </div>
-        `).join("")
+        `
+          )
+          .join("")
       : `<div class="series-insight-empty">${escapeHtml(t("detail.noEpisodeRatings", {}, "No episode ratings in this season."))}</div>`;
     return `
       <div class="series-rating-seasons" data-scroll-key="rating-seasons">${seasonButtons}</div>
@@ -2683,41 +2934,53 @@ export const MetaDetailsScreen = {
       return `<p>${escapeHtml(t("detail.noEpisodesFound", {}, "No episodes found."))}</p>`;
     }
     const seasons = Array.from(new Set(this.episodes.map((episode) => episode.season)));
-    return seasons.map((season) => `
+    return seasons
+      .map(
+        (season) => `
       <button class="series-season-btn focusable${season === this.selectedSeason ? " selected" : ""}"
               data-action="selectSeason"
               data-season="${season}">
         ${escapeHtml(t("detail.seasonLabel", { season }, "Season {{season}}"))}
       </button>
-    `).join("");
+    `
+      )
+      .join("");
   },
 
   renderEpisodeCards() {
     if (!this.episodes?.length) {
       return `<p>${escapeHtml(t("detail.noEpisodesFound", {}, "No episodes found."))}</p>`;
     }
-    const selectedSeasonEpisodes = this.episodes.filter((episode) => episode.season === this.selectedSeason);
+    const selectedSeasonEpisodes = this.episodes.filter(
+      (episode) => episode.season === this.selectedSeason
+    );
     if (!selectedSeasonEpisodes.length) {
       return `<p>${escapeHtml(t("episodes_panel_no_episodes", {}, "No episodes available"))}</p>`;
     }
-    return selectedSeasonEpisodes.map((episode) => {
-      const progress = this.episodeProgressMap.get(`${episode.season}:${episode.episode}`) || null;
-      const position = Number(progress?.positionMs || 0);
-      const duration = Number(progress?.durationMs || 0);
-      const progressRatio = duration > 0 ? Math.min(1, Math.max(0, position / duration)) : 0;
-      const episodeKey = `${episode.season}:${episode.episode}`;
-      const isWatched = this.enrichedWatchedState?.has(episodeKey)
-        ? Boolean(this.enrichedWatchedState.get(episodeKey)?.isWatched)
-        : this.watchedEpisodeKeys.has(episodeKey);
-      const rating = resolveEpisodeImdbRating(episode, this.seriesRatingsBySeason);
-      const dateLabel = formatEpisodeCardDate(episode.released || "");
-      const isUnavailable = episode.available === false;
-      const metaParts = [
-        episode.runtimeMinutes > 0 ? renderEpisodeRuntimeLabel(episode.runtimeMinutes) : "",
-        rating != null ? `<span class="series-episode-rating-inline">${renderImdbBadge(String(Number(rating).toFixed(1)))}</span>` : "",
-        dateLabel ? `<span class="series-episode-date">${escapeHtml(dateLabel)}</span>` : ""
-      ].filter(Boolean).join("");
-      return `
+    return selectedSeasonEpisodes
+      .map((episode) => {
+        const progress =
+          this.episodeProgressMap.get(`${episode.season}:${episode.episode}`) || null;
+        const position = Number(progress?.positionMs || 0);
+        const duration = Number(progress?.durationMs || 0);
+        const progressRatio = duration > 0 ? Math.min(1, Math.max(0, position / duration)) : 0;
+        const episodeKey = `${episode.season}:${episode.episode}`;
+        const isWatched = this.enrichedWatchedState?.has(episodeKey)
+          ? Boolean(this.enrichedWatchedState.get(episodeKey)?.isWatched)
+          : this.watchedEpisodeKeys.has(episodeKey);
+        const rating = resolveEpisodeImdbRating(episode, this.seriesRatingsBySeason);
+        const dateLabel = formatEpisodeCardDate(episode.released || "");
+        const isUnavailable = episode.available === false;
+        const metaParts = [
+          episode.runtimeMinutes > 0 ? renderEpisodeRuntimeLabel(episode.runtimeMinutes) : "",
+          rating != null
+            ? `<span class="series-episode-rating-inline">${renderImdbBadge(String(Number(rating).toFixed(1)))}</span>`
+            : "",
+          dateLabel ? `<span class="series-episode-date">${escapeHtml(dateLabel)}</span>` : ""
+        ]
+          .filter(Boolean)
+          .join("");
+        return `
         <article class="series-episode-card focusable${isWatched ? " watched" : ""}"
              data-action="openEpisodeStreams"
              data-video-id="${episode.id}">
@@ -2735,11 +2998,14 @@ export const MetaDetailsScreen = {
           </div>
         </article>
       `;
-    }).join("");
+      })
+      .join("");
   },
 
   syncSeriesHeroPlayButtonLabel() {
-    const labelNode = this.container?.querySelector?.(".series-detail-actions [data-action='playDefault'] span:last-child");
+    const labelNode = this.container?.querySelector?.(
+      ".series-detail-actions [data-action='playDefault'] span:last-child"
+    );
     if (labelNode instanceof HTMLElement) {
       labelNode.textContent = this.getSeriesHeroPlayLabel();
     }
@@ -2750,7 +3016,9 @@ export const MetaDetailsScreen = {
     if (!videoId || !this.container) {
       return;
     }
-    const card = this.container.querySelector(`.series-episode-card[data-video-id="${escapeSelectorValue(videoId)}"]`);
+    const card = this.container.querySelector(
+      `.series-episode-card[data-video-id="${escapeSelectorValue(videoId)}"]`
+    );
     if (!(card instanceof HTMLElement)) {
       return;
     }
@@ -2760,7 +3028,10 @@ export const MetaDetailsScreen = {
       return;
     }
 
-    const progress = this.episodeProgressMap.get(`${Number(episode.season || 0)}:${Number(episode.episode || 0)}`) || null;
+    const progress =
+      this.episodeProgressMap.get(
+        `${Number(episode.season || 0)}:${Number(episode.episode || 0)}`
+      ) || null;
     const position = Number(progress?.positionMs || 0);
     const duration = Number(progress?.durationMs || 0);
     const progressRatio = duration > 0 ? Math.min(1, Math.max(0, position / duration)) : 0;
@@ -2821,14 +3092,20 @@ export const MetaDetailsScreen = {
 
   getEpisodeFocusDescriptor(videoId) {
     const value = String(videoId || "").trim();
-    return value ? { selector: `.series-episode-card[data-video-id="${escapeSelectorValue(value)}"]` } : null;
+    return value
+      ? { selector: `.series-episode-card[data-video-id="${escapeSelectorValue(value)}"]` }
+      : null;
   },
 
   getEpisodeMenuProgress(episode) {
     if (!episode) {
       return null;
     }
-    return this.episodeProgressMap.get(`${Number(episode.season || 0)}:${Number(episode.episode || 0)}`) || null;
+    return (
+      this.episodeProgressMap.get(
+        `${Number(episode.season || 0)}:${Number(episode.episode || 0)}`
+      ) || null
+    );
   },
 
   isEpisodeMarkedWatched(episode) {
@@ -2843,7 +3120,11 @@ export const MetaDetailsScreen = {
   },
 
   getEpisodeHoldMenuEpisode() {
-    return this.getEpisodeByVideoId(this.episodeHoldMenu?.videoId) || this.episodeHoldMenu?.episode || null;
+    return (
+      this.getEpisodeByVideoId(this.episodeHoldMenu?.videoId) ||
+      this.episodeHoldMenu?.episode ||
+      null
+    );
   },
 
   getEpisodeHoldMenuOptions() {
@@ -2854,11 +3135,24 @@ export const MetaDetailsScreen = {
     const watched = this.isEpisodeMarkedWatched(episode);
     const seasonFullyWatched = this.isSeasonFullyWatched(episode.season);
     const options = [
-      { action: "toggleWatched", label: watched ? t("episodes_mark_unwatched", {}, "Mark as unwatched") : t("episodes_mark_watched", {}, "Mark as watched") },
-      { action: seasonFullyWatched ? "markSeasonUnwatched" : "markSeasonWatched", label: seasonFullyWatched ? t("episodes_mark_season_unwatched", {}, "Mark season as unwatched") : t("episodes_mark_season_watched", {}, "Mark season as watched") }
+      {
+        action: "toggleWatched",
+        label: watched
+          ? t("episodes_mark_unwatched", {}, "Mark as unwatched")
+          : t("episodes_mark_watched", {}, "Mark as watched")
+      },
+      {
+        action: seasonFullyWatched ? "markSeasonUnwatched" : "markSeasonWatched",
+        label: seasonFullyWatched
+          ? t("episodes_mark_season_unwatched", {}, "Mark season as unwatched")
+          : t("episodes_mark_season_watched", {}, "Mark season as watched")
+      }
     ];
     if (this.getPreviousEpisodes(episode).length > 0) {
-      options.push({ action: "markPreviousWatched", label: t("episodes_mark_previous_watched", {}, "Mark previous episodes as watched") });
+      options.push({
+        action: "markPreviousWatched",
+        label: t("episodes_mark_previous_watched", {}, "Mark previous episodes as watched")
+      });
     }
     options.push({ action: "play", label: t("episodes_play", {}, "Play") });
     return options;
@@ -2912,7 +3206,11 @@ export const MetaDetailsScreen = {
         selected: membership[tab.key] === true,
         className: "poster-list-picker-list-button"
       })),
-      { action: "saveLibraryLists", label: t("action_save", {}, "Save"), className: "poster-list-picker-save-button" }
+      {
+        action: "saveLibraryLists",
+        label: t("action_save", {}, "Save"),
+        className: "poster-list-picker-save-button"
+      }
     ];
   },
 
@@ -2947,7 +3245,12 @@ export const MetaDetailsScreen = {
     this.destroyDetailHoldDialog();
     this.detailHoldDialog = new NuvioDialog({
       title: this.meta?.name || this.params?.fallbackTitle || this.params?.itemId || "Untitled",
-      subtitle: [`S${Number(episode.season || 0)}E${Number(episode.episode || 0)}`, episode.title || ""].filter(Boolean).join(" - "),
+      subtitle: [
+        `S${Number(episode.season || 0)}E${Number(episode.episode || 0)}`,
+        episode.title || ""
+      ]
+        .filter(Boolean)
+        .join(" - "),
       widthVw: 37.5,
       suppressEnterUntilKeyUp: true,
       buttons: options.map((option, index) => ({
@@ -3009,17 +3312,21 @@ export const MetaDetailsScreen = {
       subtitle: t("detail.playOptions", {}, "Play options"),
       widthVw: 37.5,
       suppressEnterUntilKeyUp: true,
-      buttons: [{
-        label: t("play_manually", {}, "Play manually"),
-        key: "playManually",
-        onAction: () => {
-          void this.activateHeroOptionsMenu();
+      buttons: [
+        {
+          label: t("play_manually", {}, "Play manually"),
+          key: "playManually",
+          onAction: () => {
+            void this.activateHeroOptionsMenu();
+          }
         }
-      }],
+      ],
       onDismiss: () => {
         this.detailHoldDialog = null;
         this.heroPlayMenu = null;
-        this.focusDetailDescriptor({ selector: ".series-detail-actions [data-action='playDefault']" });
+        this.focusDetailDescriptor({
+          selector: ".series-detail-actions [data-action='playDefault']"
+        });
       }
     }).mount(document.body);
     return true;
@@ -3071,8 +3378,10 @@ export const MetaDetailsScreen = {
 
   isHeroHoldTarget(node) {
     const action = String(node?.dataset?.action || "");
-    return Boolean(node?.matches?.(".series-primary-btn.focusable, .series-circle-btn.focusable"))
-      && (action === "playDefault" || action === "toggleLibrary");
+    return (
+      Boolean(node?.matches?.(".series-primary-btn.focusable, .series-circle-btn.focusable")) &&
+      (action === "playDefault" || action === "toggleLibrary")
+    );
   },
 
   cancelPendingHeroHold() {
@@ -3107,7 +3416,8 @@ export const MetaDetailsScreen = {
       if (!pending || Router.getCurrent() !== "detail") {
         return;
       }
-      const current = this.container?.querySelector(".series-detail-actions .focusable.focused") || null;
+      const current =
+        this.container?.querySelector(".series-detail-actions .focusable.focused") || null;
       if (!this.hasPendingHeroHold(current)) {
         return;
       }
@@ -3183,14 +3493,19 @@ export const MetaDetailsScreen = {
       return false;
     }
     const tabs = await libraryRepository.getListTabs().catch(() => []);
-    const resolvedTabs = Array.isArray(tabs) && tabs.length
-      ? tabs
-      : [{ key: "local", title: t("detail.library", {}, "Library"), type: "local" }];
-    const snapshot = await libraryRepository.getMembershipSnapshot(item).catch(() => ({ listMembership: {} }));
+    const resolvedTabs =
+      Array.isArray(tabs) && tabs.length
+        ? tabs
+        : [{ key: "local", title: t("detail.library", {}, "Library"), type: "local" }];
+    const snapshot = await libraryRepository
+      .getMembershipSnapshot(item)
+      .catch(() => ({ listMembership: {} }));
     this.libraryListMenu = {
       item,
       tabs: resolvedTabs,
-      membership: Object.fromEntries(resolvedTabs.map((tab) => [tab.key, Boolean(snapshot?.listMembership?.[tab.key])])),
+      membership: Object.fromEntries(
+        resolvedTabs.map((tab) => [tab.key, Boolean(snapshot?.listMembership?.[tab.key])])
+      ),
       error: ""
     };
     this.heroPlayMenu = null;
@@ -3199,10 +3514,11 @@ export const MetaDetailsScreen = {
 
   async playDefaultFromHero() {
     if (isSeriesDetailMeta(this.meta, this.episodes)) {
-      const targetEpisode = this.nextEpisodeToWatch
-        || this.episodes?.find((entry) => entry.season === this.selectedSeason)
-        || this.episodes?.[0]
-        || null;
+      const targetEpisode =
+        this.nextEpisodeToWatch ||
+        this.episodes?.find((entry) => entry.season === this.selectedSeason) ||
+        this.episodes?.[0] ||
+        null;
       if (targetEpisode?.id) {
         await this.openEpisodeStreamChooser(targetEpisode.id);
       }
@@ -3309,7 +3625,9 @@ export const MetaDetailsScreen = {
 
   getPosterFocusDescriptor(itemId) {
     const id = String(itemId || "").trim();
-    return id ? { selector: `.detail-morelike-card[data-item-id="${escapeSelectorValue(id)}"]` } : null;
+    return id
+      ? { selector: `.detail-morelike-card[data-item-id="${escapeSelectorValue(id)}"]` }
+      : null;
   },
 
   openMoreLikeDetailFromNode(node) {
@@ -3372,7 +3690,8 @@ export const MetaDetailsScreen = {
       if (!pending || Router.getCurrent() !== "detail") {
         return;
       }
-      const current = this.container?.querySelector(".series-episode-card.focusable.focused") || null;
+      const current =
+        this.container?.querySelector(".series-episode-card.focusable.focused") || null;
       if (!this.hasPendingEpisodeHold(current)) {
         return;
       }
@@ -3522,7 +3841,7 @@ export const MetaDetailsScreen = {
     const progress = this.getEpisodeMenuProgress(episode);
     this.episodeHoldMenu = null;
     this.navigateToStreamScreenForEpisode(episode, {
-      resumePositionMs: options.startOver ? 0 : (Number(progress?.positionMs || 0) || 0)
+      resumePositionMs: options.startOver ? 0 : Number(progress?.positionMs || 0) || 0
     });
     return true;
   },
@@ -3546,7 +3865,9 @@ export const MetaDetailsScreen = {
     return (this.episodes || []).filter((entry) => {
       const entrySeason = Number(entry?.season || 0);
       const entryEpisode = Number(entry?.episode || 0);
-      return entrySeason < targetSeason || (entrySeason === targetSeason && entryEpisode < targetEpisode);
+      return (
+        entrySeason < targetSeason || (entrySeason === targetSeason && entryEpisode < targetEpisode)
+      );
     });
   },
 
@@ -3619,8 +3940,10 @@ export const MetaDetailsScreen = {
       watchedItemsRepository.isWatched(this.params?.itemId)
     ]);
     this.isMarkedWatched = Boolean(
-      watchedItem
-      || (progress && Number(progress.durationMs || 0) > 0 && Number(progress.positionMs || 0) >= Number(progress.durationMs || 0))
+      watchedItem ||
+      (progress &&
+        Number(progress.durationMs || 0) > 0 &&
+        Number(progress.positionMs || 0) >= Number(progress.durationMs || 0))
     );
     this.buildEpisodeState(allProgressItems, allWatchedItems, this.enrichedWatchedState);
     this.nextEpisodeToWatch = this.computeNextEpisodeToWatch(progress);
@@ -3665,7 +3988,10 @@ export const MetaDetailsScreen = {
   async activateEpisodeHoldMenuOption() {
     const episode = this.getEpisodeHoldMenuEpisode();
     const options = this.getEpisodeHoldMenuOptions();
-    const option = options[Math.max(0, Math.min(options.length - 1, Number(this.episodeHoldMenu?.optionIndex || 0)))];
+    const option =
+      options[
+        Math.max(0, Math.min(options.length - 1, Number(this.episodeHoldMenu?.optionIndex || 0)))
+      ];
     if (!episode || !option) {
       return false;
     }
@@ -3691,7 +4017,10 @@ export const MetaDetailsScreen = {
   async activateSeasonHoldMenuOption() {
     const season = this.getSeasonHoldMenuSeason();
     const options = this.getSeasonHoldMenuOptions();
-    const option = options[Math.max(0, Math.min(options.length - 1, Number(this.seasonHoldMenu?.optionIndex || 0)))];
+    const option =
+      options[
+        Math.max(0, Math.min(options.length - 1, Number(this.seasonHoldMenu?.optionIndex || 0)))
+      ];
     if (!season || !option) {
       return false;
     }
@@ -3718,7 +4047,10 @@ export const MetaDetailsScreen = {
         ...(this.libraryListMenu.membership || {}),
         [key]: !this.libraryListMenu.membership?.[key]
       };
-      this.detailHoldDialog?.setButtonSelected?.(action, Boolean(this.libraryListMenu.membership[key]));
+      this.detailHoldDialog?.setButtonSelected?.(
+        action,
+        Boolean(this.libraryListMenu.membership[key])
+      );
       return true;
     }
     if (action === "saveLibraryLists") {
@@ -3731,7 +4063,11 @@ export const MetaDetailsScreen = {
         this.syncDetailActionButtons();
       } catch (error) {
         console.warn("Failed to update library lists", error);
-        this.libraryListMenu.error = t("detail_lists_save_failed", {}, "Could not save list changes.");
+        this.libraryListMenu.error = t(
+          "detail_lists_save_failed",
+          {},
+          "Could not save list changes."
+        );
         this.mountLibraryListDialog();
       }
       return true;
@@ -3743,16 +4079,24 @@ export const MetaDetailsScreen = {
     if (!Array.isArray(this.castItems) || !this.castItems.length) {
       return "";
     }
-    return this.castItems.map((person) => `
+    return this.castItems
+      .map(
+        (person) => `
       <div class="card focusable">
         <div style="font-weight:700;">${person.name}</div>
         <div style="opacity:0.8;">Cast</div>
       </div>
-    `).join("");
+    `
+      )
+      .join("");
   },
 
   shouldRenderCommentsSection() {
-    return Boolean(TraktSettingsStore.get().showMetaComments && TraktAuthService.isAuthenticated() && this.supportsTraktComments(this.meta));
+    return Boolean(
+      TraktSettingsStore.get().showMetaComments &&
+      TraktAuthService.isAuthenticated() &&
+      this.supportsTraktComments(this.meta)
+    );
   },
 
   renderStandaloneCommentsSection() {
@@ -3767,11 +4111,14 @@ export const MetaDetailsScreen = {
     if (!items.length) {
       return `<div class="series-insight-empty">${escapeHtml(t("detail.noTrailers", {}, "No trailers available."))}</div>`;
     }
-    const cards = items.map((trailer, index) => {
-      const ytId = String(trailer.ytId || "").trim();
-      const title = trailer.name || trailer.type || t("detail_tab_trailer", {}, "Trailer");
-      const subtitle = [trailer.type, trailer.lang ? String(trailer.lang).toUpperCase() : ""].filter(Boolean).join(" • ");
-      return `
+    const cards = items
+      .map((trailer, index) => {
+        const ytId = String(trailer.ytId || "").trim();
+        const title = trailer.name || trailer.type || t("detail_tab_trailer", {}, "Trailer");
+        const subtitle = [trailer.type, trailer.lang ? String(trailer.lang).toUpperCase() : ""]
+          .filter(Boolean)
+          .join(" • ");
+        return `
         <article class="detail-morelike-card detail-trailer-card focusable"
                  data-action="openSharedTrailer"
                  data-trailer-index="${index}"
@@ -3784,13 +4131,19 @@ export const MetaDetailsScreen = {
           ${subtitle ? `<div class="detail-morelike-type">${escapeHtml(subtitle)}</div>` : ""}
         </article>
       `;
-    }).join("");
+      })
+      .join("");
     return `<div class="detail-morelike-track detail-trailer-track" data-scroll-key="trailer:${escapeHtml(kind)}">${cards}</div>`;
   },
 
   renderCommentsSection() {
     if (this.commentsLoading) {
-      const cards = Array.from({ length: 3 }).map(() => `<article class="detail-comment-card is-loading"><span></span><span></span><span></span></article>`).join("");
+      const cards = Array.from({ length: 3 })
+        .map(
+          () =>
+            `<article class="detail-comment-card is-loading"><span></span><span></span><span></span></article>`
+        )
+        .join("");
       return `<div class="detail-comments-track" data-scroll-key="comments:loading">${cards}</div>`;
     }
     if (this.commentsError) {
@@ -3807,9 +4160,17 @@ export const MetaDetailsScreen = {
           <button class="detail-comments-mode focusable${this.commentsMode === "episode" ? " selected" : ""}" data-action="setCommentsMode" data-comments-mode="episode">${escapeHtml(this.commentsEpisodeTarget ? `S${this.commentsEpisodeTarget.season}E${this.commentsEpisodeTarget.episode}` : t("detail_comments_mode_episode", {}, "Episode"))}</button>
         </div>`
       : "";
-    const subtitle = this.commentsMode === "episode" && this.commentsEpisodeTarget
-      ? t("detail_comments_subtitle_episode", { season: this.commentsEpisodeTarget.season, episode: this.commentsEpisodeTarget.episode }, "Reviews for S{{season}}E{{episode}}")
-      : t("detail_comments_subtitle", {}, "Top Trakt reviews");
+    const subtitle =
+      this.commentsMode === "episode" && this.commentsEpisodeTarget
+        ? t(
+            "detail_comments_subtitle_episode",
+            {
+              season: this.commentsEpisodeTarget.season,
+              episode: this.commentsEpisodeTarget.episode
+            },
+            "Reviews for S{{season}}E{{episode}}"
+          )
+        : t("detail_comments_subtitle", {}, "Top Trakt reviews");
     if (!this.commentsItems.length) {
       return `
         <div class="detail-comments-section">
@@ -3820,16 +4181,31 @@ export const MetaDetailsScreen = {
         </div>
       `;
     }
-    const cards = this.commentsItems.map((review, index) => {
-      const body = review.spoiler || review.containsInlineSpoilers
-        ? t("detail_comments_spoiler_hidden", {}, "Spoiler review. Press OK to reveal.")
-        : review.comment;
-      const chips = [
-        review.review ? t("detail_comments_badge_review", {}, "Review") : "",
-        (review.spoiler || review.containsInlineSpoilers) ? t("detail_comments_badge_spoiler", {}, "Spoiler") : "",
-        review.rating != null ? t("detail_comments_badge_rating", { rating: formatRatingValue(review.rating, { digits: 0, stripTrailingZero: true }) }, "{{rating}}/10") : ""
-      ].filter(Boolean).map((chip) => `<span>${escapeHtml(chip)}</span>`).join("");
-      return `
+    const cards = this.commentsItems
+      .map((review, index) => {
+        const body =
+          review.spoiler || review.containsInlineSpoilers
+            ? t("detail_comments_spoiler_hidden", {}, "Spoiler review. Press OK to reveal.")
+            : review.comment;
+        const chips = [
+          review.review ? t("detail_comments_badge_review", {}, "Review") : "",
+          review.spoiler || review.containsInlineSpoilers
+            ? t("detail_comments_badge_spoiler", {}, "Spoiler")
+            : "",
+          review.rating != null
+            ? t(
+                "detail_comments_badge_rating",
+                {
+                  rating: formatRatingValue(review.rating, { digits: 0, stripTrailingZero: true })
+                },
+                "{{rating}}/10"
+              )
+            : ""
+        ]
+          .filter(Boolean)
+          .map((chip) => `<span>${escapeHtml(chip)}</span>`)
+          .join("");
+        return `
         <article class="detail-comment-card focusable" data-action="openComment" data-comment-index="${index}">
           <h4>${escapeHtml(review.authorDisplayName || "Trakt user")}</h4>
           ${chips ? `<div class="detail-comment-chips">${chips}</div>` : ""}
@@ -3837,8 +4213,11 @@ export const MetaDetailsScreen = {
           <small>${escapeHtml(t("detail_comments_likes", { likes: review.likes || 0 }, "{{likes}} likes"))}</small>
         </article>
       `;
-    }).join("");
-    const loadingMore = this.commentsLoadingMore ? `<article class="detail-comment-card is-loading"><span></span><span></span><span></span></article>` : "";
+      })
+      .join("");
+    const loadingMore = this.commentsLoadingMore
+      ? `<article class="detail-comment-card is-loading"><span></span><span></span><span></span></article>`
+      : "";
     return `
       <div class="detail-comments-section">
         <div class="detail-comments-heading"><img src="assets/icons/trakt_tv_glyph.svg" alt="" /><span>${escapeHtml(t("detail_comments_title", {}, "Comments"))}</span></div>
@@ -3853,12 +4232,13 @@ export const MetaDetailsScreen = {
     if (!Array.isArray(items) || !items.length) {
       return "";
     }
-    const cards = items.map((rawItem) => {
-      const item = normalizePreviewItem(rawItem, fallbackType);
-      const year = extractPreviewYear(item.releaseInfo);
-      const primaryImage = item.landscapePoster || item.poster || "";
-      const fallbackImage = item.poster && item.poster !== primaryImage ? item.poster : "";
-      return `
+    const cards = items
+      .map((rawItem) => {
+        const item = normalizePreviewItem(rawItem, fallbackType);
+        const year = extractPreviewYear(item.releaseInfo);
+        const primaryImage = item.landscapePoster || item.poster || "";
+        const fallbackImage = item.poster && item.poster !== primaryImage ? item.poster : "";
+        return `
       <article class="detail-morelike-card focusable"
            data-action="openMoreLikeDetail"
            data-item-id="${item.id}"
@@ -3867,16 +4247,19 @@ export const MetaDetailsScreen = {
            data-poster-src="${escapeHtml(item.poster || primaryImage || "")}"
            data-backdrop-src="${escapeHtml(item.background || item.backdrop || item.landscapePoster || primaryImage || "")}">
         <div class="detail-morelike-poster-wrap">
-          ${primaryImage
-            ? `<img class="detail-morelike-poster-image" src="${escapeHtml(primaryImage)}" alt="${escapeHtml(item.name || "content")}" loading="lazy" decoding="async"${fallbackImage ? ` data-fallback-src="${escapeHtml(fallbackImage)}"` : ""} onerror="var next=this.dataset.fallbackSrc||''; if(next && this.src !== next){ this.src = next; this.dataset.fallbackSrc=''; return; } this.hidden = true; var placeholder = this.nextElementSibling; if(placeholder){ placeholder.hidden = false; }" />`
-            : ""}
+          ${
+            primaryImage
+              ? `<img class="detail-morelike-poster-image" src="${escapeHtml(primaryImage)}" alt="${escapeHtml(item.name || "content")}" loading="lazy" decoding="async"${fallbackImage ? ` data-fallback-src="${escapeHtml(fallbackImage)}"` : ""} onerror="var next=this.dataset.fallbackSrc||''; if(next && this.src !== next){ this.src = next; this.dataset.fallbackSrc=''; return; } this.hidden = true; var placeholder = this.nextElementSibling; if(placeholder){ placeholder.hidden = false; }" />`
+              : ""
+          }
           <div class="detail-morelike-poster placeholder"${primaryImage ? " hidden" : ""}></div>
         </div>
         <div class="detail-morelike-name">${escapeHtml(item.name || "Untitled")}</div>
         ${year ? `<div class="detail-morelike-type">${escapeHtml(year)}</div>` : ""}
       </article>
     `;
-    }).join("");
+      })
+      .join("");
     return `<div class="detail-morelike-track" data-scroll-key="${escapeHtml(railKey)}">${cards}</div>`;
   },
 
@@ -3907,12 +4290,17 @@ export const MetaDetailsScreen = {
     if (!companies.length) {
       return "";
     }
-    const logos = companies.slice(0, 10).map((company) => `
+    const logos = companies
+      .slice(0, 10)
+      .map(
+        (company) => `
       <article class="detail-company-card focusable"
                data-company-name="${escapeHtml(company.name || "")}">
         ${company.logo ? `<img src="${company.logo}" alt="${escapeHtml(company.name || "Company")}" loading="lazy" decoding="async" />` : `<span>${escapeHtml(company.name || "")}</span>`}
       </article>
-    `).join("");
+    `
+      )
+      .join("");
     return `
       <section class="detail-company-section">
         <h3 class="detail-company-title">${escapeHtml(title)}</h3>
@@ -3960,12 +4348,20 @@ export const MetaDetailsScreen = {
           return;
         }
         if (isSeriesDetailMeta(this.meta, this.episodes) && tab !== this.seriesInsightTab) {
-          this.seriesInsightTab = ["cast", "ratings", "morelike", "trailer", "collection"].includes(tab) ? tab : "cast";
+          this.seriesInsightTab = ["cast", "ratings", "morelike", "trailer", "collection"].includes(
+            tab
+          )
+            ? tab
+            : "cast";
           this.updateRenderedDetailSections(this.meta);
           return;
         }
         if (!isSeriesDetailMeta(this.meta, this.episodes) && tab !== this.movieInsightTab) {
-          this.movieInsightTab = ["cast", "ratings", "morelike", "trailer", "collection"].includes(tab) ? tab : "cast";
+          this.movieInsightTab = ["cast", "ratings", "morelike", "trailer", "collection"].includes(
+            tab
+          )
+            ? tab
+            : "cast";
           this.updateRenderedDetailSections(this.meta);
         }
         return;
@@ -4101,12 +4497,19 @@ export const MetaDetailsScreen = {
       return tab ? { selector: `.series-insight-tab[data-tab="${tab}"]` } : null;
     }
     if (action === "setCommentsMode") {
-      const mode = String(target.dataset.commentsMode || "title") === "episode" ? "episode" : "title";
-      return { selector: `.detail-comments-mode[data-comments-mode="${mode}"]`, preserveVerticalScroll: true };
+      const mode =
+        String(target.dataset.commentsMode || "title") === "episode" ? "episode" : "title";
+      return {
+        selector: `.detail-comments-mode[data-comments-mode="${mode}"]`,
+        preserveVerticalScroll: true
+      };
     }
     if (action === "openComment") {
       const index = Number(target.dataset.commentIndex || 0);
-      return { selector: `.detail-comment-card[data-comment-index="${index}"]`, preserveVerticalScroll: true };
+      return {
+        selector: `.detail-comment-card[data-comment-index="${index}"]`,
+        preserveVerticalScroll: true
+      };
     }
     if (action === "openSharedTrailer") {
       const index = Number(target.dataset.trailerIndex || 0);
@@ -4118,23 +4521,35 @@ export const MetaDetailsScreen = {
     }
     if (action === "openEpisodeStreams") {
       const videoId = String(target.dataset.videoId || "");
-      return videoId ? { selector: `.series-episode-card[data-video-id="${escapeSelectorValue(videoId)}"]` } : null;
+      return videoId
+        ? { selector: `.series-episode-card[data-video-id="${escapeSelectorValue(videoId)}"]` }
+        : null;
     }
     if (action === "openCastDetail") {
       const castKey = String(target.dataset.castKey || "");
-      return castKey ? { selector: `.series-cast-card[data-cast-key="${escapeSelectorValue(castKey)}"]` } : null;
+      return castKey
+        ? { selector: `.series-cast-card[data-cast-key="${escapeSelectorValue(castKey)}"]` }
+        : null;
     }
     if (action === "openMoreLikeDetail") {
       const itemId = String(target.dataset.itemId || "");
-      return itemId ? { selector: `.detail-morelike-card[data-item-id="${escapeSelectorValue(itemId)}"]` } : null;
+      return itemId
+        ? { selector: `.detail-morelike-card[data-item-id="${escapeSelectorValue(itemId)}"]` }
+        : null;
     }
     if (target.matches(".detail-company-card.focusable")) {
       const companyName = String(target.dataset.companyName || "");
-      return companyName ? { selector: `.detail-company-card[data-company-name="${escapeSelectorValue(companyName)}"]` } : null;
+      return companyName
+        ? {
+            selector: `.detail-company-card[data-company-name="${escapeSelectorValue(companyName)}"]`
+          }
+        : null;
     }
     if (target.matches(".series-episode-rating-chip.focusable")) {
       const episode = Number(target.dataset.ratingEpisode || 0);
-      return episode > 0 ? { selector: `.series-episode-rating-chip[data-rating-episode="${episode}"]` } : null;
+      return episode > 0
+        ? { selector: `.series-episode-rating-chip[data-rating-episode="${episode}"]` }
+        : null;
     }
     if (action) {
       return { selector: `.series-detail-actions [data-action="${action}"]` };
@@ -4176,9 +4591,10 @@ export const MetaDetailsScreen = {
       return;
     }
     const property = axis === "y" ? "scrollTop" : "scrollLeft";
-    const max = axis === "y"
-      ? Math.max(0, container.scrollHeight - container.clientHeight)
-      : Math.max(0, container.scrollWidth - container.clientWidth);
+    const max =
+      axis === "y"
+        ? Math.max(0, container.scrollHeight - container.clientHeight)
+        : Math.max(0, container.scrollWidth - container.clientWidth);
     const nextValue = Math.max(0, Math.min(max, Math.round(targetValue)));
     const startValue = Number(container[property] || 0);
     if (Math.abs(startValue - nextValue) <= 1) {
@@ -4186,10 +4602,14 @@ export const MetaDetailsScreen = {
       return;
     }
 
-    const prefersReducedMotion = globalThis?.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches;
+    const prefersReducedMotion = globalThis?.matchMedia?.(
+      "(prefers-reduced-motion: reduce)"
+    )?.matches;
     const effectiveDuration = this.isLegacyTvRuntime()
       ? 0
-      : (this.isPerformanceConstrained() ? Math.min(Number(duration || 150), 90) : Number(duration || 150));
+      : this.isPerformanceConstrained()
+        ? Math.min(Number(duration || 150), 90)
+        : Number(duration || 150);
     if (prefersReducedMotion || effectiveDuration <= 0) {
       container[property] = nextValue;
       return;
@@ -4200,9 +4620,12 @@ export const MetaDetailsScreen = {
       const p1y = 0;
       const p2x = 0.2;
       const p2y = 1;
-      const sampleCurveX = (x) => ((1 - 3 * p2x + 3 * p1x) * x + (3 * p2x - 6 * p1x)) * x * x + (3 * p1x) * x;
-      const sampleCurveY = (x) => ((1 - 3 * p2y + 3 * p1y) * x + (3 * p2y - 6 * p1y)) * x * x + (3 * p1y) * x;
-      const sampleDerivativeX = (x) => (3 * (1 - 3 * p2x + 3 * p1x) * x + 2 * (3 * p2x - 6 * p1x)) * x + (3 * p1x);
+      const sampleCurveX = (x) =>
+        ((1 - 3 * p2x + 3 * p1x) * x + (3 * p2x - 6 * p1x)) * x * x + 3 * p1x * x;
+      const sampleCurveY = (x) =>
+        ((1 - 3 * p2y + 3 * p1y) * x + (3 * p2y - 6 * p1y)) * x * x + 3 * p1y * x;
+      const sampleDerivativeX = (x) =>
+        (3 * (1 - 3 * p2x + 3 * p1x) * x + 2 * (3 * p2x - 6 * p1x)) * x + 3 * p1x;
       let x = t;
       for (let i = 0; i < 4; i += 1) {
         const derivative = sampleDerivativeX(x);
@@ -4221,7 +4644,7 @@ export const MetaDetailsScreen = {
     const startTime = performance.now();
     const tick = (now) => {
       const progress = Math.min(1, (now - startTime) / effectiveDuration);
-      container[property] = Math.round(startValue + ((nextValue - startValue) * ease(progress)));
+      container[property] = Math.round(startValue + (nextValue - startValue) * ease(progress));
       if (progress < 1) {
         existing[key] = requestAnimationFrame(tick);
         map.set(container, existing);
@@ -4240,11 +4663,14 @@ export const MetaDetailsScreen = {
       return;
     }
     const property = axis === "y" ? "scrollTop" : "scrollLeft";
-    const max = axis === "y"
-      ? Math.max(0, container.scrollHeight - container.clientHeight)
-      : Math.max(0, container.scrollWidth - container.clientWidth);
+    const max =
+      axis === "y"
+        ? Math.max(0, container.scrollHeight - container.clientHeight)
+        : Math.max(0, container.scrollWidth - container.clientWidth);
     const nextValue = Math.max(0, Math.min(max, Math.round(targetValue)));
-    const prefersReducedMotion = globalThis?.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches;
+    const prefersReducedMotion = globalThis?.matchMedia?.(
+      "(prefers-reduced-motion: reduce)"
+    )?.matches;
     if (prefersReducedMotion) {
       container[property] = nextValue;
       return;
@@ -4265,7 +4691,9 @@ export const MetaDetailsScreen = {
     if (active) {
       active.target = nextValue;
       active.stiffness = Number(options?.stiffness ?? active.stiffness ?? DETAIL_SCROLL_STIFFNESS);
-      active.dampingRatio = Number(options?.dampingRatio ?? active.dampingRatio ?? DETAIL_SCROLL_DAMPING_RATIO);
+      active.dampingRatio = Number(
+        options?.dampingRatio ?? active.dampingRatio ?? DETAIL_SCROLL_DAMPING_RATIO
+      );
       active.precision = Number(options?.precision ?? active.precision ?? 0.5);
       active.velocityEpsilon = Number(options?.velocityEpsilon ?? active.velocityEpsilon ?? 0.5);
       active.damping = 2 * active.dampingRatio * Math.sqrt(active.stiffness);
@@ -4289,16 +4717,22 @@ export const MetaDetailsScreen = {
     };
 
     const tick = (now) => {
-      const deltaSeconds = Math.min(DETAIL_SCROLL_MAX_FRAME_SECONDS, Math.max(0.001, (now - state.lastTime) / 1000));
+      const deltaSeconds = Math.min(
+        DETAIL_SCROLL_MAX_FRAME_SECONDS,
+        Math.max(0.001, (now - state.lastTime) / 1000)
+      );
       state.lastTime = now;
       const displacement = state.position - Number(state.target || 0);
-      const acceleration = (-state.stiffness * displacement) - (state.damping * state.velocity);
+      const acceleration = -state.stiffness * displacement - state.damping * state.velocity;
       state.velocity += acceleration * deltaSeconds;
       state.position += state.velocity * deltaSeconds;
       container[property] = state.position;
 
       const remaining = Number(state.target || 0) - Number(container[property] || 0);
-      if (Math.abs(remaining) <= state.precision && Math.abs(state.velocity) <= state.velocityEpsilon) {
+      if (
+        Math.abs(remaining) <= state.precision &&
+        Math.abs(state.velocity) <= state.velocityEpsilon
+      ) {
         container[property] = state.target;
         existing[key] = null;
         springMap.set(container, existing);
@@ -4321,12 +4755,12 @@ export const MetaDetailsScreen = {
       this.trailerAutoplayTimer = null;
     }
     if (
-      !this.trailerSource
-      || this.isTrailerPlaying
-      || this.pendingEpisodeSelection
-      || this.pendingMovieSelection
-      || this.shouldSuppressTrailerAutoplay()
-      || !PlayerSettingsStore.get().trailerAutoplay
+      !this.trailerSource ||
+      this.isTrailerPlaying ||
+      this.pendingEpisodeSelection ||
+      this.pendingMovieSelection ||
+      this.shouldSuppressTrailerAutoplay() ||
+      !PlayerSettingsStore.get().trailerAutoplay
     ) {
       return;
     }
@@ -4371,7 +4805,11 @@ export const MetaDetailsScreen = {
     }
     this.trailerProxyLoadingTimer = setTimeout(() => {
       const activeId = String(this.trailerSource?.ytId || "").trim();
-      if (!this.isTrailerPlaying || this.trailerSource?.kind !== "youtube" || activeId !== expectedId) {
+      if (
+        !this.isTrailerPlaying ||
+        this.trailerSource?.kind !== "youtube" ||
+        activeId !== expectedId
+      ) {
         return;
       }
       if (this.trailerProxyState && !this.trailerProxyState.loading) {
@@ -4419,7 +4857,11 @@ export const MetaDetailsScreen = {
     this.stopTrailerProgressTimer();
     this.updateTrailerOverlay();
     this.trailerProgressTimer = setInterval(() => {
-      if (this.isTrailerPlaying && this.trailerSource?.kind === "youtube" && !this.trailerYoutubeFallbackActive) {
+      if (
+        this.isTrailerPlaying &&
+        this.trailerSource?.kind === "youtube" &&
+        !this.trailerYoutubeFallbackActive
+      ) {
         this.postTrailerProxyCommand("getState");
       }
       this.updateTrailerOverlay();
@@ -4430,21 +4872,21 @@ export const MetaDetailsScreen = {
     const layer = this.container?.querySelector(".detail-trailer-layer");
     this.trailerUiRefs = layer
       ? {
-        layer,
-        overlay: layer.querySelector(".detail-trailer-controls-overlay"),
-        media: layer.querySelector("[data-trailer-media]"),
-        frame: layer.querySelector(".detail-trailer-frame"),
-        video: layer.querySelector(".detail-trailer-video"),
-        status: layer.querySelector("[data-trailer-status]"),
-        progressFill: layer.querySelector("[data-trailer-progress-fill]"),
-        timeLabel: layer.querySelector("[data-trailer-time-label]"),
-        playPauseButton: layer.querySelector('[data-trailer-control="playPause"]'),
-        playPauseIcon: layer.querySelector("[data-trailer-play-icon]"),
-        playPauseText: layer.querySelector("[data-trailer-play-label]"),
-        muteButton: layer.querySelector('[data-trailer-control="mute"]'),
-        muteIcon: layer.querySelector("[data-trailer-mute-icon]"),
-        muteText: layer.querySelector("[data-trailer-mute-label]")
-      }
+          layer,
+          overlay: layer.querySelector(".detail-trailer-controls-overlay"),
+          media: layer.querySelector("[data-trailer-media]"),
+          frame: layer.querySelector(".detail-trailer-frame"),
+          video: layer.querySelector(".detail-trailer-video"),
+          status: layer.querySelector("[data-trailer-status]"),
+          progressFill: layer.querySelector("[data-trailer-progress-fill]"),
+          timeLabel: layer.querySelector("[data-trailer-time-label]"),
+          playPauseButton: layer.querySelector('[data-trailer-control="playPause"]'),
+          playPauseIcon: layer.querySelector("[data-trailer-play-icon]"),
+          playPauseText: layer.querySelector("[data-trailer-play-label]"),
+          muteButton: layer.querySelector('[data-trailer-control="mute"]'),
+          muteIcon: layer.querySelector("[data-trailer-mute-icon]"),
+          muteText: layer.querySelector("[data-trailer-mute-label]")
+        }
       : null;
   },
 
@@ -4502,9 +4944,10 @@ export const MetaDetailsScreen = {
     }
     const playback = this.getTrailerPlaybackSnapshot();
     this.trailerMuted = Boolean(playback.muted);
-    const progress = playback.duration > 0
-      ? Math.max(0, Math.min(100, (playback.currentTime / playback.duration) * 100))
-      : 0;
+    const progress =
+      playback.duration > 0
+        ? Math.max(0, Math.min(100, (playback.currentTime / playback.duration) * 100))
+        : 0;
     if (refs.progressFill) {
       refs.progressFill.style.width = `${progress.toFixed(3)}%`;
     }
@@ -4515,11 +4958,17 @@ export const MetaDetailsScreen = {
       refs.status.textContent = playback.loading
         ? t("detail.trailerLoading", {}, "Loading trailer...")
         : playback.controllable
-          ? t("detail.trailerControlsHint", {}, "OK Play/Pause  LEFT/RIGHT Seek  UP/DOWN Audio  BACK Close")
+          ? t(
+              "detail.trailerControlsHint",
+              {},
+              "OK Play/Pause  LEFT/RIGHT Seek  UP/DOWN Audio  BACK Close"
+            )
           : t("detail.trailerFallbackHint", {}, "Use back to close the trailer");
     }
     if (refs.playPauseIcon) {
-      refs.playPauseIcon.src = playback.paused ? "assets/icons/ic_player_play.svg" : "assets/icons/ic_player_pause.svg";
+      refs.playPauseIcon.src = playback.paused
+        ? "assets/icons/ic_player_play.svg"
+        : "assets/icons/ic_player_pause.svg";
       refs.playPauseIcon.alt = "";
     }
     if (refs.playPauseText) {
@@ -4528,9 +4977,12 @@ export const MetaDetailsScreen = {
         : t("detail.trailerPause", {}, "Pause");
     }
     if (refs.playPauseButton) {
-      refs.playPauseButton.setAttribute("aria-label", playback.paused
-        ? t("detail.trailerResume", {}, "Resume")
-        : t("detail.trailerPause", {}, "Pause"));
+      refs.playPauseButton.setAttribute(
+        "aria-label",
+        playback.paused
+          ? t("detail.trailerResume", {}, "Resume")
+          : t("detail.trailerPause", {}, "Pause")
+      );
     }
     if (refs.muteIcon) {
       refs.muteIcon.src = playback.muted
@@ -4544,9 +4996,12 @@ export const MetaDetailsScreen = {
         : t("detail.trailerMute", {}, "Mute");
     }
     if (refs.muteButton) {
-      refs.muteButton.setAttribute("aria-label", playback.muted
-        ? t("detail.trailerUnmute", {}, "Unmute")
-        : t("detail.trailerMute", {}, "Mute"));
+      refs.muteButton.setAttribute(
+        "aria-label",
+        playback.muted
+          ? t("detail.trailerUnmute", {}, "Unmute")
+          : t("detail.trailerMute", {}, "Mute")
+      );
       refs.muteButton.disabled = !playback.controllable;
     }
     if (playback.loading || playback.paused) {
@@ -4565,7 +5020,17 @@ export const MetaDetailsScreen = {
     }
     this.detachTrailerMediaListeners();
     const sync = () => this.updateTrailerOverlay();
-    const eventNames = ["play", "pause", "timeupdate", "volumechange", "loadedmetadata", "durationchange", "waiting", "playing", "canplay"];
+    const eventNames = [
+      "play",
+      "pause",
+      "timeupdate",
+      "volumechange",
+      "loadedmetadata",
+      "durationchange",
+      "waiting",
+      "playing",
+      "canplay"
+    ];
     this.trailerMediaListeners = eventNames.map((eventName) => {
       video.addEventListener(eventName, sync);
       return { target: video, eventName, handler: sync };
@@ -4580,7 +5045,12 @@ export const MetaDetailsScreen = {
 
   async initYoutubeTrailerPlayer() {
     const ytId = String(this.trailerSource?.ytId || "").trim();
-    if (!ytId || !this.trailerUiRefs?.frame || !this.isTrailerPlaying || this.trailerSource?.kind !== "youtube") {
+    if (
+      !ytId ||
+      !this.trailerUiRefs?.frame ||
+      !this.isTrailerPlaying ||
+      this.trailerSource?.kind !== "youtube"
+    ) {
       return;
     }
     this.destroyYoutubeTrailerPlayer();
@@ -4596,7 +5066,11 @@ export const MetaDetailsScreen = {
     this.startTrailerProxyLoadingTimer(ytId);
     this.updateTrailerOverlay();
     setTimeout(() => {
-      if (!this.isTrailerPlaying || this.trailerSource?.kind !== "youtube" || String(this.trailerSource?.ytId || "").trim() !== ytId) {
+      if (
+        !this.isTrailerPlaying ||
+        this.trailerSource?.kind !== "youtube" ||
+        String(this.trailerSource?.ytId || "").trim() !== ytId
+      ) {
         return;
       }
       this.postTrailerProxyCommand("setMuted", { muted: Boolean(this.trailerMuted) });
@@ -4704,7 +5178,9 @@ export const MetaDetailsScreen = {
       layer.innerHTML = "";
       return;
     }
-    const title = escapeHtml(this.meta?.name || this.params?.fallbackTitle || this.params?.itemId || "Trailer");
+    const title = escapeHtml(
+      this.meta?.name || this.params?.fallbackTitle || this.params?.itemId || "Trailer"
+    );
     const subtitle = escapeHtml(t("detail.trailerLabel", {}, "Trailer"));
     const controlsMarkup = `
       <div class="detail-trailer-controls-overlay" tabindex="-1">
@@ -4741,7 +5217,10 @@ export const MetaDetailsScreen = {
       </div>
     `;
     if (this.trailerSource.kind === "youtube") {
-      const youtubeFrameUrl = buildInlineYoutubePlayerUrl(this.trailerSource.ytId, { muted: this.trailerMuted }) || this.trailerSource.embedUrl || "";
+      const youtubeFrameUrl =
+        buildInlineYoutubePlayerUrl(this.trailerSource.ytId, { muted: this.trailerMuted }) ||
+        this.trailerSource.embedUrl ||
+        "";
       layer.innerHTML = `
         <div class="detail-trailer-media detail-trailer-youtube" data-trailer-media>
           <iframe
@@ -4782,7 +5261,12 @@ export const MetaDetailsScreen = {
     this.startTrailerProgressTimer();
   },
 
-  async playTrailer({ muted = null, restart = false, initiatedByUser = true, preserveSource = false } = {}) {
+  async playTrailer({
+    muted = null,
+    restart = false,
+    initiatedByUser = true,
+    preserveSource = false
+  } = {}) {
     if (!preserveSource && (!this.trailerSource || this.trailerSource.kind === "youtube")) {
       const preferredSource = await this.resolvePreferredTrailerSource(this.meta);
       if (preferredSource) {
@@ -4829,12 +5313,10 @@ export const MetaDetailsScreen = {
         if (activeFrame) {
           try {
             activeFrame.src = "about:blank";
-          } catch (_) {
-          }
+          } catch (_) {}
           try {
             activeFrame.removeAttribute("src");
-          } catch (_) {
-          }
+          } catch (_) {}
         }
         layer.innerHTML = "";
       }
@@ -4893,19 +5375,25 @@ export const MetaDetailsScreen = {
       return;
     }
 
-    const addons = Array.from(new Set(pending.streams.map((stream) => stream.addonName).filter(Boolean)));
+    const addons = Array.from(
+      new Set(pending.streams.map((stream) => stream.addonName).filter(Boolean))
+    );
     const filtered = this.getFilteredEpisodeStreams();
     const filterTabs = [
       `<button class="series-stream-filter focusable${pending.addonFilter === "all" ? " selected" : ""}" data-action="setStreamFilter" data-addon="all">All</button>`,
-      ...addons.map((addon) => `
+      ...addons.map(
+        (addon) => `
         <button class="series-stream-filter focusable${pending.addonFilter === addon ? " selected" : ""}" data-action="setStreamFilter" data-addon="${addon}">
           ${addon}
         </button>
-      `)
+      `
+      )
     ].join("");
 
     const streamCards = filtered.length
-      ? filtered.map((stream) => `
+      ? filtered
+          .map(
+            (stream) => `
           <article class="series-stream-card focusable"
                    data-action="playEpisodeStream"
                    data-stream-id="${stream.id}">
@@ -4917,10 +5405,18 @@ export const MetaDetailsScreen = {
             </div>
             <div class="series-stream-tags">
               <span class="series-stream-tag">${detectQuality(stream.label || stream.description || "")}</span>
-              <span class="series-stream-tag">${String(stream.sourceType || "").toLowerCase().includes("torrent") ? "Torrent" : "Stream"}</span>
+              <span class="series-stream-tag">${
+                String(stream.sourceType || "")
+                  .toLowerCase()
+                  .includes("torrent")
+                  ? "Torrent"
+                  : "Stream"
+              }</span>
             </div>
           </article>
-        `).join("")
+        `
+          )
+          .join("")
       : pending.loading
         ? `<div class="series-stream-empty">Loading streams...</div>`
         : `<div class="series-stream-empty">No streams found for this filter.</div>`;
@@ -4957,19 +5453,25 @@ export const MetaDetailsScreen = {
       return;
     }
 
-    const addons = Array.from(new Set(pending.streams.map((stream) => stream.addonName).filter(Boolean)));
+    const addons = Array.from(
+      new Set(pending.streams.map((stream) => stream.addonName).filter(Boolean))
+    );
     const filtered = this.getFilteredEpisodeStreams();
     const filterTabs = [
       `<button class="series-stream-filter focusable${pending.addonFilter === "all" ? " selected" : ""}" data-action="setStreamFilter" data-addon="all">All</button>`,
-      ...addons.map((addon) => `
+      ...addons.map(
+        (addon) => `
         <button class="series-stream-filter focusable${pending.addonFilter === addon ? " selected" : ""}" data-action="setStreamFilter" data-addon="${addon}">
           ${addon}
         </button>
-      `)
+      `
+      )
     ].join("");
 
     const streamCards = filtered.length
-      ? filtered.map((stream) => `
+      ? filtered
+          .map(
+            (stream) => `
           <article class="series-stream-card focusable"
                    data-action="playPendingStream"
                    data-stream-id="${stream.id}">
@@ -4981,10 +5483,18 @@ export const MetaDetailsScreen = {
             </div>
             <div class="series-stream-tags">
               <span class="series-stream-tag">${detectQuality(stream.label || stream.description || "")}</span>
-              <span class="series-stream-tag">${String(stream.sourceType || "").toLowerCase().includes("torrent") ? "Torrent" : "Stream"}</span>
+              <span class="series-stream-tag">${
+                String(stream.sourceType || "")
+                  .toLowerCase()
+                  .includes("torrent")
+                  ? "Torrent"
+                  : "Stream"
+              }</span>
             </div>
           </article>
-        `).join("")
+        `
+          )
+          .join("")
       : pending.loading
         ? `<div class="series-stream-empty">Loading streams...</div>`
         : `<div class="series-stream-empty">No streams found for this filter.</div>`;
@@ -5058,12 +5568,14 @@ export const MetaDetailsScreen = {
     if (!pending) {
       return;
     }
-    const selectedStream = pending.streams.find((stream) => stream.id === streamId) || this.getFilteredEpisodeStreams()[0];
+    const selectedStream =
+      pending.streams.find((stream) => stream.id === streamId) ||
+      this.getFilteredEpisodeStreams()[0];
     if (!selectedStream?.url) {
       return;
     }
     const currentIndex = this.episodes.findIndex((entry) => entry.id === pending.videoId);
-    const nextEpisode = currentIndex >= 0 ? (this.episodes[currentIndex + 1] || null) : null;
+    const nextEpisode = currentIndex >= 0 ? this.episodes[currentIndex + 1] || null : null;
     const imdbId = resolveMetaImdbId(this.meta, this.params);
     Router.navigate("player", {
       streamUrl: selectedStream.url,
@@ -5073,10 +5585,16 @@ export const MetaDetailsScreen = {
       videoId: pending.videoId,
       season: pending.episode?.season ?? null,
       episode: pending.episode?.episode ?? null,
-      episodeLabel: pending.episode ? `S${pending.episode.season}E${pending.episode.episode}` : null,
-      playerTitle: this.meta?.name || this.params?.fallbackTitle || this.params?.itemId || "Untitled",
+      episodeLabel: pending.episode
+        ? `S${pending.episode.season}E${pending.episode.episode}`
+        : null,
+      playerTitle:
+        this.meta?.name || this.params?.fallbackTitle || this.params?.itemId || "Untitled",
       playerSubtitle: pending.episode
-        ? `S${pending.episode.season}E${pending.episode.episode} - ${pending.episode.title || ""}`.replace(/\s+-\s*$/, "")
+        ? `S${pending.episode.season}E${pending.episode.episode} - ${pending.episode.title || ""}`.replace(
+            /\s+-\s*$/,
+            ""
+          )
         : "",
       playerEpisodeTitle: pending.episode?.title || "",
       playerBackdropUrl: this.meta?.background || this.meta?.poster || null,
@@ -5100,8 +5618,9 @@ export const MetaDetailsScreen = {
       return;
     }
     const currentIndex = this.episodes.findIndex((entry) => entry.id === episode.id);
-    const nextEpisode = currentIndex >= 0 ? (this.episodes[currentIndex + 1] || null) : null;
-    const streamBackdrop = this.meta?.background || this.meta?.landscapePoster || this.meta?.poster || null;
+    const nextEpisode = currentIndex >= 0 ? this.episodes[currentIndex + 1] || null : null;
+    const streamBackdrop =
+      this.meta?.background || this.meta?.landscapePoster || this.meta?.poster || null;
     const imdbId = resolveMetaImdbId(this.meta, this.params);
     Router.navigate("stream", {
       itemId: this.params?.itemId || null,
@@ -5133,7 +5652,8 @@ export const MetaDetailsScreen = {
 
   navigateToStreamScreenForMovie(extraParams = {}) {
     const releaseYear = String(this.meta?.releaseInfo || "").match(/\b(19|20)\d{2}\b/)?.[0] || "";
-    const streamBackdrop = this.meta?.background || this.meta?.landscapePoster || this.meta?.poster || null;
+    const streamBackdrop =
+      this.meta?.background || this.meta?.landscapePoster || this.meta?.poster || null;
     const itemType = resolvePlayableDetailType(this.params?.itemType || this.meta?.type, this.meta);
     const imdbId = resolveMetaImdbId(this.meta, this.params);
     Router.navigate("stream", {
@@ -5162,7 +5682,9 @@ export const MetaDetailsScreen = {
     if (!pending) {
       return;
     }
-    const selectedStream = pending.streams.find((stream) => stream.id === streamId) || this.getFilteredEpisodeStreams()[0];
+    const selectedStream =
+      pending.streams.find((stream) => stream.id === streamId) ||
+      this.getFilteredEpisodeStreams()[0];
     if (!selectedStream?.url) {
       return;
     }
@@ -5174,7 +5696,8 @@ export const MetaDetailsScreen = {
       imdbId,
       season: null,
       episode: null,
-      playerTitle: this.meta?.name || this.params?.fallbackTitle || this.params?.itemId || "Untitled",
+      playerTitle:
+        this.meta?.name || this.params?.fallbackTitle || this.params?.itemId || "Untitled",
       playerSubtitle: "",
       playerReleaseYear: String(this.meta?.releaseInfo || "").match(/\b(19|20)\d{2}\b/)?.[0] || "",
       playerBackdropUrl: this.meta?.background || this.meta?.poster || null,
@@ -5208,7 +5731,11 @@ export const MetaDetailsScreen = {
     if (!(node instanceof HTMLElement)) {
       return null;
     }
-    return node.closest(".series-detail-actions, .series-season-row, .series-episode-track, .series-insight-tabs, .detail-comments-modes, .detail-comments-track, .movie-cast-track, .series-cast-track, .series-rating-seasons, .series-episode-ratings-grid, .detail-morelike-track, .detail-company-track") || node;
+    return (
+      node.closest(
+        ".series-detail-actions, .series-season-row, .series-episode-track, .series-insight-tabs, .detail-comments-modes, .detail-comments-track, .movie-cast-track, .series-cast-track, .series-rating-seasons, .series-episode-ratings-grid, .detail-morelike-track, .detail-company-track"
+      ) || node
+    );
   },
 
   getHorizontalTrackScrollLeft(horizontalTrack, target) {
@@ -5217,12 +5744,19 @@ export const MetaDetailsScreen = {
     }
     const maxScrollLeft = Math.max(0, horizontalTrack.scrollWidth - horizontalTrack.clientWidth);
     if (horizontalTrack.classList.contains("series-episode-track")) {
-      const styles = globalThis.getComputedStyle ? globalThis.getComputedStyle(horizontalTrack) : null;
+      const styles = globalThis.getComputedStyle
+        ? globalThis.getComputedStyle(horizontalTrack)
+        : null;
       const leftPad = Math.max(0, Number.parseFloat(styles?.paddingLeft || "0") || 0);
       return Math.max(0, Math.min(maxScrollLeft, target.offsetLeft - leftPad));
     }
-    if (horizontalTrack.classList.contains("detail-morelike-track") || horizontalTrack.classList.contains("detail-comments-track")) {
-      const styles = globalThis.getComputedStyle ? globalThis.getComputedStyle(horizontalTrack) : null;
+    if (
+      horizontalTrack.classList.contains("detail-morelike-track") ||
+      horizontalTrack.classList.contains("detail-comments-track")
+    ) {
+      const styles = globalThis.getComputedStyle
+        ? globalThis.getComputedStyle(horizontalTrack)
+        : null;
       const leftPad = Math.max(0, Number.parseFloat(styles?.paddingLeft || "0") || 0);
       return Math.max(0, Math.min(maxScrollLeft, target.offsetLeft - leftPad));
     }
@@ -5232,10 +5766,13 @@ export const MetaDetailsScreen = {
     const targetRight = targetLeft + target.offsetWidth;
     const viewLeft = horizontalTrack.scrollLeft;
     const viewRight = viewLeft + horizontalTrack.clientWidth;
-    if (targetRight > (viewRight - edgePadding)) {
-      return Math.max(0, Math.min(maxScrollLeft, targetRight - horizontalTrack.clientWidth + edgePadding));
+    if (targetRight > viewRight - edgePadding) {
+      return Math.max(
+        0,
+        Math.min(maxScrollLeft, targetRight - horizontalTrack.clientWidth + edgePadding)
+      );
     }
-    if (targetLeft < (viewLeft + edgePadding)) {
+    if (targetLeft < viewLeft + edgePadding) {
       return Math.max(0, Math.min(maxScrollLeft, targetLeft - edgePadding));
     }
     return viewLeft;
@@ -5246,7 +5783,9 @@ export const MetaDetailsScreen = {
     if (!detailContent || !(target instanceof HTMLElement) || !detailContent.contains(target)) {
       return;
     }
-    const focusables = Array.from(detailContent.querySelectorAll(".focusable")).filter((node) => node instanceof HTMLElement);
+    const focusables = Array.from(detailContent.querySelectorAll(".focusable")).filter(
+      (node) => node instanceof HTMLElement
+    );
     if (!focusables.length) {
       return;
     }
@@ -5258,7 +5797,10 @@ export const MetaDetailsScreen = {
       return;
     }
     if (targetGroup && lastGroup && targetGroup === lastGroup) {
-      detailContent.scrollTop = Math.max(0, detailContent.scrollHeight - detailContent.clientHeight);
+      detailContent.scrollTop = Math.max(
+        0,
+        detailContent.scrollHeight - detailContent.clientHeight
+      );
     }
   },
 
@@ -5278,7 +5820,9 @@ export const MetaDetailsScreen = {
     if (!Array.isArray(seasons) || !seasons.length) {
       return 0;
     }
-    const selectedIndex = seasons.findIndex((node) => Number(node?.dataset?.season || 0) === Number(this.selectedSeason || 0));
+    const selectedIndex = seasons.findIndex(
+      (node) => Number(node?.dataset?.season || 0) === Number(this.selectedSeason || 0)
+    );
     return selectedIndex >= 0 ? selectedIndex : 0;
   },
 
@@ -5293,7 +5837,9 @@ export const MetaDetailsScreen = {
       return 0;
     }
     const activeTabKey = this.getActiveInsightTabKey();
-    const activeTabIndex = tabs.findIndex((node) => String(node?.dataset?.tab || "") === activeTabKey);
+    const activeTabIndex = tabs.findIndex(
+      (node) => String(node?.dataset?.tab || "") === activeTabKey
+    );
     if (activeTabIndex >= 0) {
       return activeTabIndex;
     }
@@ -5309,9 +5855,14 @@ export const MetaDetailsScreen = {
       return;
     }
     const seasonKey = String(Number(this.selectedSeason || 0) || 0);
-    const items = Array.isArray(list) && list.length
-      ? list
-      : Array.from(this.container?.querySelectorAll(".series-episode-track .series-episode-card.focusable") || []);
+    const items =
+      Array.isArray(list) && list.length
+        ? list
+        : Array.from(
+            this.container?.querySelectorAll(
+              ".series-episode-track .series-episode-card.focusable"
+            ) || []
+          );
     const index = items.indexOf(target);
     if (index >= 0) {
       this.episodeFocusIndexBySeason[seasonKey] = index;
@@ -5342,7 +5893,10 @@ export const MetaDetailsScreen = {
   },
 
   rememberRailFocus(target, list = null) {
-    if (!(target instanceof HTMLElement) || !target.matches(".detail-morelike-card, .detail-company-card")) {
+    if (
+      !(target instanceof HTMLElement) ||
+      !target.matches(".detail-morelike-card, .detail-company-card")
+    ) {
       return;
     }
     const track = target.closest("[data-scroll-key]");
@@ -5353,9 +5907,8 @@ export const MetaDetailsScreen = {
     const itemSelector = target.matches(".detail-company-card")
       ? ".detail-company-card.focusable"
       : ".detail-morelike-card.focusable";
-    const items = Array.isArray(list) && list.length
-      ? list
-      : Array.from(track.querySelectorAll(itemSelector));
+    const items =
+      Array.isArray(list) && list.length ? list : Array.from(track.querySelectorAll(itemSelector));
     const index = items.indexOf(target);
     if (index >= 0) {
       this.railFocusIndexByKey[railKey] = index;
@@ -5363,9 +5916,7 @@ export const MetaDetailsScreen = {
   },
 
   getMoreLikeRailKey() {
-    return isSeriesDetailMeta(this.meta, this.episodes)
-      ? "morelike:series"
-      : "morelike:movie";
+    return isSeriesDetailMeta(this.meta, this.episodes) ? "morelike:series" : "morelike:movie";
   },
 
   focusInList(list, targetIndex, options = {}) {
@@ -5380,33 +5931,39 @@ export const MetaDetailsScreen = {
       return false;
     }
     const previous = this.container.querySelector(".focusable.focused");
-    this.container.querySelectorAll(".focusable").forEach((node) => node.classList.remove("focused"));
+    this.container
+      .querySelectorAll(".focusable")
+      .forEach((node) => node.classList.remove("focused"));
     target.classList.add("focused");
     target.focus({ preventScroll: true });
     this.rememberEpisodeFocus(target, list);
     this.rememberRailFocus(target, list);
-    const horizontalTrack = target.closest(".series-episode-track, .series-cast-track, .movie-cast-track, .home-track, .series-episode-ratings-grid, .series-rating-seasons, .detail-morelike-track, .detail-company-track, .series-season-row, .series-insight-tabs, .detail-comments-modes, .detail-comments-track");
+    const horizontalTrack = target.closest(
+      ".series-episode-track, .series-cast-track, .movie-cast-track, .home-track, .series-episode-ratings-grid, .series-rating-seasons, .detail-morelike-track, .detail-company-track, .series-season-row, .series-insight-tabs, .detail-comments-modes, .detail-comments-track"
+    );
     if (horizontalTrack) {
       if (previous && previous !== target && horizontalTrack.contains(previous)) {
         preserveVerticalScroll = true;
       }
       const nextScrollLeft = this.getHorizontalTrackScrollLeft(horizontalTrack, target);
       if (animated) {
-          this.animateScroll(horizontalTrack, "x", nextScrollLeft, 260);
+        this.animateScroll(horizontalTrack, "x", nextScrollLeft, 260);
       } else {
         horizontalTrack.scrollLeft = nextScrollLeft;
       }
       const detailContent = this.getDetailContentScroller();
       if (!preserveVerticalScroll && detailContent && detailContent.contains(horizontalTrack)) {
-        const verticalTarget = horizontalTrack.matches(".detail-comments-modes, .detail-comments-track")
-          ? (target.closest(".detail-comments-section") || horizontalTrack)
+        const verticalTarget = horizontalTrack.matches(
+          ".detail-comments-modes, .detail-comments-track"
+        )
+          ? target.closest(".detail-comments-section") || horizontalTrack
           : horizontalTrack;
         const rect = verticalTarget.getBoundingClientRect();
         const contentRect = detailContent.getBoundingClientRect();
         const focusTarget = horizontalTrack.matches(".series-insight-tabs")
           ? DETAIL_TAB_FOCUS_TARGET
           : DETAIL_ROW_FOCUS_TARGET;
-        const targetTop = contentRect.top + (detailContent.clientHeight * focusTarget);
+        const targetTop = contentRect.top + detailContent.clientHeight * focusTarget;
         const nextScrollTop = detailContent.scrollTop + rect.top - targetTop;
         if (animated) {
           this.animateScroll(detailContent, "y", nextScrollTop, 280);
@@ -5443,9 +6000,13 @@ export const MetaDetailsScreen = {
       active.classList.add("focused");
       return active;
     }
-    const first = this.container.querySelector(".series-stream-filter.focusable, .series-stream-card.focusable");
+    const first = this.container.querySelector(
+      ".series-stream-filter.focusable, .series-stream-card.focusable"
+    );
     if (first) {
-      this.container.querySelectorAll(".focusable").forEach((node) => node.classList.remove("focused"));
+      this.container
+        .querySelectorAll(".focusable")
+        .forEach((node) => node.classList.remove("focused"));
       first.classList.add("focused");
       first.focus();
       return first;
@@ -5456,19 +6017,26 @@ export const MetaDetailsScreen = {
   getStreamChooserLists() {
     const filters = Array.from(this.container.querySelectorAll(".series-stream-filter.focusable"));
     const cards = Array.from(this.container.querySelectorAll(".series-stream-card.focusable"));
-    const selectedFilterIndex = Math.max(0, filters.findIndex((node) => node.classList.contains("selected")));
+    const selectedFilterIndex = Math.max(
+      0,
+      filters.findIndex((node) => node.classList.contains("selected"))
+    );
     return { filters, cards, selectedFilterIndex };
   },
 
   syncStreamChooserFocusFromDom() {
     const { filters, cards, selectedFilterIndex } = this.getStreamChooserLists();
     const activeElement = document.activeElement;
-    const focusedFilterIndex = filters.findIndex((node) => node.classList.contains("focused") || node === activeElement);
+    const focusedFilterIndex = filters.findIndex(
+      (node) => node.classList.contains("focused") || node === activeElement
+    );
     if (focusedFilterIndex >= 0) {
       this.streamChooserFocus = { zone: "filter", index: focusedFilterIndex };
       return this.streamChooserFocus;
     }
-    const focusedCardIndex = cards.findIndex((node) => node.classList.contains("focused") || node === activeElement);
+    const focusedCardIndex = cards.findIndex(
+      (node) => node.classList.contains("focused") || node === activeElement
+    );
     if (focusedCardIndex >= 0) {
       this.streamChooserFocus = { zone: "card", index: focusedCardIndex };
       return this.streamChooserFocus;
@@ -5527,9 +6095,15 @@ export const MetaDetailsScreen = {
 
     const { filters, cards, selectedFilterIndex } = this.getStreamChooserLists();
     const hasValidLocalFocus =
-      this.streamChooserFocus
-      && ((this.streamChooserFocus.zone === "filter" && filters.length && Number(this.streamChooserFocus.index) >= 0 && Number(this.streamChooserFocus.index) < filters.length)
-        || (this.streamChooserFocus.zone === "card" && cards.length && Number(this.streamChooserFocus.index) >= 0 && Number(this.streamChooserFocus.index) < cards.length));
+      this.streamChooserFocus &&
+      ((this.streamChooserFocus.zone === "filter" &&
+        filters.length &&
+        Number(this.streamChooserFocus.index) >= 0 &&
+        Number(this.streamChooserFocus.index) < filters.length) ||
+        (this.streamChooserFocus.zone === "card" &&
+          cards.length &&
+          Number(this.streamChooserFocus.index) >= 0 &&
+          Number(this.streamChooserFocus.index) < cards.length));
     const focusState = hasValidLocalFocus
       ? this.streamChooserFocus
       : this.syncStreamChooserFocusFromDom();
@@ -5543,12 +6117,16 @@ export const MetaDetailsScreen = {
       index = selectedFilterIndex;
     }
     if (zone === "filter" && filters.length) {
-      const focusedFilterIndex = filters.findIndex((node) => node.classList.contains("focused") || node === document.activeElement);
+      const focusedFilterIndex = filters.findIndex(
+        (node) => node.classList.contains("focused") || node === document.activeElement
+      );
       if (focusedFilterIndex >= 0) {
         index = focusedFilterIndex;
       }
     } else if (zone === "card" && cards.length) {
-      const focusedCardIndex = cards.findIndex((node) => node.classList.contains("focused") || node === document.activeElement);
+      const focusedCardIndex = cards.findIndex(
+        (node) => node.classList.contains("focused") || node === document.activeElement
+      );
       if (focusedCardIndex >= 0) {
         index = focusedCardIndex;
       }
@@ -5609,15 +6187,25 @@ export const MetaDetailsScreen = {
   },
 
   handleSeriesDpad(event) {
-    if (!this.meta || !isSeriesDetailMeta(this.meta, this.episodes) || this.pendingEpisodeSelection || this.pendingMovieSelection) {
+    if (
+      !this.meta ||
+      !isSeriesDetailMeta(this.meta, this.episodes) ||
+      this.pendingEpisodeSelection ||
+      this.pendingMovieSelection
+    ) {
       return false;
     }
     const keyCode = Number(event?.keyCode || 0);
-    const direction = keyCode === 37 ? "left"
-      : keyCode === 39 ? "right"
-        : keyCode === 38 ? "up"
-          : keyCode === 40 ? "down"
-            : null;
+    const direction =
+      keyCode === 37
+        ? "left"
+        : keyCode === 39
+          ? "right"
+          : keyCode === 38
+            ? "up"
+            : keyCode === 40
+              ? "down"
+              : null;
     if (!direction) {
       return false;
     }
@@ -5627,20 +6215,48 @@ export const MetaDetailsScreen = {
       return false;
     }
 
-    const actions = Array.from(this.container.querySelectorAll(".series-detail-actions .focusable"));
-    const seasons = Array.from(this.container.querySelectorAll(".series-season-row .series-season-btn.focusable"));
-    const episodes = Array.from(this.container.querySelectorAll(".series-episode-track .series-episode-card.focusable"));
-    const insightTabs = Array.from(this.container.querySelectorAll(".series-insight-tabs .series-insight-tab.focusable"));
-    const castCards = Array.from(this.container.querySelectorAll(".series-cast-track .series-cast-card.focusable"));
-    const ratingSeasons = Array.from(this.container.querySelectorAll(".series-rating-seasons .series-rating-season.focusable"));
-    const ratingChips = Array.from(this.container.querySelectorAll(".series-episode-ratings-grid .series-episode-rating-chip.focusable"));
-    const moreLikeCards = Array.from(this.container.querySelectorAll(".detail-morelike-track .detail-morelike-card.focusable"));
-    const commentModes = Array.from(this.container.querySelectorAll(".detail-comments-modes .detail-comments-mode.focusable"));
-    const commentCards = Array.from(this.container.querySelectorAll(".detail-comments-track .detail-comment-card.focusable"));
-    const moreLikeRememberedIndex = this.getRememberedRailIndex(this.getMoreLikeRailKey(), moreLikeCards);
+    const actions = Array.from(
+      this.container.querySelectorAll(".series-detail-actions .focusable")
+    );
+    const seasons = Array.from(
+      this.container.querySelectorAll(".series-season-row .series-season-btn.focusable")
+    );
+    const episodes = Array.from(
+      this.container.querySelectorAll(".series-episode-track .series-episode-card.focusable")
+    );
+    const insightTabs = Array.from(
+      this.container.querySelectorAll(".series-insight-tabs .series-insight-tab.focusable")
+    );
+    const castCards = Array.from(
+      this.container.querySelectorAll(".series-cast-track .series-cast-card.focusable")
+    );
+    const ratingSeasons = Array.from(
+      this.container.querySelectorAll(".series-rating-seasons .series-rating-season.focusable")
+    );
+    const ratingChips = Array.from(
+      this.container.querySelectorAll(
+        ".series-episode-ratings-grid .series-episode-rating-chip.focusable"
+      )
+    );
+    const moreLikeCards = Array.from(
+      this.container.querySelectorAll(".detail-morelike-track .detail-morelike-card.focusable")
+    );
+    const commentModes = Array.from(
+      this.container.querySelectorAll(".detail-comments-modes .detail-comments-mode.focusable")
+    );
+    const commentCards = Array.from(
+      this.container.querySelectorAll(".detail-comments-track .detail-comment-card.focusable")
+    );
+    const moreLikeRememberedIndex = this.getRememberedRailIndex(
+      this.getMoreLikeRailKey(),
+      moreLikeCards
+    );
     const companyTracks = Array.from(this.container.querySelectorAll(".detail-company-track"));
-    const companyCards = companyTracks.map((track) => Array.from(track.querySelectorAll(".detail-company-card.focusable")));
-    const rememberedCompanyIndex = (trackIndex = 0) => this.getRememberedCompanyIndex(companyTracks, companyCards, trackIndex);
+    const companyCards = companyTracks.map((track) =>
+      Array.from(track.querySelectorAll(".detail-company-card.focusable"))
+    );
+    const rememberedCompanyIndex = (trackIndex = 0) =>
+      this.getRememberedCompanyIndex(companyTracks, companyCards, trackIndex);
     const focusCommentsEntry = (index = 0, options = {}) => {
       if (commentModes.length) {
         return this.focusInList(commentModes, Math.min(index, commentModes.length - 1), options);
@@ -5652,15 +6268,28 @@ export const MetaDetailsScreen = {
     };
     const focusActiveSectionFromComments = (index = 0) => {
       if (this.seriesInsightTab === "ratings") {
-        if (ratingChips.length) return this.focusInList(ratingChips, Math.min(index, ratingChips.length - 1));
-        if (ratingSeasons.length) return this.focusInList(ratingSeasons, Math.min(index, ratingSeasons.length - 1));
+        if (ratingChips.length)
+          return this.focusInList(ratingChips, Math.min(index, ratingChips.length - 1));
+        if (ratingSeasons.length)
+          return this.focusInList(ratingSeasons, Math.min(index, ratingSeasons.length - 1));
       }
-      if ((this.seriesInsightTab === "morelike" || this.seriesInsightTab === "trailer" || this.seriesInsightTab === "collection") && moreLikeCards.length) {
-        return this.focusInList(moreLikeCards, this.getRememberedRailIndex(this.getMoreLikeRailKey(), moreLikeCards));
+      if (
+        (this.seriesInsightTab === "morelike" ||
+          this.seriesInsightTab === "trailer" ||
+          this.seriesInsightTab === "collection") &&
+        moreLikeCards.length
+      ) {
+        return this.focusInList(
+          moreLikeCards,
+          this.getRememberedRailIndex(this.getMoreLikeRailKey(), moreLikeCards)
+        );
       }
-      if (castCards.length) return this.focusInList(castCards, Math.min(index, castCards.length - 1));
-      if (insightTabs.length) return this.focusInList(insightTabs, this.getActiveInsightTabIndex(insightTabs));
-      if (episodes.length) return this.focusInList(episodes, this.getRememberedEpisodeIndex(episodes));
+      if (castCards.length)
+        return this.focusInList(castCards, Math.min(index, castCards.length - 1));
+      if (insightTabs.length)
+        return this.focusInList(insightTabs, this.getActiveInsightTabIndex(insightTabs));
+      if (episodes.length)
+        return this.focusInList(episodes, this.getRememberedEpisodeIndex(episodes));
       return false;
     };
     const focusFirstSeriesSectionBelowHero = (index = 0) => {
@@ -5741,8 +6370,14 @@ export const MetaDetailsScreen = {
 
     const episodeIndex = episodes.indexOf(current);
     if (episodeIndex >= 0) {
-      if (direction === "left") return this.focusInList(episodes, episodeIndex - 1, { preserveVerticalScroll: true }) || true;
-      if (direction === "right") return this.focusInList(episodes, episodeIndex + 1, { preserveVerticalScroll: true }) || true;
+      if (direction === "left")
+        return (
+          this.focusInList(episodes, episodeIndex - 1, { preserveVerticalScroll: true }) || true
+        );
+      if (direction === "right")
+        return (
+          this.focusInList(episodes, episodeIndex + 1, { preserveVerticalScroll: true }) || true
+        );
       if (direction === "up") {
         if (seasons.length) {
           return this.focusInList(seasons, this.getSelectedSeasonIndex(seasons)) || true;
@@ -5773,8 +6408,14 @@ export const MetaDetailsScreen = {
 
     const tabIndex = insightTabs.indexOf(current);
     if (tabIndex >= 0) {
-      if (direction === "left") return this.focusInList(insightTabs, tabIndex - 1, { preserveVerticalScroll: true }) || true;
-      if (direction === "right") return this.focusInList(insightTabs, tabIndex + 1, { preserveVerticalScroll: true }) || true;
+      if (direction === "left")
+        return (
+          this.focusInList(insightTabs, tabIndex - 1, { preserveVerticalScroll: true }) || true
+        );
+      if (direction === "right")
+        return (
+          this.focusInList(insightTabs, tabIndex + 1, { preserveVerticalScroll: true }) || true
+        );
       if (direction === "up") {
         if (focusSeriesSectionAboveInsights(tabIndex)) {
           return true;
@@ -5782,7 +6423,9 @@ export const MetaDetailsScreen = {
       }
       if (direction === "down") {
         if (this.seriesInsightTab === "ratings" && ratingSeasons.length) {
-          return this.focusInList(ratingSeasons, Math.min(tabIndex, ratingSeasons.length - 1)) || true;
+          return (
+            this.focusInList(ratingSeasons, Math.min(tabIndex, ratingSeasons.length - 1)) || true
+          );
         }
         if (castCards.length) {
           return this.focusInList(castCards, Math.min(tabIndex, castCards.length - 1)) || true;
@@ -5823,18 +6466,24 @@ export const MetaDetailsScreen = {
 
     const ratingSeasonIndex = ratingSeasons.indexOf(current);
     if (ratingSeasonIndex >= 0) {
-      if (direction === "left") return this.focusInList(ratingSeasons, ratingSeasonIndex - 1) || true;
-      if (direction === "right") return this.focusInList(ratingSeasons, ratingSeasonIndex + 1) || true;
+      if (direction === "left")
+        return this.focusInList(ratingSeasons, ratingSeasonIndex - 1) || true;
+      if (direction === "right")
+        return this.focusInList(ratingSeasons, ratingSeasonIndex + 1) || true;
       if (direction === "up") {
         if (insightTabs.length) {
-          return this.focusInList(insightTabs, this.getActiveInsightTabIndex(insightTabs, 1)) || true;
+          return (
+            this.focusInList(insightTabs, this.getActiveInsightTabIndex(insightTabs, 1)) || true
+          );
         }
         if (episodes.length) {
           return this.focusInList(episodes, this.getRememberedEpisodeIndex(episodes)) || true;
         }
       }
       if (direction === "down" && ratingChips.length) {
-        return this.focusInList(ratingChips, Math.min(ratingSeasonIndex, ratingChips.length - 1)) || true;
+        return (
+          this.focusInList(ratingChips, Math.min(ratingSeasonIndex, ratingChips.length - 1)) || true
+        );
       }
       if (direction === "down" && moreLikeCards.length) {
         return this.focusInList(moreLikeCards, moreLikeRememberedIndex) || true;
@@ -5851,10 +6500,15 @@ export const MetaDetailsScreen = {
       if (direction === "right") return this.focusInList(ratingChips, ratingChipIndex + 1) || true;
       if (direction === "up") {
         if (ratingSeasons.length) {
-          return this.focusInList(ratingSeasons, Math.min(ratingChipIndex, ratingSeasons.length - 1)) || true;
+          return (
+            this.focusInList(ratingSeasons, Math.min(ratingChipIndex, ratingSeasons.length - 1)) ||
+            true
+          );
         }
         if (insightTabs.length) {
-          return this.focusInList(insightTabs, this.getActiveInsightTabIndex(insightTabs, 1)) || true;
+          return (
+            this.focusInList(insightTabs, this.getActiveInsightTabIndex(insightTabs, 1)) || true
+          );
         }
         if (episodes.length) {
           return this.focusInList(episodes, this.getRememberedEpisodeIndex(episodes)) || true;
@@ -5874,22 +6528,48 @@ export const MetaDetailsScreen = {
 
     const commentModeIndex = commentModes.indexOf(current);
     if (commentModeIndex >= 0) {
-      if (direction === "left") return this.focusInList(commentModes, commentModeIndex - 1, { preserveVerticalScroll: true }) || true;
-      if (direction === "right") return this.focusInList(commentModes, commentModeIndex + 1, { preserveVerticalScroll: true }) || true;
+      if (direction === "left")
+        return (
+          this.focusInList(commentModes, commentModeIndex - 1, { preserveVerticalScroll: true }) ||
+          true
+        );
+      if (direction === "right")
+        return (
+          this.focusInList(commentModes, commentModeIndex + 1, { preserveVerticalScroll: true }) ||
+          true
+        );
       if (direction === "up") return focusActiveSectionFromComments(commentModeIndex) || true;
-      if (direction === "down" && commentCards.length) return this.focusInList(commentCards, Math.min(commentModeIndex, commentCards.length - 1)) || true;
+      if (direction === "down" && commentCards.length)
+        return (
+          this.focusInList(commentCards, Math.min(commentModeIndex, commentCards.length - 1)) ||
+          true
+        );
       return true;
     }
 
     const commentCardIndex = commentCards.indexOf(current);
     if (commentCardIndex >= 0) {
-      if (direction === "left") return this.focusInList(commentCards, commentCardIndex - 1, { preserveVerticalScroll: true }) || true;
-      if (direction === "right") return this.focusInList(commentCards, commentCardIndex + 1, { preserveVerticalScroll: true }) || true;
+      if (direction === "left")
+        return (
+          this.focusInList(commentCards, commentCardIndex - 1, { preserveVerticalScroll: true }) ||
+          true
+        );
+      if (direction === "right")
+        return (
+          this.focusInList(commentCards, commentCardIndex + 1, { preserveVerticalScroll: true }) ||
+          true
+        );
       if (direction === "up") {
-        if (commentModes.length) return this.focusInList(commentModes, Math.min(commentCardIndex, commentModes.length - 1), { preserveVerticalScroll: true }) || true;
+        if (commentModes.length)
+          return (
+            this.focusInList(commentModes, Math.min(commentCardIndex, commentModes.length - 1), {
+              preserveVerticalScroll: true
+            }) || true
+          );
         return focusActiveSectionFromComments(commentCardIndex) || true;
       }
-      if (direction === "down" && companyCards[0]?.length) return this.focusInList(companyCards[0], rememberedCompanyIndex(0)) || true;
+      if (direction === "down" && companyCards[0]?.length)
+        return this.focusInList(companyCards[0], rememberedCompanyIndex(0)) || true;
       return true;
     }
 
@@ -5899,7 +6579,10 @@ export const MetaDetailsScreen = {
       if (direction === "right") return this.focusInList(moreLikeCards, moreLikeIndex + 1) || true;
       if (direction === "up") {
         if (insightTabs.length) {
-          const moreLikeTabIndex = Math.max(0, insightTabs.findIndex((node) => String(node?.dataset?.tab || "") === "morelike"));
+          const moreLikeTabIndex = Math.max(
+            0,
+            insightTabs.findIndex((node) => String(node?.dataset?.tab || "") === "morelike")
+          );
           return this.focusInList(insightTabs, moreLikeTabIndex) || true;
         }
         if (episodes.length) {
@@ -5925,7 +6608,12 @@ export const MetaDetailsScreen = {
       if (direction === "right") return this.focusInList(cards, companyIndex + 1) || true;
       if (direction === "up") {
         if (trackIndex > 0 && companyCards[trackIndex - 1]?.length) {
-          return this.focusInList(companyCards[trackIndex - 1], rememberedCompanyIndex(trackIndex - 1)) || true;
+          return (
+            this.focusInList(
+              companyCards[trackIndex - 1],
+              rememberedCompanyIndex(trackIndex - 1)
+            ) || true
+          );
         }
         if (commentCards.length || commentModes.length) {
           return focusCommentsEntry(companyIndex) || true;
@@ -5934,7 +6622,9 @@ export const MetaDetailsScreen = {
           return this.focusInList(moreLikeCards, moreLikeRememberedIndex) || true;
         }
         if (this.seriesInsightTab === "ratings" && ratingChips.length) {
-          return this.focusInList(ratingChips, Math.min(companyIndex, ratingChips.length - 1)) || true;
+          return (
+            this.focusInList(ratingChips, Math.min(companyIndex, ratingChips.length - 1)) || true
+          );
         }
         if (castCards.length) {
           return this.focusInList(castCards, Math.min(companyIndex, castCards.length - 1)) || true;
@@ -5946,8 +6636,15 @@ export const MetaDetailsScreen = {
           return this.focusInList(episodes, this.getRememberedEpisodeIndex(episodes)) || true;
         }
       }
-      if (direction === "down" && trackIndex < companyCards.length - 1 && companyCards[trackIndex + 1]?.length) {
-        return this.focusInList(companyCards[trackIndex + 1], rememberedCompanyIndex(trackIndex + 1)) || true;
+      if (
+        direction === "down" &&
+        trackIndex < companyCards.length - 1 &&
+        companyCards[trackIndex + 1]?.length
+      ) {
+        return (
+          this.focusInList(companyCards[trackIndex + 1], rememberedCompanyIndex(trackIndex + 1)) ||
+          true
+        );
       }
       return true;
     }
@@ -5956,15 +6653,25 @@ export const MetaDetailsScreen = {
   },
 
   handleMovieDpad(event) {
-    if (!this.meta || isSeriesDetailMeta(this.meta, this.episodes) || this.pendingEpisodeSelection || this.pendingMovieSelection) {
+    if (
+      !this.meta ||
+      isSeriesDetailMeta(this.meta, this.episodes) ||
+      this.pendingEpisodeSelection ||
+      this.pendingMovieSelection
+    ) {
       return false;
     }
     const keyCode = Number(event?.keyCode || 0);
-    const direction = keyCode === 37 ? "left"
-      : keyCode === 39 ? "right"
-        : keyCode === 38 ? "up"
-          : keyCode === 40 ? "down"
-            : null;
+    const direction =
+      keyCode === 37
+        ? "left"
+        : keyCode === 39
+          ? "right"
+          : keyCode === 38
+            ? "up"
+            : keyCode === 40
+              ? "down"
+              : null;
     if (!direction) {
       return false;
     }
@@ -5973,16 +6680,34 @@ export const MetaDetailsScreen = {
     if (!current) {
       return false;
     }
-    const actions = Array.from(this.container.querySelectorAll(".series-detail-actions .focusable"));
-    const tabs = Array.from(this.container.querySelectorAll(".series-insight-tabs .series-insight-tab.focusable"));
-    const cast = Array.from(this.container.querySelectorAll(".movie-cast-track .movie-cast-card.focusable"));
-    const moreLikeCards = Array.from(this.container.querySelectorAll(".detail-morelike-track .detail-morelike-card.focusable"));
-    const commentModes = Array.from(this.container.querySelectorAll(".detail-comments-modes .detail-comments-mode.focusable"));
-    const commentCards = Array.from(this.container.querySelectorAll(".detail-comments-track .detail-comment-card.focusable"));
-    const moreLikeRememberedIndex = this.getRememberedRailIndex(this.getMoreLikeRailKey(), moreLikeCards);
+    const actions = Array.from(
+      this.container.querySelectorAll(".series-detail-actions .focusable")
+    );
+    const tabs = Array.from(
+      this.container.querySelectorAll(".series-insight-tabs .series-insight-tab.focusable")
+    );
+    const cast = Array.from(
+      this.container.querySelectorAll(".movie-cast-track .movie-cast-card.focusable")
+    );
+    const moreLikeCards = Array.from(
+      this.container.querySelectorAll(".detail-morelike-track .detail-morelike-card.focusable")
+    );
+    const commentModes = Array.from(
+      this.container.querySelectorAll(".detail-comments-modes .detail-comments-mode.focusable")
+    );
+    const commentCards = Array.from(
+      this.container.querySelectorAll(".detail-comments-track .detail-comment-card.focusable")
+    );
+    const moreLikeRememberedIndex = this.getRememberedRailIndex(
+      this.getMoreLikeRailKey(),
+      moreLikeCards
+    );
     const companyTracks = Array.from(this.container.querySelectorAll(".detail-company-track"));
-    const companyCards = companyTracks.map((track) => Array.from(track.querySelectorAll(".detail-company-card.focusable")));
-    const rememberedCompanyIndex = (trackIndex = 0) => this.getRememberedCompanyIndex(companyTracks, companyCards, trackIndex);
+    const companyCards = companyTracks.map((track) =>
+      Array.from(track.querySelectorAll(".detail-company-card.focusable"))
+    );
+    const rememberedCompanyIndex = (trackIndex = 0) =>
+      this.getRememberedCompanyIndex(companyTracks, companyCards, trackIndex);
     const focusCommentsEntry = (index = 0, options = {}) => {
       if (commentModes.length) {
         return this.focusInList(commentModes, Math.min(index, commentModes.length - 1), options);
@@ -5993,8 +6718,16 @@ export const MetaDetailsScreen = {
       return false;
     };
     const focusActiveSectionFromComments = (index = 0) => {
-      if ((this.movieInsightTab === "morelike" || this.movieInsightTab === "trailer" || this.movieInsightTab === "collection") && moreLikeCards.length) {
-        return this.focusInList(moreLikeCards, this.getRememberedRailIndex(this.getMoreLikeRailKey(), moreLikeCards));
+      if (
+        (this.movieInsightTab === "morelike" ||
+          this.movieInsightTab === "trailer" ||
+          this.movieInsightTab === "collection") &&
+        moreLikeCards.length
+      ) {
+        return this.focusInList(
+          moreLikeCards,
+          this.getRememberedRailIndex(this.getMoreLikeRailKey(), moreLikeCards)
+        );
       }
       if (cast.length) return this.focusInList(cast, Math.min(index, cast.length - 1));
       if (tabs.length) return this.focusInList(tabs, this.getActiveInsightTabIndex(tabs));
@@ -6028,14 +6761,19 @@ export const MetaDetailsScreen = {
 
     const tabIndex = tabs.indexOf(current);
     if (tabIndex >= 0) {
-      if (direction === "left") return this.focusInList(tabs, tabIndex - 1, { preserveVerticalScroll: true }) || true;
-      if (direction === "right") return this.focusInList(tabs, tabIndex + 1, { preserveVerticalScroll: true }) || true;
-      if (direction === "up") return this.focusInList(actions, Math.min(tabIndex, actions.length - 1)) || true;
+      if (direction === "left")
+        return this.focusInList(tabs, tabIndex - 1, { preserveVerticalScroll: true }) || true;
+      if (direction === "right")
+        return this.focusInList(tabs, tabIndex + 1, { preserveVerticalScroll: true }) || true;
+      if (direction === "up")
+        return this.focusInList(actions, Math.min(tabIndex, actions.length - 1)) || true;
       if (direction === "down") {
         if (cast.length) return this.focusInList(cast, Math.min(tabIndex, cast.length - 1)) || true;
-        if (moreLikeCards.length) return this.focusInList(moreLikeCards, moreLikeRememberedIndex) || true;
+        if (moreLikeCards.length)
+          return this.focusInList(moreLikeCards, moreLikeRememberedIndex) || true;
         if (focusCommentsEntry(tabIndex)) return true;
-        if (companyCards[0]?.length) return this.focusInList(companyCards[0], rememberedCompanyIndex(0)) || true;
+        if (companyCards[0]?.length)
+          return this.focusInList(companyCards[0], rememberedCompanyIndex(0)) || true;
       }
       return true;
     }
@@ -6068,7 +6806,10 @@ export const MetaDetailsScreen = {
       if (direction === "right") return this.focusInList(moreLikeCards, moreLikeIndex + 1) || true;
       if (direction === "up") {
         if (tabs.length) {
-          const moreLikeTabIndex = Math.max(0, tabs.findIndex((node) => String(node?.dataset?.tab || "") === "morelike"));
+          const moreLikeTabIndex = Math.max(
+            0,
+            tabs.findIndex((node) => String(node?.dataset?.tab || "") === "morelike")
+          );
           return this.focusInList(tabs, moreLikeTabIndex) || true;
         }
         if (cast.length) {
@@ -6087,22 +6828,48 @@ export const MetaDetailsScreen = {
 
     const commentModeIndex = commentModes.indexOf(current);
     if (commentModeIndex >= 0) {
-      if (direction === "left") return this.focusInList(commentModes, commentModeIndex - 1, { preserveVerticalScroll: true }) || true;
-      if (direction === "right") return this.focusInList(commentModes, commentModeIndex + 1, { preserveVerticalScroll: true }) || true;
+      if (direction === "left")
+        return (
+          this.focusInList(commentModes, commentModeIndex - 1, { preserveVerticalScroll: true }) ||
+          true
+        );
+      if (direction === "right")
+        return (
+          this.focusInList(commentModes, commentModeIndex + 1, { preserveVerticalScroll: true }) ||
+          true
+        );
       if (direction === "up") return focusActiveSectionFromComments(commentModeIndex) || true;
-      if (direction === "down" && commentCards.length) return this.focusInList(commentCards, Math.min(commentModeIndex, commentCards.length - 1)) || true;
+      if (direction === "down" && commentCards.length)
+        return (
+          this.focusInList(commentCards, Math.min(commentModeIndex, commentCards.length - 1)) ||
+          true
+        );
       return true;
     }
 
     const commentCardIndex = commentCards.indexOf(current);
     if (commentCardIndex >= 0) {
-      if (direction === "left") return this.focusInList(commentCards, commentCardIndex - 1, { preserveVerticalScroll: true }) || true;
-      if (direction === "right") return this.focusInList(commentCards, commentCardIndex + 1, { preserveVerticalScroll: true }) || true;
+      if (direction === "left")
+        return (
+          this.focusInList(commentCards, commentCardIndex - 1, { preserveVerticalScroll: true }) ||
+          true
+        );
+      if (direction === "right")
+        return (
+          this.focusInList(commentCards, commentCardIndex + 1, { preserveVerticalScroll: true }) ||
+          true
+        );
       if (direction === "up") {
-        if (commentModes.length) return this.focusInList(commentModes, Math.min(commentCardIndex, commentModes.length - 1), { preserveVerticalScroll: true }) || true;
+        if (commentModes.length)
+          return (
+            this.focusInList(commentModes, Math.min(commentCardIndex, commentModes.length - 1), {
+              preserveVerticalScroll: true
+            }) || true
+          );
         return focusActiveSectionFromComments(commentCardIndex) || true;
       }
-      if (direction === "down" && companyCards[0]?.length) return this.focusInList(companyCards[0], rememberedCompanyIndex(0)) || true;
+      if (direction === "down" && companyCards[0]?.length)
+        return this.focusInList(companyCards[0], rememberedCompanyIndex(0)) || true;
       return true;
     }
 
@@ -6116,7 +6883,12 @@ export const MetaDetailsScreen = {
       if (direction === "right") return this.focusInList(cards, companyIndex + 1) || true;
       if (direction === "up") {
         if (trackIndex > 0 && companyCards[trackIndex - 1]?.length) {
-          return this.focusInList(companyCards[trackIndex - 1], rememberedCompanyIndex(trackIndex - 1)) || true;
+          return (
+            this.focusInList(
+              companyCards[trackIndex - 1],
+              rememberedCompanyIndex(trackIndex - 1)
+            ) || true
+          );
         }
         if (commentCards.length || commentModes.length) {
           return focusCommentsEntry(companyIndex) || true;
@@ -6132,8 +6904,15 @@ export const MetaDetailsScreen = {
         }
         return this.focusInList(actions, Math.min(companyIndex, actions.length - 1)) || true;
       }
-      if (direction === "down" && trackIndex < companyCards.length - 1 && companyCards[trackIndex + 1]?.length) {
-        return this.focusInList(companyCards[trackIndex + 1], rememberedCompanyIndex(trackIndex + 1)) || true;
+      if (
+        direction === "down" &&
+        trackIndex < companyCards.length - 1 &&
+        companyCards[trackIndex + 1]?.length
+      ) {
+        return (
+          this.focusInList(companyCards[trackIndex + 1], rememberedCompanyIndex(trackIndex + 1)) ||
+          true
+        );
       }
       return true;
     }
@@ -6305,23 +7084,32 @@ export const MetaDetailsScreen = {
     if (action === "setSeriesInsightTab") {
       const tab = String(current.dataset.tab || "cast");
       if (tab !== this.seriesInsightTab) {
-          this.seriesInsightTab = ["cast", "ratings", "morelike", "trailer", "collection"].includes(tab) ? tab : "cast";
-          this.updateRenderedDetailSections(this.meta);
-        }
-        return;
+        this.seriesInsightTab = ["cast", "ratings", "morelike", "trailer", "collection"].includes(
+          tab
+        )
+          ? tab
+          : "cast";
+        this.updateRenderedDetailSections(this.meta);
       }
+      return;
+    }
 
     if (action === "setMovieInsightTab") {
       const tab = String(current.dataset.tab || "cast");
       if (tab !== this.movieInsightTab) {
-          this.movieInsightTab = ["cast", "ratings", "morelike", "trailer", "collection"].includes(tab) ? tab : "cast";
-          this.updateRenderedDetailSections(this.meta);
-        }
-        return;
+        this.movieInsightTab = ["cast", "ratings", "morelike", "trailer", "collection"].includes(
+          tab
+        )
+          ? tab
+          : "cast";
+        this.updateRenderedDetailSections(this.meta);
       }
+      return;
+    }
 
     if (action === "setCommentsMode") {
-      const mode = String(current.dataset.commentsMode || "title") === "episode" ? "episode" : "title";
+      const mode =
+        String(current.dataset.commentsMode || "title") === "episode" ? "episode" : "title";
       this.commentsMode = mode;
       if (mode === "episode" && !this.commentsEpisodeTarget) {
         this.commentsEpisodeTarget = this.nextEpisodeToWatch || this.episodes?.[0] || null;
@@ -6341,8 +7129,17 @@ export const MetaDetailsScreen = {
     if (action === "openSharedTrailer") {
       const ytId = String(current.dataset.trailerYtId || "").trim();
       if (ytId) {
-        this.trailerSource = { kind: "youtube", ytId, embedUrl: buildYoutubeEmbedUrl(ytId, { muted: false }) };
-        this.playTrailer({ muted: false, restart: true, initiatedByUser: true, preserveSource: true });
+        this.trailerSource = {
+          kind: "youtube",
+          ytId,
+          embedUrl: buildYoutubeEmbedUrl(ytId, { muted: false })
+        };
+        this.playTrailer({
+          muted: false,
+          restart: true,
+          initiatedByUser: true,
+          preserveSource: true
+        });
       }
       return;
     }
@@ -6375,13 +7172,21 @@ export const MetaDetailsScreen = {
         const addon = current.dataset.addon || "all";
         if (this.pendingEpisodeSelection) {
           this.pendingEpisodeSelection.addonFilter = addon;
-          const addons = Array.from(new Set(this.pendingEpisodeSelection.streams.map((stream) => stream.addonName).filter(Boolean)));
+          const addons = Array.from(
+            new Set(
+              this.pendingEpisodeSelection.streams.map((stream) => stream.addonName).filter(Boolean)
+            )
+          );
           const order = ["all", ...addons];
           this.streamChooserFocus = { zone: "filter", index: Math.max(0, order.indexOf(addon)) };
           this.renderEpisodeStreamChooser();
         } else {
           this.pendingMovieSelection.addonFilter = addon;
-          const addons = Array.from(new Set(this.pendingMovieSelection.streams.map((stream) => stream.addonName).filter(Boolean)));
+          const addons = Array.from(
+            new Set(
+              this.pendingMovieSelection.streams.map((stream) => stream.addonName).filter(Boolean)
+            )
+          );
           const order = ["all", ...addons];
           this.streamChooserFocus = { zone: "filter", index: Math.max(0, order.indexOf(addon)) };
           this.renderMovieStreamChooser();
@@ -6437,7 +7242,10 @@ export const MetaDetailsScreen = {
         });
       }
       if (!isSeries && this.meta?.ids?.trakt) {
-        const enriched = await detailWatchedEnrichmentService.enrichMovieWatchedState(this.params?.itemId, this.meta.ids.trakt);
+        const enriched = await detailWatchedEnrichmentService.enrichMovieWatchedState(
+          this.params?.itemId,
+          this.meta.ids.trakt
+        );
         this.enrichedMovieState = enriched;
         this.isMarkedWatched = Boolean(enriched?.isWatched);
       }
@@ -6455,8 +7263,10 @@ export const MetaDetailsScreen = {
         imdbId,
         season: this.nextEpisodeToWatch?.season ?? null,
         episode: this.nextEpisodeToWatch?.episode ?? null,
-        playerTitle: this.meta?.name || this.params?.fallbackTitle || this.params?.itemId || "Untitled",
-        playerSubtitle: this.params?.itemType === "series" ? (this.nextEpisodeToWatch?.title || "") : "",
+        playerTitle:
+          this.meta?.name || this.params?.fallbackTitle || this.params?.itemId || "Untitled",
+        playerSubtitle:
+          this.params?.itemType === "series" ? this.nextEpisodeToWatch?.title || "" : "",
         playerEpisodeTitle: this.nextEpisodeToWatch?.title || "",
         playerBackdropUrl: this.meta?.background || this.meta?.poster || null,
         playerLogoUrl: this.meta?.logo || null,
@@ -6536,5 +7346,4 @@ export const MetaDetailsScreen = {
     }
     ScreenUtils.hide(this.container);
   }
-
 };

--- a/js/ui/screens/home/homeScreen.js
+++ b/js/ui/screens/home/homeScreen.js
@@ -1840,7 +1840,8 @@ function continueWatchingStreamParams(item, options = {}) {
     landscapePoster: firstNonEmpty(normalized.landscapePoster, normalized.backdrop, normalized.background, normalized.poster),
     poster: firstNonEmpty(normalized.poster, normalized.backdrop, normalized.background),
     logo: firstNonEmpty(normalized.logo),
-    resumePositionMs: options.startOver ? 0 : (Number(normalized.positionMs || 0) || 0)
+    resumePositionMs: options.startOver ? 0 : (Number(normalized.positionMs || 0) || 0),
+    resumeStreamIdentity: options.startOver ? null : (normalized.streamIdentity || null)
   };
 }
 
@@ -4092,7 +4093,8 @@ export const HomeScreen = {
       resumeProgressMs: Number(params.resumePositionMs || 0) || 0,
       resumeVideoId: normalized.videoId || null,
       resumeSeason: normalized.season ?? null,
-      resumeEpisode: normalized.episode ?? null
+      resumeEpisode: normalized.episode ?? null,
+      resumeStreamIdentity: params.resumeStreamIdentity || null
     });
     return true;
   },
@@ -7054,7 +7056,15 @@ export const HomeScreen = {
       ? (this.pendingCollectionRouteReturnAnimation ? " nuvio-route-slide-enter" : " home-route-content-enter")
       : "";
     this.pendingCollectionRouteReturnAnimation = false;
-    const sidebarFocusLocked = Boolean(this.sidebarExpanded);
+    // When returning to home via Back, only keep the sidebar expanded/focused if
+    // the focus we are restoring actually belonged to the sidebar. Otherwise the
+    // sidebar stole focus and "popped up" on every back navigation (issue #232).
+    if (this.isRestoringFocusFromBack && retainedFocusState?.focusKind !== "sidebar") {
+      this.sidebarExpanded = false;
+    }
+    const sidebarFocusLocked = Boolean(
+      this.sidebarExpanded && retainedFocusState?.focusKind === "sidebar",
+    );
 
     this.container.innerHTML = `
       <div class="home-shell home-screen-shell ${layoutClass}"${sizingStyle ? ` style="${escapeAttribute(sizingStyle)}"` : ""}>
@@ -7939,7 +7949,7 @@ export const HomeScreen = {
       if (!rowKey || this._trackScrollHandlers.has(track)) {
         return;
       }
-      const handler = () => {
+      const runPagination = () => {
         if (this._trackPaginationInFlight?.has(rowKey)) {
           return;
         }
@@ -8027,6 +8037,19 @@ export const HomeScreen = {
           console.warn("Home track pagination failed for", rowKey, err);
         }).finally(() => {
           this._trackPaginationInFlight?.delete(rowKey);
+        });
+      };
+      // Coalesce to one run per frame. The pagination check reads offsetWidth
+      // (forced reflow); running it on every raw scroll event made the modern
+      // layout stutter on slow TVs once content was loaded (issue #232).
+      let scrollRaf = 0;
+      const handler = () => {
+        if (scrollRaf) {
+          return;
+        }
+        scrollRaf = requestAnimationFrame(() => {
+          scrollRaf = 0;
+          runPagination();
         });
       };
       this._trackScrollHandlers.set(track, handler);

--- a/js/ui/screens/player/playerScreen.js
+++ b/js/ui/screens/player/playerScreen.js
@@ -21,7 +21,10 @@ import { DirectDebridResolver } from "../../../core/debrid/directDebridResolver.
 import { TraktScrobbleService } from "../../../data/repository/traktScrobbleService.js";
 import { WebOsEngineFsResolver } from "../../../core/p2p/webosEngineFsResolver.js";
 import { TizenStreamingServerResolver } from "../../../core/p2p/tizenStreamingServerResolver.js";
-import { requestWebOsCompanionService, subscribeWebOsCompanionService } from "../../../platform/webos/webosCompanionService.js";
+import {
+  requestWebOsCompanionService,
+  subscribeWebOsCompanionService
+} from "../../../platform/webos/webosCompanionService.js";
 
 const CLOCK_FORMATTER_CACHE = new Map();
 const LANGUAGE_DISPLAY_NAME_CACHE = new Map();
@@ -45,7 +48,9 @@ function logEngineFsDebug(...args) {
 }
 
 function getEngineFsClaimKey(state = null) {
-  const infoHash = String(state?.infoHash || "").trim().toLowerCase();
+  const infoHash = String(state?.infoHash || "")
+    .trim()
+    .toLowerCase();
   return infoHash || "";
 }
 
@@ -54,7 +59,9 @@ function createEngineFsClaimToken() {
 }
 
 function clearDeferredEngineFsRemoval(key = "") {
-  const normalizedKey = String(key || "").trim().toLowerCase();
+  const normalizedKey = String(key || "")
+    .trim()
+    .toLowerCase();
   const pending = normalizedKey ? deferredEngineFsRemovalTimers.get(normalizedKey) : null;
   if (!pending) {
     return false;
@@ -91,7 +98,12 @@ function hasActiveEngineFsPlaybackClaim(state = null) {
   return Boolean(key && activeEngineFsPlaybackClaims.has(key));
 }
 
-function scheduleDeferredEngineFsRemoval(state = null, reason = "cleanup", delayMs = 0, removeFn = null) {
+function scheduleDeferredEngineFsRemoval(
+  state = null,
+  reason = "cleanup",
+  delayMs = 0,
+  removeFn = null
+) {
   const key = getEngineFsClaimKey(state);
   const waitMs = Math.max(0, Number(delayMs || 0));
   if (!key || waitMs <= 0 || typeof removeFn !== "function") {
@@ -359,34 +371,27 @@ function extractReleaseYear(value) {
 }
 
 function normalizeComparableText(value) {
-  return cleanDisplayText(value)
-    .toLowerCase()
-    .replace(/[_-]+/g, " ");
+  return cleanDisplayText(value).toLowerCase().replace(/[_-]+/g, " ");
 }
 
 function extractPauseOverlayCast(data = {}) {
   const result = [];
   const seen = new Set();
-  const collections = [
-    data?.castItems,
-    data?.castMembers,
-    data?.cast,
-    data?.credits?.cast
-  ];
+  const collections = [data?.castItems, data?.castMembers, data?.cast, data?.credits?.cast];
 
   const pushEntry = (entry) => {
     if (!entry) {
       return;
     }
-    const name = typeof entry === "string"
-      ? cleanDisplayText(entry)
-      : cleanDisplayText(entry?.name || entry?.fullName || entry?.actor || "");
+    const name =
+      typeof entry === "string"
+        ? cleanDisplayText(entry)
+        : cleanDisplayText(entry?.name || entry?.fullName || entry?.actor || "");
     if (!name) {
       return;
     }
-    const character = typeof entry === "string"
-      ? ""
-      : cleanDisplayText(entry?.character || entry?.role || "");
+    const character =
+      typeof entry === "string" ? "" : cleanDisplayText(entry?.character || entry?.role || "");
     const key = normalizeComparableText(`${name}|${character}`);
     if (seen.has(key)) {
       return;
@@ -438,11 +443,13 @@ function flattenTrackMetadata(value, into = []) {
 
 function isGenericAudioTrackLabel(value) {
   const normalized = normalizeComparableText(value);
-  return normalized === ""
-    || /^audio\s*\d*$/.test(normalized)
-    || /^track\s*\d*$/.test(normalized)
-    || normalized === "soundhandler"
-    || normalized === "sound handler";
+  return (
+    normalized === "" ||
+    /^audio\s*\d*$/.test(normalized) ||
+    /^track\s*\d*$/.test(normalized) ||
+    normalized === "soundhandler" ||
+    normalized === "sound handler"
+  );
 }
 
 function getTrackMetadataStrings(track = {}) {
@@ -496,13 +503,15 @@ function normalizeTrackLanguageCode(value) {
 
 function normalizeLanguageNameText(value) {
   const comparable = normalizeComparableText(value);
-  const asciiComparable = typeof comparable.normalize === "function"
-    ? comparable.normalize("NFD")
-    : comparable;
+  const asciiComparable =
+    typeof comparable.normalize === "function" ? comparable.normalize("NFD") : comparable;
   return asciiComparable
     .replace(/[\u0300-\u036f]/g, "")
     .replace(/[^a-z0-9]+/g, " ")
-    .replace(/\b(forced|force|forc|forzato|forzata|forzati|forzate|subtitle|subtitles|sub|sdh|cc|closed|captions?|full|normal|default|signs?|songs?|foreign|only)\b/g, " ")
+    .replace(
+      /\b(forced|force|forc|forzato|forzata|forzati|forzate|subtitle|subtitles|sub|sdh|cc|closed|captions?|full|normal|default|signs?|songs?|foreign|only)\b/g,
+      " "
+    )
     .replace(/\s+/g, " ")
     .trim();
 }
@@ -513,8 +522,9 @@ function inferTrackLanguageCodeFromText(value) {
     return "";
   }
   const padded = ` ${normalized} `;
-  const aliasEntries = Object.entries(LANGUAGE_NAME_ALIASES)
-    .sort((left, right) => right[0].length - left[0].length);
+  const aliasEntries = Object.entries(LANGUAGE_NAME_ALIASES).sort(
+    (left, right) => right[0].length - left[0].length
+  );
   const match = aliasEntries.find(([name]) => padded.includes(` ${name} `));
   return match?.[1] || "";
 }
@@ -553,7 +563,9 @@ function getTrackLanguageLabel(track = {}) {
       }
       if (!displayName) {
         const fallbackKey = AUDIO_TRACK_LANGUAGE_KEY_BY_CODE[displayCode];
-        displayName = fallbackKey ? t(fallbackKey, {}, rawLanguage.toUpperCase()) : rawLanguage.toUpperCase();
+        displayName = fallbackKey
+          ? t(fallbackKey, {}, rawLanguage.toUpperCase())
+          : rawLanguage.toUpperCase();
       }
       LANGUAGE_DISPLAY_NAME_CACHE.set(cacheKey, displayName);
     }
@@ -590,11 +602,13 @@ function isTruthyTrackFlag(value) {
 }
 
 function isSdhSubtitleTrack(track = {}) {
-  if (isTruthyTrackFlag(track?.sdh)
-    || isTruthyTrackFlag(track?.isSdh)
-    || isTruthyTrackFlag(track?.is_sdh)
-    || isTruthyTrackFlag(track?.hearingImpaired)
-    || isTruthyTrackFlag(track?.hearing_impaired)) {
+  if (
+    isTruthyTrackFlag(track?.sdh) ||
+    isTruthyTrackFlag(track?.isSdh) ||
+    isTruthyTrackFlag(track?.is_sdh) ||
+    isTruthyTrackFlag(track?.hearingImpaired) ||
+    isTruthyTrackFlag(track?.hearing_impaired)
+  ) {
     return true;
   }
   const searchText = getTrackMetadataStrings(track).join(" ").toLowerCase();
@@ -602,10 +616,12 @@ function isSdhSubtitleTrack(track = {}) {
 }
 
 function isClosedCaptionTrack(track = {}) {
-  if (isTruthyTrackFlag(track?.cc)
-    || isTruthyTrackFlag(track?.closedCaption)
-    || isTruthyTrackFlag(track?.closedCaptions)
-    || isTruthyTrackFlag(track?.closed_caption)) {
+  if (
+    isTruthyTrackFlag(track?.cc) ||
+    isTruthyTrackFlag(track?.closedCaption) ||
+    isTruthyTrackFlag(track?.closedCaptions) ||
+    isTruthyTrackFlag(track?.closed_caption)
+  ) {
     return true;
   }
   const searchText = getTrackMetadataStrings(track).join(" ").toLowerCase();
@@ -624,7 +640,9 @@ function detectChannelLayout(value) {
     }
     return explicitLayout[1];
   }
-  const numericMatch = text.match(/\b([0-9]{1,2})(?:ch| channels?)\b/) || text.match(/^([0-9]{1,2})(?:\/[a-z0-9.]+)?$/);
+  const numericMatch =
+    text.match(/\b([0-9]{1,2})(?:ch| channels?)\b/) ||
+    text.match(/^([0-9]{1,2})(?:\/[a-z0-9.]+)?$/);
   if (!numericMatch) {
     return "";
   }
@@ -689,7 +707,11 @@ function getTrackDescriptorLabels(track = {}) {
     pushUniqueText(descriptors, "MP3");
   }
 
-  if (/\bforced\b/.test(searchText) || isTruthyTrackFlag(track?.forced) || isTruthyTrackFlag(track?.isForced)) {
+  if (
+    /\bforced\b/.test(searchText) ||
+    isTruthyTrackFlag(track?.forced) ||
+    isTruthyTrackFlag(track?.isForced)
+  ) {
     pushUniqueText(descriptors, t("sub_forced_lang", {}, "Forced"));
   }
   if (isSdhSubtitleTrack(track)) {
@@ -701,7 +723,11 @@ function getTrackDescriptorLabels(track = {}) {
   if (/\b(commentary)\b/.test(searchText)) {
     pushUniqueText(descriptors, t("player.track.commentary", {}, "Commentary"));
   }
-  if (/\b(audio description|audio-description|describes-video|describes video|descriptive)\b/.test(searchText)) {
+  if (
+    /\b(audio description|audio-description|describes-video|describes video|descriptive)\b/.test(
+      searchText
+    )
+  ) {
     pushUniqueText(descriptors, t("player.track.audioDescription", {}, "Audio description"));
   }
 
@@ -734,13 +760,21 @@ function formatAudioCodecName(value) {
     return "";
   }
 
-  if (text.includes("eac3-joc") || text.includes("ec-3-joc") || text.includes("atmos")) return "E-AC-3-JOC";
+  if (text.includes("eac3-joc") || text.includes("ec-3-joc") || text.includes("atmos"))
+    return "E-AC-3-JOC";
   if (text.includes("truehd")) return "TrueHD";
   if (text.includes("dts-hd")) return "DTS-HD";
   if (text.includes("dts express")) return "DTS Express";
   if (text.includes("dts")) return "DTS";
-  if (text.includes("ec-3") || text.includes("eac3") || text.includes("ddp") || text.includes("dolby digital plus")) return "E-AC-3";
-  if (text.includes("ac-3") || text.includes("ac3") || text.includes("dolby digital")) return "AC-3";
+  if (
+    text.includes("ec-3") ||
+    text.includes("eac3") ||
+    text.includes("ddp") ||
+    text.includes("dolby digital plus")
+  )
+    return "E-AC-3";
+  if (text.includes("ac-3") || text.includes("ac3") || text.includes("dolby digital"))
+    return "AC-3";
   if (text.includes("ac-4") || text.includes("ac4")) return "AC-4";
   if (text.includes("aac") || text.includes("mp4a")) return "AAC";
   if (text.includes("mp3") || text.includes("mpeg audio")) return "MP3";
@@ -796,11 +830,11 @@ function formatAudioTrackDisplay(track = {}, index = 0) {
   const rawLanguage = cleanDisplayText(getTrackLanguageValue(track));
   const languageLabel = getTrackLanguageLabel(track);
   const codecName = formatAudioCodecName(
-    track?.sampleMimeType
-    || track?.codec
-    || track?.codecs
-    || track?.audioCodec
-    || getTrackMetadataStrings(track).join(" ")
+    track?.sampleMimeType ||
+      track?.codec ||
+      track?.codecs ||
+      track?.audioCodec ||
+      getTrackMetadataStrings(track).join(" ")
   );
   const channelLayout = formatAudioChannelLayout(track?.channelCount || track?.channels);
   const sampleRate = Number(track?.sampleRate || track?.audioSampleRate || 0);
@@ -808,7 +842,10 @@ function formatAudioTrackDisplay(track = {}, index = 0) {
   const suffix = [codecName, channelLayout].filter(Boolean).join(" ");
   const label = suffix ? `${baseName} (${suffix})` : baseName;
   const secondaryParts = [];
-  if (languageLabel && normalizeComparableText(languageLabel) !== normalizeComparableText(baseName)) {
+  if (
+    languageLabel &&
+    normalizeComparableText(languageLabel) !== normalizeComparableText(baseName)
+  ) {
     pushUniqueText(secondaryParts, languageLabel);
   }
   if (Number.isFinite(sampleRate) && sampleRate > 0) {
@@ -835,11 +872,14 @@ function formatClock(date = new Date()) {
   const localeKey = String(locale || "__default__");
   if (!CLOCK_FORMATTER_CACHE.has(localeKey)) {
     try {
-      CLOCK_FORMATTER_CACHE.set(localeKey, new Intl.DateTimeFormat(locale || undefined, {
-        hour: "2-digit",
-        minute: "2-digit",
-        hour12: false
-      }));
+      CLOCK_FORMATTER_CACHE.set(
+        localeKey,
+        new Intl.DateTimeFormat(locale || undefined, {
+          hour: "2-digit",
+          minute: "2-digit",
+          hour12: false
+        })
+      );
     } catch (_) {
       CLOCK_FORMATTER_CACHE.set(localeKey, null);
     }
@@ -896,7 +936,8 @@ function trackListToArray(trackList) {
   if (Number.isFinite(length) && length > 0) {
     const indexedTracks = [];
     for (let index = 0; index < length; index += 1) {
-      const track = trackList[index] || (typeof trackList.item === "function" ? trackList.item(index) : null);
+      const track =
+        trackList[index] || (typeof trackList.item === "function" ? trackList.item(index) : null);
       if (track) {
         indexedTracks.push(track);
       }
@@ -940,7 +981,7 @@ function escapeHtml(value) {
     .replaceAll("&", "&amp;")
     .replaceAll("<", "&lt;")
     .replaceAll(">", "&gt;")
-    .replaceAll("\"", "&quot;")
+    .replaceAll('"', "&quot;")
     .replaceAll("'", "&#39;");
 }
 
@@ -963,13 +1004,13 @@ function episodeDisplayCode(episode = {}) {
 
 function episodeThumbnailUrl(episode = {}) {
   return cleanDisplayText(
-    episode?.thumbnail
-    || episode?.thumbnailUrl
-    || episode?.still
-    || episode?.stillUrl
-    || episode?.poster
-    || episode?.image
-    || ""
+    episode?.thumbnail ||
+      episode?.thumbnailUrl ||
+      episode?.still ||
+      episode?.stillUrl ||
+      episode?.poster ||
+      episode?.image ||
+      ""
   );
 }
 
@@ -1013,7 +1054,9 @@ function formatBytesPerSecond(value) {
 }
 
 function normalizeStreamBadgeChipColor(value = "") {
-  const hex = String(value || "").trim().replace(/^#/, "");
+  const hex = String(value || "")
+    .trim()
+    .replace(/^#/, "");
   if (!/^[0-9a-fA-F]{6}([0-9a-fA-F]{2})?$/.test(hex)) {
     return "";
   }
@@ -1028,7 +1071,10 @@ function renderPlayerImageBadgeChip(badge = {}) {
   const backgroundColor = normalizeStreamBadgeChipColor(badge.tagColor);
   const outlineColor = normalizeStreamBadgeChipColor(badge.borderColor);
   const textColor = normalizeStreamBadgeChipColor(badge.textColor);
-  const filled = String(badge.tagStyle || "").trim().toLowerCase() === "filled";
+  const filled =
+    String(badge.tagStyle || "")
+      .trim()
+      .toLowerCase() === "filled";
   const style = [
     filled && backgroundColor ? `background:${backgroundColor};` : "",
     outlineColor ? `border-color:${outlineColor};` : "",
@@ -1041,14 +1087,19 @@ function renderPlayerImageBadgeChip(badge = {}) {
   `;
 }
 
-function renderPlayerSourceBadges(stream = {}, badgeSettings = StreamBadgeSettingsStore.snapshot()) {
+function renderPlayerSourceBadges(
+  stream = {},
+  badgeSettings = StreamBadgeSettingsStore.snapshot()
+) {
   const matchedBadges = matchStreamBadges(stream, badgeSettings.rules);
   const chips = [];
   const sizeBytes = stream.behaviorHints?.videoSize;
   if (badgeSettings.showFileSizeBadges !== false && sizeBytes != null) {
     const label = formatBytes(sizeBytes);
     if (label) {
-      chips.push(`<span class="stream-route-stream-badge size">${escapeHtml(t("streams_size", [label], `SIZE ${label}`))}</span>`);
+      chips.push(
+        `<span class="stream-route-stream-badge size">${escapeHtml(t("streams_size", [label], `SIZE ${label}`))}</span>`
+      );
     }
   }
   matchedBadges.slice(0, 8).forEach((badge) => {
@@ -1063,7 +1114,11 @@ function renderPlayerSourceBadges(stream = {}, badgeSettings = StreamBadgeSettin
 }
 
 function resolvePlayerSourceBadgePlacement(badgeSettings = StreamBadgeSettingsStore.snapshot()) {
-  return String(badgeSettings.badgePlacement || "BOTTOM").trim().toUpperCase() === "TOP" ? "TOP" : "BOTTOM";
+  return String(badgeSettings.badgePlacement || "BOTTOM")
+    .trim()
+    .toUpperCase() === "TOP"
+    ? "TOP"
+    : "BOTTOM";
 }
 
 function formatSubtitleDelay(delayMs = 0) {
@@ -1117,7 +1172,10 @@ function normalizeSubtitleLanguageKey(value) {
 
 function extractSubtitleLanguageSetting(value, fallback = SUBTITLE_LANGUAGE_OFF_KEY) {
   if (value && typeof value === "object") {
-    return extractSubtitleLanguageSetting(value.id ?? value.value ?? value.code ?? value.language ?? value.languageCode, fallback);
+    return extractSubtitleLanguageSetting(
+      value.id ?? value.value ?? value.code ?? value.language ?? value.languageCode,
+      fallback
+    );
   }
   const code = cleanDisplayText(value);
   if (!code || code.toLowerCase() === "[object object]") {
@@ -1150,21 +1208,21 @@ function subtitleLanguageLabel(languageKey) {
   if (!label) {
     label = String(languageKey || "").toUpperCase();
   }
-  return label
-    ? `${label.charAt(0).toLocaleUpperCase(locale)}${label.slice(1)}`
-    : "";
+  return label ? `${label.charAt(0).toLocaleUpperCase(locale)}${label.slice(1)}` : "";
 }
 
 function formatSubtitleTrackDisplay(track = {}, index = 0) {
   const languageSource = getSubtitleEntryLanguageSource(track);
   const languageKey = normalizeSubtitleLanguageKey(languageSource);
   const languageLabel = subtitleLanguageLabel(languageKey);
-  const descriptors = getTrackDescriptorLabels(track)
-    .filter((detail) => !isSubtitleLanguageOnlyDetail(detail, languageLabel, languageKey));
+  const descriptors = getTrackDescriptorLabels(track).filter(
+    (detail) => !isSubtitleLanguageOnlyDetail(detail, languageLabel, languageKey)
+  );
   const rawLabel = getMeaningfulTrackLabel(track);
-  const label = languageKey !== SUBTITLE_LANGUAGE_UNKNOWN_KEY && languageLabel
-    ? languageLabel
-    : (rawLabel || subtitleLabel(index));
+  const label =
+    languageKey !== SUBTITLE_LANGUAGE_UNKNOWN_KEY && languageLabel
+      ? languageLabel
+      : rawLabel || subtitleLabel(index);
 
   return {
     label,
@@ -1186,23 +1244,31 @@ function isSubtitleLanguageOnlyDetail(value, languageLabel = "", languageKey = "
     return true;
   }
 
-  const normalizedDetailCode = normalizeTrackLanguageCode(text) || inferTrackLanguageCodeFromText(text);
-  const normalizedLanguageCode = normalizeTrackLanguageCode(languageKey) || inferTrackLanguageCodeFromText(languageKey);
+  const normalizedDetailCode =
+    normalizeTrackLanguageCode(text) || inferTrackLanguageCodeFromText(text);
+  const normalizedLanguageCode =
+    normalizeTrackLanguageCode(languageKey) || inferTrackLanguageCodeFromText(languageKey);
   if (normalizedDetailCode && normalizedLanguageCode) {
-    return normalizedDetailCode === normalizedLanguageCode
-      || normalizedDetailCode.split("-")[0] === normalizedLanguageCode.split("-")[0];
+    return (
+      normalizedDetailCode === normalizedLanguageCode ||
+      normalizedDetailCode.split("-")[0] === normalizedLanguageCode.split("-")[0]
+    );
   }
 
   const inferredKey = normalizeSubtitleLanguageKey(text);
   if (normalizedLanguageCode && inferredKey && inferredKey !== SUBTITLE_LANGUAGE_UNKNOWN_KEY) {
-    return inferredKey === normalizedLanguageCode
-      || inferredKey.split("-")[0] === normalizedLanguageCode.split("-")[0];
+    return (
+      inferredKey === normalizedLanguageCode ||
+      inferredKey.split("-")[0] === normalizedLanguageCode.split("-")[0]
+    );
   }
   return false;
 }
 
 function styleChipLabel(value = "") {
-  return String(value || "").replace(/^#/, "").toUpperCase();
+  return String(value || "")
+    .replace(/^#/, "")
+    .toUpperCase();
 }
 
 function createTrackDialogCache() {
@@ -1227,23 +1293,27 @@ function supportsTvWebAudioAmplification() {
 }
 
 function isMagnetUrl(value = "") {
-  return String(value || "").trim().toLowerCase().startsWith("magnet:");
+  return String(value || "")
+    .trim()
+    .toLowerCase()
+    .startsWith("magnet:");
 }
 
 function streamDebridIdentity(item = {}) {
   const resolve = item.clientResolve || item.raw?.clientResolve || {};
   const behaviorHints = item.behaviorHints || item.raw?.behaviorHints || {};
   const infoHash = item.infoHash || item.raw?.infoHash || resolve.infoHash || "";
-  const magnetUri = resolve.magnetUri
-    || (isMagnetUrl(item.url) ? item.url : "")
-    || (isMagnetUrl(item.externalUrl) ? item.externalUrl : "");
+  const magnetUri =
+    resolve.magnetUri ||
+    (isMagnetUrl(item.url) ? item.url : "") ||
+    (isMagnetUrl(item.externalUrl) ? item.externalUrl : "");
   const hasDebridMarker = Boolean(
-    item.clientResolve
-      || item.raw?.clientResolve
-      || item.debridCacheStatus
-      || item.raw?.debridCacheStatus
-      || infoHash
-      || magnetUri
+    item.clientResolve ||
+    item.raw?.clientResolve ||
+    item.debridCacheStatus ||
+    item.raw?.debridCacheStatus ||
+    infoHash ||
+    magnetUri
   );
   if (!hasDebridMarker) {
     return "";
@@ -1254,7 +1324,12 @@ function streamDebridIdentity(item = {}) {
   }
   return [
     String(item.addonName || "Addon"),
-    String(resolve.service || item.debridCacheStatus?.providerId || item.raw?.debridCacheStatus?.providerId || ""),
+    String(
+      resolve.service ||
+        item.debridCacheStatus?.providerId ||
+        item.raw?.debridCacheStatus?.providerId ||
+        ""
+    ),
     String(locator),
     String(resolve.fileIdx ?? item.fileIdx ?? item.raw?.fileIdx ?? ""),
     String(behaviorHints.filename || resolve.filename || ""),
@@ -1293,7 +1368,8 @@ function mergeStreamItem(previous = {}, next = {}) {
     externalUrl: next.externalUrl || previous.externalUrl || null,
     ytId: next.ytId || previous.ytId || null,
     behaviorHints: Object.keys(behaviorHints).length ? behaviorHints : null,
-    subtitles: Array.isArray(next.subtitles) && next.subtitles.length ? next.subtitles : previous.subtitles,
+    subtitles:
+      Array.isArray(next.subtitles) && next.subtitles.length ? next.subtitles : previous.subtitles,
     sources: Array.isArray(next.sources) && next.sources.length ? next.sources : previous.sources
   };
 }
@@ -1308,7 +1384,9 @@ function flattenStreamGroups(streamResult) {
     (group.streams || []).forEach((stream, index) => {
       const resolve = stream.clientResolve || stream.raw?.clientResolve || {};
       const entry = {
-        id: stream.id || `${addonName}-${index}-${stream.url || stream.externalUrl || stream.ytId || stream.infoHash || resolve.infoHash || resolve.magnetUri || ""}`,
+        id:
+          stream.id ||
+          `${addonName}-${index}-${stream.url || stream.externalUrl || stream.ytId || stream.infoHash || resolve.infoHash || resolve.magnetUri || ""}`,
         label: stream.name || stream.title || `${addonName} stream`,
         name: stream.name || null,
         title: stream.title || null,
@@ -1327,7 +1405,9 @@ function flattenStreamGroups(streamResult) {
         behaviorHints: stream.behaviorHints || null,
         sources: Array.isArray(stream.sources) ? stream.sources : [],
         quality: stream.quality || null,
-        qualityValue: Number.isFinite(Number(stream.qualityValue)) ? Number(stream.qualityValue) : -1,
+        qualityValue: Number.isFinite(Number(stream.qualityValue))
+          ? Number(stream.qualityValue)
+          : -1,
         clientResolve: stream.clientResolve || null,
         debridCacheStatus: stream.debridCacheStatus || null,
         subtitles: Array.isArray(stream.subtitles) ? stream.subtitles : [],
@@ -1337,9 +1417,9 @@ function flattenStreamGroups(streamResult) {
         raw: stream
       };
       if (
-        DirectDebridResolver.shouldListStream(entry)
-        || WebOsEngineFsResolver.canResolveStream(entry)
-        || TizenStreamingServerResolver.canResolveStream(entry)
+        DirectDebridResolver.shouldListStream(entry) ||
+        WebOsEngineFsResolver.canResolveStream(entry) ||
+        TizenStreamingServerResolver.canResolveStream(entry)
       ) {
         flattened.push(entry);
       }
@@ -1443,10 +1523,15 @@ function buildLocalizedParentalWarnings(guide = {}) {
   return Object.entries(labels)
     .map(([key, label]) => ({
       label,
-      severityKey: String(guide?.[key] || "").trim().toLowerCase()
+      severityKey: String(guide?.[key] || "")
+        .trim()
+        .toLowerCase()
     }))
     .filter((entry) => entry.severityKey && entry.severityKey !== "none")
-    .sort((left, right) => (severityRank[left.severityKey] ?? 50) - (severityRank[right.severityKey] ?? 50))
+    .sort(
+      (left, right) =>
+        (severityRank[left.severityKey] ?? 50) - (severityRank[right.severityKey] ?? 50)
+    )
     .map((entry) => ({
       label: entry.label,
       severity: severityLabels[entry.severityKey] || entry.severityKey
@@ -1455,7 +1540,9 @@ function buildLocalizedParentalWarnings(guide = {}) {
 }
 
 function normalizePlayableImdbId(value = "") {
-  const candidate = String(value || "").trim().split(":")[0];
+  const candidate = String(value || "")
+    .trim()
+    .split(":")[0];
   return /^tt\d+$/i.test(candidate) ? candidate : "";
 }
 
@@ -1469,7 +1556,9 @@ function normalizePlayableTmdbId(value = "") {
 }
 
 function buildSkipIntervalLabel(interval = {}) {
-  const type = String(interval?.type || "").trim().toLowerCase();
+  const type = String(interval?.type || "")
+    .trim()
+    .toLowerCase();
   if (type === "recap") {
     return t("skip_recap", {}, "Skip Recap");
   }
@@ -1481,7 +1570,7 @@ function buildSkipIntervalLabel(interval = {}) {
 
 function stripQuotes(value) {
   const text = String(value || "").trim();
-  if (text.startsWith("\"") && text.endsWith("\"")) {
+  if (text.startsWith('"') && text.endsWith('"')) {
     return text.slice(1, -1);
   }
   return text;
@@ -1526,7 +1615,6 @@ function uniqueNonEmptyValues(values = []) {
 }
 
 export const PlayerScreen = {
-
   async mount(params = {}) {
     this.container = document.getElementById("player");
     this.container.style.display = "block";
@@ -1549,12 +1637,16 @@ export const PlayerScreen = {
       { objectFit: "fill", label: t("player_aspect_stretch", {}, "Stretch") }
     ];
 
-    this.streamCandidates = this.normalizeStreamCandidates(Array.isArray(params.streamCandidates) ? params.streamCandidates : []);
+    this.streamCandidates = this.normalizeStreamCandidates(
+      Array.isArray(params.streamCandidates) ? params.streamCandidates : []
+    );
     const preferredStreamId = String(params?.preferredStreamId || "").trim();
     const preferredStreamCandidate = preferredStreamId
-      ? this.streamCandidates.find((stream) => String(stream?.id || "") === preferredStreamId) || null
+      ? this.streamCandidates.find((stream) => String(stream?.id || "") === preferredStreamId) ||
+        null
       : null;
-    const initialStreamCandidate = preferredStreamCandidate || this.selectBestStreamCandidate(this.streamCandidates);
+    const initialStreamCandidate =
+      preferredStreamCandidate || this.selectBestStreamCandidate(this.streamCandidates);
     const initialStreamUrl = params.streamUrl || initialStreamCandidate?.url || null;
     if (!this.streamCandidates.length && initialStreamUrl) {
       this.streamCandidates = this.normalizeStreamCandidates([
@@ -1566,10 +1658,12 @@ export const PlayerScreen = {
       ]);
     }
 
-    this.currentStreamIndex = this.streamCandidates.findIndex((stream) => (
-      (preferredStreamCandidate && String(stream?.id || "") === String(preferredStreamCandidate.id || ""))
-      || stream.url === initialStreamUrl
-    ));
+    this.currentStreamIndex = this.streamCandidates.findIndex(
+      (stream) =>
+        (preferredStreamCandidate &&
+          String(stream?.id || "") === String(preferredStreamCandidate.id || "")) ||
+        stream.url === initialStreamUrl
+    );
     if (this.currentStreamIndex < 0) {
       this.currentStreamIndex = 0;
     }
@@ -1630,10 +1724,14 @@ export const PlayerScreen = {
     const explicitEpisodeIndex = this.episodes.findIndex((entry) => entry.id === params.videoId);
     const fallbackEpisodeIndex = this.episodes.findIndex((entry) => {
       const seasonMatch = params.season == null || Number(entry?.season) === Number(params.season);
-      const episodeMatch = params.episode == null || Number(entry?.episode) === Number(params.episode);
+      const episodeMatch =
+        params.episode == null || Number(entry?.episode) === Number(params.episode);
       return seasonMatch && episodeMatch;
     });
-    this.episodePanelIndex = Math.max(0, explicitEpisodeIndex >= 0 ? explicitEpisodeIndex : fallbackEpisodeIndex);
+    this.episodePanelIndex = Math.max(
+      0,
+      explicitEpisodeIndex >= 0 ? explicitEpisodeIndex : fallbackEpisodeIndex
+    );
     this.switchingEpisode = false;
 
     this.seekOverlayVisible = false;
@@ -1652,7 +1750,9 @@ export const PlayerScreen = {
     this.nextEpisodeCardDismissed = false;
     this.nextEpisodeBackExitArmed = false;
 
-    this.parentalWarnings = normalizeParentalWarnings(params.parentalWarnings || params.parentalGuide);
+    this.parentalWarnings = normalizeParentalWarnings(
+      params.parentalWarnings || params.parentalGuide
+    );
     this.parentalGuideVisible = false;
     this.parentalGuideExiting = false;
     this.parentalGuideShown = false;
@@ -1693,14 +1793,15 @@ export const PlayerScreen = {
     this.selectedManifestSubtitleTrackId = null;
     this.hlsManifestSubtitlePromotionUrls = new Set();
     this.activePlaybackUrl = initialStreamUrl || null;
-    this.pendingPlaybackRestore = Number(params.resumePositionMs || 0) > 0
-      ? {
-          timeSeconds: Number(params.resumePositionMs || 0) / 1000,
-          paused: false,
-          attempts: 0,
-          lastAttemptAt: 0
-        }
-      : null;
+    this.pendingPlaybackRestore =
+      Number(params.resumePositionMs || 0) > 0
+        ? {
+            timeSeconds: Number(params.resumePositionMs || 0) / 1000,
+            paused: false,
+            attempts: 0,
+            lastAttemptAt: 0
+          }
+        : null;
     this.trackDiscoveryToken = 0;
     this.trackDiscoveryInProgress = false;
     this.trackDiscoveryTimer = null;
@@ -1765,13 +1866,24 @@ export const PlayerScreen = {
     this.subtitleDelayMs = Number(playerSettings.subtitleDelayMs || 0);
     this.subtitleStyleSettings = {
       ...playerSettings.subtitleStyle,
-      preferredLanguage: extractSubtitleLanguageSetting(playerSettings.subtitleStyle?.preferredLanguage || playerSettings.subtitleLanguage || "off"),
-      secondaryPreferredLanguage: extractSubtitleLanguageSetting(playerSettings.subtitleStyle?.secondaryPreferredLanguage || playerSettings.secondarySubtitleLanguage || "off")
+      preferredLanguage: extractSubtitleLanguageSetting(
+        playerSettings.subtitleStyle?.preferredLanguage || playerSettings.subtitleLanguage || "off"
+      ),
+      secondaryPreferredLanguage: extractSubtitleLanguageSetting(
+        playerSettings.subtitleStyle?.secondaryPreferredLanguage ||
+          playerSettings.secondarySubtitleLanguage ||
+          "off"
+      )
     };
-    this.audioAmplificationDb = clamp(Number(playerSettings.audioAmplificationDb || 0), AUDIO_AMPLIFICATION_MIN_DB, AUDIO_AMPLIFICATION_MAX_DB);
+    this.audioAmplificationDb = clamp(
+      Number(playerSettings.audioAmplificationDb || 0),
+      AUDIO_AMPLIFICATION_MIN_DB,
+      AUDIO_AMPLIFICATION_MAX_DB
+    );
     this.persistAudioAmplification = Boolean(playerSettings.persistAudioAmplification);
-    this.audioAmplificationAvailable = supportsTvWebAudioAmplification()
-      && typeof (globalThis.AudioContext || globalThis.webkitAudioContext) === "function";
+    this.audioAmplificationAvailable =
+      supportsTvWebAudioAmplification() &&
+      typeof (globalThis.AudioContext || globalThis.webkitAudioContext) === "function";
     this.audioContext = null;
     this.audioGainNode = null;
     this.audioMediaSource = null;
@@ -1795,7 +1907,8 @@ export const PlayerScreen = {
     }
 
     if (initialStreamUrl && !this.isExternalFrameMode()) {
-      const sourceCandidate = this.getStreamCandidateByUrl(initialStreamUrl) || this.getCurrentStreamCandidate();
+      const sourceCandidate =
+        this.getStreamCandidateByUrl(initialStreamUrl) || this.getCurrentStreamCandidate();
       this.activePlaybackUrl = initialStreamUrl;
       this.currentEngineFsStream = this.getEngineFsStateForStream(sourceCandidate);
       if (this.currentEngineFsStream) {
@@ -1813,12 +1926,10 @@ export const PlayerScreen = {
     } else if (!this.isExternalFrameMode()) {
       const sourceCandidate = initialStreamCandidate || this.getCurrentStreamCandidate();
       if (
-        sourceCandidate
-        && (
-          DirectDebridResolver.canResolveStream(sourceCandidate)
-          || WebOsEngineFsResolver.canResolveStream(sourceCandidate)
-          || TizenStreamingServerResolver.canResolveStream(sourceCandidate)
-        )
+        sourceCandidate &&
+        (DirectDebridResolver.canResolveStream(sourceCandidate) ||
+          WebOsEngineFsResolver.canResolveStream(sourceCandidate) ||
+          TizenStreamingServerResolver.canResolveStream(sourceCandidate))
       ) {
         void this.playStreamCandidate(sourceCandidate);
       }
@@ -1846,9 +1957,10 @@ export const PlayerScreen = {
   },
 
   resolvePlaybackMediaSourceType(streamCandidate = this.getCurrentStreamCandidate()) {
-    const normalizeSourceType = typeof PlayerController.normalizePlaybackSourceType === "function"
-      ? PlayerController.normalizePlaybackSourceType.bind(PlayerController)
-      : (value) => String(value || "").includes("/") ? String(value || "").trim() : null;
+    const normalizeSourceType =
+      typeof PlayerController.normalizePlaybackSourceType === "function"
+        ? PlayerController.normalizePlaybackSourceType.bind(PlayerController)
+        : (value) => (String(value || "").includes("/") ? String(value || "").trim() : null);
 
     const declaredTypes = [
       streamCandidate?.raw?.mimeType,
@@ -1873,9 +1985,10 @@ export const PlayerScreen = {
       streamCandidate?.raw?.filename
     ];
     for (const value of filenameHints) {
-      const guessed = typeof PlayerController.guessMediaMimeType === "function"
-        ? PlayerController.guessMediaMimeType(String(value || ""))
-        : null;
+      const guessed =
+        typeof PlayerController.guessMediaMimeType === "function"
+          ? PlayerController.guessMediaMimeType(String(value || ""))
+          : null;
       if (guessed) {
         return guessed;
       }
@@ -1894,10 +2007,12 @@ export const PlayerScreen = {
       episode: this.params.episode == null ? null : Number(this.params.episode),
       title: this.params.playerTitle || this.params.itemTitle || null,
       poster: this.params.poster || null,
-      background: this.params.playerBackdropUrl || this.params.backdrop || this.params.poster || null,
+      background:
+        this.params.playerBackdropUrl || this.params.backdrop || this.params.poster || null,
       episodeTitle: this.params.episodeTitle || this.params.playerSubtitle || null,
       requestHeaders,
-      mediaSourceType
+      mediaSourceType,
+      streamIdentity: streamCandidate ? streamMergeKey(streamCandidate) || null : null
     };
   },
 
@@ -1940,16 +2055,18 @@ export const PlayerScreen = {
     const rawVideoId = String(this.params?.videoId || "").trim();
     const season = Number(this.params?.season || 0);
     const episode = Number(this.params?.episode || 0);
-    const imdbId = [
-      normalizePlayableImdbId(rawImdbId),
-      normalizePlayableImdbId(rawVideoId),
-      normalizePlayableImdbId(rawItemId)
-    ].find(Boolean) || "";
-    const tmdbId = [
-      normalizePlayableTmdbId(this.params?.tmdbId || this.params?.tmdb_id),
-      normalizePlayableTmdbId(rawItemId),
-      normalizePlayableTmdbId(rawVideoId)
-    ].find(Boolean) || 0;
+    const imdbId =
+      [
+        normalizePlayableImdbId(rawImdbId),
+        normalizePlayableImdbId(rawVideoId),
+        normalizePlayableImdbId(rawItemId)
+      ].find(Boolean) || "";
+    const tmdbId =
+      [
+        normalizePlayableTmdbId(this.params?.tmdbId || this.params?.tmdb_id),
+        normalizePlayableTmdbId(rawItemId),
+        normalizePlayableTmdbId(rawVideoId)
+      ].find(Boolean) || 0;
     return {
       itemType,
       imdbId,
@@ -1963,32 +2080,39 @@ export const PlayerScreen = {
     const identity = this.buildPlaybackIdentityContext();
     const currentSec = this.getPlaybackCurrentSeconds();
     const durationSec = this.getPlaybackDurationSeconds();
-    const progress =
-      durationSec > 0 ? Math.min(100, (currentSec / durationSec) * 100) : 0;
+    const progress = durationSec > 0 ? Math.min(100, (currentSec / durationSec) * 100) : 0;
     return {
       contentId: String(this.params?.itemId || identity.imdbId || ""),
       contentType: identity.itemType === "series" ? "series" : "movie",
       imdbId: identity.imdbId,
       tmdbId: identity.tmdbId || null,
       title: String(this.params?.playerTitle || this.params?.itemTitle || this.params?.title || ""),
-      year: Number(this.params?.playerReleaseYear || this.params?.releaseYear || this.params?.year || 0) || null,
+      year:
+        Number(
+          this.params?.playerReleaseYear || this.params?.releaseYear || this.params?.year || 0
+        ) || null,
       seasonNumber: identity.season,
       episodeNumber: identity.episode,
-      episodeTitle: String(this.params?.playerEpisodeTitle || this.params?.episodeTitle || this.params?.playerSubtitle || ""),
+      episodeTitle: String(
+        this.params?.playerEpisodeTitle ||
+          this.params?.episodeTitle ||
+          this.params?.playerSubtitle ||
+          ""
+      ),
       positionMs: Math.round(currentSec * 1000),
       durationMs: Math.round(durationSec * 1000),
-      progressPercent: progress,
+      progressPercent: progress
     };
   },
 
   maybeShowParentalGuideOverlay() {
     if (
-      this.parentalGuideShown
-      || !this.parentalWarnings.length
-      || this.paused
-      || this.loadingVisible
-      || this.startupAudioGateActive
-      || !this.hasPresentedPlaybackFrame
+      this.parentalGuideShown ||
+      !this.parentalWarnings.length ||
+      this.paused ||
+      this.loadingVisible ||
+      this.startupAudioGateActive ||
+      !this.hasPresentedPlaybackFrame
     ) {
       return;
     }
@@ -2000,9 +2124,10 @@ export const PlayerScreen = {
     if (!imdbId) {
       return;
     }
-    const response = (itemType === "series" || itemType === "tv") && season && episode
-      ? await parentalGuideRepository.getTvGuide(imdbId, season, episode)
-      : await parentalGuideRepository.getMovieGuide(imdbId);
+    const response =
+      (itemType === "series" || itemType === "tv") && season && episode
+        ? await parentalGuideRepository.getTvGuide(imdbId, season, episode)
+        : await parentalGuideRepository.getMovieGuide(imdbId);
     const warnings = buildLocalizedParentalWarnings(response?.parentalGuide || {});
     if (!warnings.length) {
       return;
@@ -2065,12 +2190,20 @@ export const PlayerScreen = {
 
   updateActiveSkipInterval(currentTime = this.getPlaybackCurrentSeconds()) {
     const previous = this.activeSkipInterval;
-    const active = (Array.isArray(this.skipIntervals) ? this.skipIntervals : []).find((interval) => {
-      const start = Number(interval?.startTime);
-      const end = Number(interval?.endTime);
-      return Number.isFinite(start) && Number.isFinite(end) && currentTime >= start && currentTime < end;
-    }) || null;
-    const previousKey = previous ? `${previous.type}:${previous.startTime}:${previous.endTime}` : "";
+    const active =
+      (Array.isArray(this.skipIntervals) ? this.skipIntervals : []).find((interval) => {
+        const start = Number(interval?.startTime);
+        const end = Number(interval?.endTime);
+        return (
+          Number.isFinite(start) &&
+          Number.isFinite(end) &&
+          currentTime >= start &&
+          currentTime < end
+        );
+      }) || null;
+    const previousKey = previous
+      ? `${previous.type}:${previous.startTime}:${previous.endTime}`
+      : "";
     const nextKey = active ? `${active.type}:${active.startTime}:${active.endTime}` : "";
     if (previousKey !== nextKey) {
       this.skipIntervalDismissed = false;
@@ -2087,14 +2220,22 @@ export const PlayerScreen = {
     }
   },
 
-  getSkipIntervalProgress(interval = this.activeSkipInterval, currentTime = this.getPlaybackCurrentSeconds()) {
+  getSkipIntervalProgress(
+    interval = this.activeSkipInterval,
+    currentTime = this.getPlaybackCurrentSeconds()
+  ) {
     if (!interval) {
       return 0;
     }
     const start = Number(interval.startTime);
     const end = Number(interval.endTime);
     const current = Number(currentTime);
-    if (!Number.isFinite(start) || !Number.isFinite(end) || end <= start || !Number.isFinite(current)) {
+    if (
+      !Number.isFinite(start) ||
+      !Number.isFinite(end) ||
+      end <= start ||
+      !Number.isFinite(current)
+    ) {
       return 0;
     }
     return clamp((current - start) / (end - start), 0, 1);
@@ -2114,7 +2255,8 @@ export const PlayerScreen = {
 
   updateSkipIntroCountdown(now = Date.now()) {
     const playbackReady = this.isSkipIntroPlaybackReady();
-    const shouldTrack = Boolean(this.activeSkipInterval) && playbackReady && !this.skipIntervalDismissed;
+    const shouldTrack =
+      Boolean(this.activeSkipInterval) && playbackReady && !this.skipIntervalDismissed;
     if (!shouldTrack) {
       this.stopSkipIntroCountdownAnimation();
       this.skipIntroAutoHidden = false;
@@ -2142,7 +2284,13 @@ export const PlayerScreen = {
       return;
     }
 
-    if (!this.activeSkipInterval || !this.isSkipIntroPlaybackReady() || this.skipIntervalDismissed || this.controlsVisible || this.skipIntroAutoHidden) {
+    if (
+      !this.activeSkipInterval ||
+      !this.isSkipIntroPlaybackReady() ||
+      this.skipIntervalDismissed ||
+      this.controlsVisible ||
+      this.skipIntroAutoHidden
+    ) {
       return;
     }
 
@@ -2155,14 +2303,19 @@ export const PlayerScreen = {
 
     const tick = (timestamp) => {
       this.skipIntroAnimationFrame = null;
-      if (!this.activeSkipInterval || !this.isSkipIntroPlaybackReady() || this.skipIntervalDismissed || this.controlsVisible) {
+      if (
+        !this.activeSkipInterval ||
+        !this.isSkipIntroPlaybackReady() ||
+        this.skipIntervalDismissed ||
+        this.controlsVisible
+      ) {
         this.syncSkipIntroButtonProgress();
         return;
       }
 
       const now = Number(timestamp || Date.now());
       if (!this.skipIntroCountdownStartAt) {
-        this.skipIntroCountdownStartAt = now - (currentProgress * SKIP_INTRO_COUNTDOWN_MS);
+        this.skipIntroCountdownStartAt = now - currentProgress * SKIP_INTRO_COUNTDOWN_MS;
       }
       const elapsed = Math.max(0, now - Number(this.skipIntroCountdownStartAt || 0));
       this.skipIntroCountdownProgress = clamp(elapsed / SKIP_INTRO_COUNTDOWN_MS, 0, 1);
@@ -2191,7 +2344,8 @@ export const PlayerScreen = {
       fill.style.transform = `scaleX(${clamp(this.skipIntroCountdownProgress, 0, 1)})`;
     }
     if (progressNode) {
-      const progressVisible = !this.controlsVisible && !this.skipIntroAutoHidden && !this.skipIntervalDismissed;
+      const progressVisible =
+        !this.controlsVisible && !this.skipIntroAutoHidden && !this.skipIntervalDismissed;
       progressNode.style.opacity = progressVisible ? "1" : "0";
     }
   },
@@ -2219,12 +2373,12 @@ export const PlayerScreen = {
     const container = this.uiRefs?.skipIntro;
     const button = container?.querySelector(".player-skip-intro-btn");
     return Boolean(
-      button
-      && button.isConnected
-      && !container.classList.contains("hidden")
-      && this.activeSkipInterval
-      && !this.skipIntervalDismissed
-      && this.isSkipIntroPlaybackReady()
+      button &&
+      button.isConnected &&
+      !container.classList.contains("hidden") &&
+      this.activeSkipInterval &&
+      !this.skipIntervalDismissed &&
+      this.isSkipIntroPlaybackReady()
     );
   },
 
@@ -2237,7 +2391,12 @@ export const PlayerScreen = {
     button.classList.toggle("focused", focused);
     if (focused) {
       const activeElement = document.activeElement;
-      if (activeElement && activeElement !== button && activeElement !== document.body && typeof activeElement.blur === "function") {
+      if (
+        activeElement &&
+        activeElement !== button &&
+        activeElement !== document.body &&
+        typeof activeElement.blur === "function"
+      ) {
         activeElement.blur();
       }
       if (document.activeElement !== button && typeof button.focus === "function") {
@@ -2273,22 +2432,29 @@ export const PlayerScreen = {
     const playbackReady = this.isSkipIntroPlaybackReady();
     const shouldShow = Boolean(activeInterval) && playbackReady && !this.skipIntervalDismissed;
     const isVisible = shouldShow && (!this.skipIntroAutoHidden || this.controlsVisible);
-    const activeKey = activeInterval ? `${activeInterval.type}:${activeInterval.startTime}:${activeInterval.endTime}` : "none";
+    const activeKey = activeInterval
+      ? `${activeInterval.type}:${activeInterval.startTime}:${activeInterval.endTime}`
+      : "none";
     const renderKey = `${activeKey}|ready:${playbackReady ? 1 : 0}|controls:${this.controlsVisible ? 1 : 0}|hidden:${this.skipIntroAutoHidden ? 1 : 0}|dismissed:${this.skipIntervalDismissed ? 1 : 0}`;
     button.classList.toggle("hidden", !isVisible);
     button.classList.toggle("is-raised", Boolean(this.controlsVisible));
     if (!isVisible && this.controlFocusZone === "skipIntro") {
-      this.controlFocusZone = this.controlsVisible && this.isSeekBarAvailable() ? "progress" : "buttons";
+      this.controlFocusZone =
+        this.controlsVisible && this.isSeekBarAvailable() ? "progress" : "buttons";
     }
     if (!shouldShow) {
       button.innerHTML = "";
       this.skipIntroRenderedKey = renderKey;
       return;
     }
-    if (this.skipIntroRenderedKey !== renderKey || !button.querySelector(".player-skip-intro-btn")) {
+    if (
+      this.skipIntroRenderedKey !== renderKey ||
+      !button.querySelector(".player-skip-intro-btn")
+    ) {
       const label = buildSkipIntervalLabel(activeInterval);
       const progress = clamp(this.skipIntroCountdownProgress, 0, 1);
-      const progressVisible = !this.controlsVisible && !this.skipIntroAutoHidden && !this.skipIntervalDismissed;
+      const progressVisible =
+        !this.controlsVisible && !this.skipIntroAutoHidden && !this.skipIntervalDismissed;
       button.innerHTML = `
         <button class="player-skip-intro-btn focusable" type="button" tabindex="-1" data-player-pointer-action="skipIntro" style="--skip-intro-progress-visible:${progressVisible ? 1 : 0};">
           <span class="player-skip-intro-content">
@@ -2319,7 +2485,12 @@ export const PlayerScreen = {
       focusTarget.classList.toggle("focused", this.controlFocusZone === "skipIntro");
       this.syncSkipIntroButtonTheme(focusTarget);
     }
-    if (isVisible && !this.controlsVisible && !this.skipIntroAutoHidden && !this.skipIntervalDismissed) {
+    if (
+      isVisible &&
+      !this.controlsVisible &&
+      !this.skipIntroAutoHidden &&
+      !this.skipIntervalDismissed
+    ) {
       if (this.skipIntroFocusFrame != null && typeof cancelAnimationFrame === "function") {
         cancelAnimationFrame(this.skipIntroFocusFrame);
       }
@@ -2393,40 +2564,44 @@ export const PlayerScreen = {
   },
 
   normalizeStreamCandidates(streams = []) {
-    return (streams || []).map((stream, index) => {
-      const streamUrl = stream?.url || stream?.externalUrl || "";
-      const entry = {
-        id: stream.id || `stream-${index}-${streamUrl}`,
-        label: stream.name || stream.title || stream.label || `Source ${index + 1}`,
-        name: stream.name || null,
-        title: stream.title || stream.label || null,
-        description: stream.description || stream.name || "",
-        addonName: stream.addonName || stream.sourceName || "Addon",
-        addonLogo: stream.addonLogo || null,
-        mimeType: stream.mimeType || stream.raw?.mimeType || stream.type || stream.source || null,
-        sourceType: stream.sourceType || stream.mimeType || stream.type || stream.source || "",
-        url: streamUrl,
-        ytId: stream.ytId || null,
-        infoHash: stream.infoHash || null,
-        fileIdx: stream.fileIdx ?? null,
-        engineFs: stream.engineFs || stream.raw?.engineFs || null,
-        tizenP2p: stream.tizenP2p || stream.raw?.tizenP2p || null,
-        externalUrl: stream.externalUrl || null,
-        behaviorHints: stream.behaviorHints || null,
-        sources: Array.isArray(stream.sources) ? stream.sources : [],
-        quality: stream.quality || null,
-        qualityValue: Number.isFinite(Number(stream.qualityValue)) ? Number(stream.qualityValue) : -1,
-        clientResolve: stream.clientResolve || stream.raw?.clientResolve || null,
-        debridCacheStatus: stream.debridCacheStatus || null,
-        subtitles: Array.isArray(stream.subtitles) ? stream.subtitles : [],
-        raw: stream
-      };
-      return (
-        DirectDebridResolver.shouldListStream(entry)
-        || WebOsEngineFsResolver.canResolveStream(entry)
-        || TizenStreamingServerResolver.canResolveStream(entry)
-      ) ? entry : null;
-    }).filter(Boolean);
+    return (streams || [])
+      .map((stream, index) => {
+        const streamUrl = stream?.url || stream?.externalUrl || "";
+        const entry = {
+          id: stream.id || `stream-${index}-${streamUrl}`,
+          label: stream.name || stream.title || stream.label || `Source ${index + 1}`,
+          name: stream.name || null,
+          title: stream.title || stream.label || null,
+          description: stream.description || stream.name || "",
+          addonName: stream.addonName || stream.sourceName || "Addon",
+          addonLogo: stream.addonLogo || null,
+          mimeType: stream.mimeType || stream.raw?.mimeType || stream.type || stream.source || null,
+          sourceType: stream.sourceType || stream.mimeType || stream.type || stream.source || "",
+          url: streamUrl,
+          ytId: stream.ytId || null,
+          infoHash: stream.infoHash || null,
+          fileIdx: stream.fileIdx ?? null,
+          engineFs: stream.engineFs || stream.raw?.engineFs || null,
+          tizenP2p: stream.tizenP2p || stream.raw?.tizenP2p || null,
+          externalUrl: stream.externalUrl || null,
+          behaviorHints: stream.behaviorHints || null,
+          sources: Array.isArray(stream.sources) ? stream.sources : [],
+          quality: stream.quality || null,
+          qualityValue: Number.isFinite(Number(stream.qualityValue))
+            ? Number(stream.qualityValue)
+            : -1,
+          clientResolve: stream.clientResolve || stream.raw?.clientResolve || null,
+          debridCacheStatus: stream.debridCacheStatus || null,
+          subtitles: Array.isArray(stream.subtitles) ? stream.subtitles : [],
+          raw: stream
+        };
+        return DirectDebridResolver.shouldListStream(entry) ||
+          WebOsEngineFsResolver.canResolveStream(entry) ||
+          TizenStreamingServerResolver.canResolveStream(entry)
+          ? entry
+          : null;
+      })
+      .filter(Boolean);
   },
 
   getCurrentStreamCandidate() {
@@ -2443,25 +2618,25 @@ export const PlayerScreen = {
   isDebridPlaybackCandidate(streamCandidate = this.getCurrentStreamCandidate()) {
     const stream = streamCandidate?.raw || streamCandidate || {};
     const resolve = streamCandidate?.clientResolve || stream?.clientResolve || {};
-    const debridCacheStatus = streamCandidate?.debridCacheStatus || stream?.debridCacheStatus || null;
-    return Boolean(
-      String(resolve.type || "").toLowerCase() === "debrid"
-      || debridCacheStatus
-    );
+    const debridCacheStatus =
+      streamCandidate?.debridCacheStatus || stream?.debridCacheStatus || null;
+    return Boolean(String(resolve.type || "").toLowerCase() === "debrid" || debridCacheStatus);
   },
 
   getStreamSearchText(streamCandidate) {
     const stream = streamCandidate?.raw || streamCandidate || {};
-    return String([
-      streamCandidate?.label || "",
-      streamCandidate?.description || "",
-      streamCandidate?.sourceType || "",
-      streamCandidate?.url || "",
-      stream?.title || "",
-      stream?.name || "",
-      stream?.description || "",
-      stream?.url || ""
-    ].join(" ")).toLowerCase();
+    return String(
+      [
+        streamCandidate?.label || "",
+        streamCandidate?.description || "",
+        streamCandidate?.sourceType || "",
+        streamCandidate?.url || "",
+        stream?.title || "",
+        stream?.name || "",
+        stream?.description || "",
+        stream?.url || ""
+      ].join(" ")
+    ).toLowerCase();
   },
 
   getWebOsAudioCompatibilityScore(streamCandidate) {
@@ -2469,14 +2644,16 @@ export const PlayerScreen = {
     let score = 0;
 
     if (/\b(aac|mp4a)\b/.test(text)) score += 22;
-    if (/\b(ac3|dolby digital)\b/.test(text) && !/\b(eac3|ec-3|ddp|atmos)\b/.test(text)) score += 14;
+    if (/\b(ac3|dolby digital)\b/.test(text) && !/\b(eac3|ec-3|ddp|atmos)\b/.test(text))
+      score += 14;
     if (/\b(mp3|mpeg audio)\b/.test(text)) score += 8;
     if (/\b(stereo|2\.0|2ch)\b/.test(text)) score += 8;
 
     if (/\b(eac3|ec-3|ddp|atmos)\b/.test(text)) score -= 28;
-    const devicePenalty = typeof PlayerController.getWebOsUnsupportedAudioPenalty === "function"
-      ? Number(PlayerController.getWebOsUnsupportedAudioPenalty(text) || 0)
-      : 0;
+    const devicePenalty =
+      typeof PlayerController.getWebOsUnsupportedAudioPenalty === "function"
+        ? Number(PlayerController.getWebOsUnsupportedAudioPenalty(text) || 0)
+        : 0;
     if (devicePenalty !== 0) {
       score += devicePenalty;
     } else if (/\b(truehd|dts-hd|dts:x|dts)\b/.test(text)) {
@@ -2493,7 +2670,9 @@ export const PlayerScreen = {
     if (!normalized) {
       return null;
     }
-    return this.streamCandidates.find((entry) => String(entry?.url || "").trim() === normalized) || null;
+    return (
+      this.streamCandidates.find((entry) => String(entry?.url || "").trim() === normalized) || null
+    );
   },
 
   getEngineFsStateForStream(streamCandidate = null) {
@@ -2510,7 +2689,9 @@ export const PlayerScreen = {
     } else {
       return null;
     }
-    const playbackUrl = String(streamCandidate?.url || streamCandidate?.externalUrl || streamCandidate || "").trim();
+    const playbackUrl = String(
+      streamCandidate?.url || streamCandidate?.externalUrl || streamCandidate || ""
+    ).trim();
     if (!playbackUrl) {
       return null;
     }
@@ -2526,11 +2707,20 @@ export const PlayerScreen = {
         infoHash: String(match[1] || "").toLowerCase(),
         fileIdx: Number.isFinite(fileIdx) ? fileIdx : -1,
         playbackUrl,
-        mimeType: String(streamCandidate?.mimeType || streamCandidate?.sourceType || "").trim() || null,
-        baseUrlKind: parsed.hostname === "127.0.0.1" || parsed.hostname === "localhost" || parsed.hostname === "::1"
-          ? "local-service"
-          : "public-service",
-        publicPlaybackUrl: String(streamCandidate?.engineFs?.publicPlaybackUrl || streamCandidate?.raw?.engineFs?.publicPlaybackUrl || "").trim() || null,
+        mimeType:
+          String(streamCandidate?.mimeType || streamCandidate?.sourceType || "").trim() || null,
+        baseUrlKind:
+          parsed.hostname === "127.0.0.1" ||
+          parsed.hostname === "localhost" ||
+          parsed.hostname === "::1"
+            ? "local-service"
+            : "public-service",
+        publicPlaybackUrl:
+          String(
+            streamCandidate?.engineFs?.publicPlaybackUrl ||
+              streamCandidate?.raw?.engineFs?.publicPlaybackUrl ||
+              ""
+          ).trim() || null,
         baseUrl: `${parsed.protocol}//${parsed.host}`
       };
     } catch (_) {
@@ -2557,15 +2747,15 @@ export const PlayerScreen = {
         : value || ""
     ).toLowerCase();
     return (
-      text.includes("message not processed")
-      || text.includes("connection refused")
-      || text.includes("econnrefused")
-      || text.includes("failed to fetch")
-      || text.includes("network error")
-      || text.includes("not found")
-      || text.includes("404")
-      || text.includes("unavailable")
-      || text.includes("timed out")
+      text.includes("message not processed") ||
+      text.includes("connection refused") ||
+      text.includes("econnrefused") ||
+      text.includes("failed to fetch") ||
+      text.includes("network error") ||
+      text.includes("not found") ||
+      text.includes("404") ||
+      text.includes("unavailable") ||
+      text.includes("timed out")
     );
   },
 
@@ -2590,9 +2780,13 @@ export const PlayerScreen = {
         return false;
       }
       try {
-        const result = target.kind === "tizen-streaming-server"
-          ? await TizenStreamingServerResolver.remove(target.infoHash, { baseUrl: target.baseUrl, timeoutMs: 2500 })
-          : await WebOsEngineFsResolver.remove(target.infoHash, { timeoutMs: 2500 });
+        const result =
+          target.kind === "tizen-streaming-server"
+            ? await TizenStreamingServerResolver.remove(target.infoHash, {
+                baseUrl: target.baseUrl,
+                timeoutMs: 2500
+              })
+            : await WebOsEngineFsResolver.remove(target.infoHash, { timeoutMs: 2500 });
         if (result?.status === "success") {
           logEngineFsDebug("EngineFS torrent removed", {
             reason,
@@ -2646,7 +2840,8 @@ export const PlayerScreen = {
       }
     };
 
-    const removalPromise = scheduleDeferredEngineFsRemoval(target, reason, deferMs, performRemoval) || performRemoval();
+    const removalPromise =
+      scheduleDeferredEngineFsRemoval(target, reason, deferMs, performRemoval) || performRemoval();
 
     this.engineFsRemovalRequests.set(key, removalPromise);
     try {
@@ -2729,7 +2924,10 @@ export const PlayerScreen = {
     this.engineFsKeepAliveToken = "";
   },
 
-  async releaseCurrentEngineFsStream(reason = "cleanup", { removeTorrent = false, deferRemoveMs = 0 } = {}) {
+  async releaseCurrentEngineFsStream(
+    reason = "cleanup",
+    { removeTorrent = false, deferRemoveMs = 0 } = {}
+  ) {
     const current = this.currentEngineFsStream;
     if (!current) {
       return;
@@ -2763,12 +2961,17 @@ export const PlayerScreen = {
     await this.cleanupEngineFsState(current, reason, { deferMs: deferRemoveMs });
   },
 
-  releaseCurrentEngineFsStreamBestEffort(reason = "cleanup", { removeTorrent = false, deferRemoveMs = 0 } = {}) {
+  releaseCurrentEngineFsStreamBestEffort(
+    reason = "cleanup",
+    { removeTorrent = false, deferRemoveMs = 0 } = {}
+  ) {
     const current = this.currentEngineFsStream;
     if (!current) {
       return;
     }
-    void this.releaseCurrentEngineFsStream(reason, { removeTorrent, deferRemoveMs }).catch(() => null);
+    void this.releaseCurrentEngineFsStream(reason, { removeTorrent, deferRemoveMs }).catch(
+      () => null
+    );
   },
 
   sendEngineFsRemoveOnPageExit(state = null) {
@@ -2776,7 +2979,9 @@ export const PlayerScreen = {
     if (!target?.infoHash) {
       return;
     }
-    const playbackUrl = String(target.playbackUrl || target.publicPlaybackUrl || this.activePlaybackUrl || "").trim();
+    const playbackUrl = String(
+      target.playbackUrl || target.publicPlaybackUrl || this.activePlaybackUrl || ""
+    ).trim();
     if (!playbackUrl) {
       return;
     }
@@ -2818,20 +3023,22 @@ export const PlayerScreen = {
   getTrackProbeUrl() {
     const currentCandidate = this.getCurrentStreamCandidate();
     return String(
-      this.activePlaybackUrl
-      || currentCandidate?.url
-      || PlayerController.video?.currentSrc
-      || ""
+      this.activePlaybackUrl || currentCandidate?.url || PlayerController.video?.currentSrc || ""
     ).trim();
   },
 
   isCurrentSourceAdaptiveManifest() {
     const probeUrl = this.getTrackProbeUrl();
-    const probeMimeType = typeof PlayerController.guessMediaMimeType === "function"
-      ? PlayerController.guessMediaMimeType(probeUrl)
-      : null;
-    return (typeof PlayerController.isLikelyHlsMimeType === "function" && PlayerController.isLikelyHlsMimeType(probeMimeType))
-      || (typeof PlayerController.isLikelyDashMimeType === "function" && PlayerController.isLikelyDashMimeType(probeMimeType));
+    const probeMimeType =
+      typeof PlayerController.guessMediaMimeType === "function"
+        ? PlayerController.guessMediaMimeType(probeUrl)
+        : null;
+    return (
+      (typeof PlayerController.isLikelyHlsMimeType === "function" &&
+        PlayerController.isLikelyHlsMimeType(probeMimeType)) ||
+      (typeof PlayerController.isLikelyDashMimeType === "function" &&
+        PlayerController.isLikelyDashMimeType(probeMimeType))
+    );
   },
 
   isCurrentSourceLikelyMkv() {
@@ -2846,9 +3053,10 @@ export const PlayerScreen = {
   },
 
   canDiscoverEmbeddedSubtitleTracks() {
-    const usingNativePlayback = typeof PlayerController.isUsingNativePlayback === "function"
-      ? PlayerController.isUsingNativePlayback()
-      : false;
+    const usingNativePlayback =
+      typeof PlayerController.isUsingNativePlayback === "function"
+        ? PlayerController.isUsingNativePlayback()
+        : false;
     if (!usingNativePlayback) {
       return false;
     }
@@ -2889,15 +3097,25 @@ export const PlayerScreen = {
         const type = String(track?.type || track?.track || track?.codecType || "").toLowerCase();
         return type === "text" || type === "subtitle";
       })
-      .filter((track) => !UNSUPPORTED_EMBEDDED_SUBTITLE_CODECS.has(String(track?.codec || "").trim().toUpperCase()))
+      .filter(
+        (track) =>
+          !UNSUPPORTED_EMBEDDED_SUBTITLE_CODECS.has(
+            String(track?.codec || "")
+              .trim()
+              .toUpperCase()
+          )
+      )
       .map((track, index) => {
         const sourceTrackId = Number(track?.id);
         const rawLanguage = getTrackLanguageValue(track);
         const normalizedLanguage = normalizeTrackLanguageCode(rawLanguage);
-        const languageKey = normalizeSubtitleLanguageKey(normalizedLanguage || String(rawLanguage || ""));
-        const fallbackLabel = languageKey && languageKey !== SUBTITLE_LANGUAGE_UNKNOWN_KEY
-          ? subtitleLanguageLabel(languageKey)
-          : subtitleLabel(index);
+        const languageKey = normalizeSubtitleLanguageKey(
+          normalizedLanguage || String(rawLanguage || "")
+        );
+        const fallbackLabel =
+          languageKey && languageKey !== SUBTITLE_LANGUAGE_UNKNOWN_KEY
+            ? subtitleLanguageLabel(languageKey)
+            : subtitleLabel(index);
         const descriptors = getTrackDescriptorLabels(track);
         return {
           id: `embedded-subtitle-${index}`,
@@ -2905,8 +3123,16 @@ export const PlayerScreen = {
           sourceTrackId: Number.isFinite(sourceTrackId) ? sourceTrackId : -1,
           nativeTrackIndex: Number.isFinite(sourceTrackId) ? Math.max(0, sourceTrackId - 1) : -1,
           label: getMeaningfulTrackLabel(track) || fallbackLabel,
-          language: normalizedLanguage || String(rawLanguage || "").trim().toLowerCase(),
-          secondary: descriptors.length ? descriptors.join(" · ") : String(normalizedLanguage || rawLanguage || "").trim().toUpperCase(),
+          language:
+            normalizedLanguage ||
+            String(rawLanguage || "")
+              .trim()
+              .toLowerCase(),
+          secondary: descriptors.length
+            ? descriptors.join(" · ")
+            : String(normalizedLanguage || rawLanguage || "")
+                .trim()
+                .toUpperCase(),
           forced: isForcedSubtitleTrack(track),
           codec: cleanDisplayText(track?.codec)
         };
@@ -2916,13 +3142,14 @@ export const PlayerScreen = {
   normalizeEmbeddedAudioTracks(rawTracks = []) {
     return rawTracks
       .filter((track) => String(track?.type || "").toLowerCase() === "audio")
-      .filter((track) => !PlayerController.isLikelyUnsupportedWebOsAudioTrackDescription?.([
-        track?.label,
-        track?.codec,
-        track?.audioCodec,
-        track?.channels,
-        track?.channelCount
-      ].filter(Boolean).join(" ")))
+      .filter(
+        (track) =>
+          !PlayerController.isLikelyUnsupportedWebOsAudioTrackDescription?.(
+            [track?.label, track?.codec, track?.audioCodec, track?.channels, track?.channelCount]
+              .filter(Boolean)
+              .join(" ")
+          )
+      )
       .map((track, index) => {
         const sourceTrackId = Number(track?.id);
         return {
@@ -2931,7 +3158,11 @@ export const PlayerScreen = {
           sourceTrackId: Number.isFinite(sourceTrackId) ? sourceTrackId : -1,
           nativeTrackIndex: Number.isFinite(sourceTrackId) ? Math.max(0, sourceTrackId - 1) : -1,
           label: cleanDisplayText(track?.label),
-          language: normalizeTrackLanguageCode(track?.lang) || String(track?.lang || "").trim().toLowerCase(),
+          language:
+            normalizeTrackLanguageCode(track?.lang) ||
+            String(track?.lang || "")
+              .trim()
+              .toLowerCase(),
           lang: cleanDisplayText(track?.lang),
           codec: cleanDisplayText(track?.codec || track?.audioCodec),
           audioCodec: cleanDisplayText(track?.audioCodec || track?.codec),
@@ -2943,9 +3174,10 @@ export const PlayerScreen = {
   },
 
   getUnavailableTrackMessage(kind = "audio") {
-    const usingAvPlay = typeof PlayerController.isUsingAvPlay === "function"
-      ? PlayerController.isUsingAvPlay()
-      : false;
+    const usingAvPlay =
+      typeof PlayerController.isUsingAvPlay === "function"
+        ? PlayerController.isUsingAvPlay()
+        : false;
     if (!usingAvPlay && this.isCurrentSourceLikelyMkv()) {
       if (kind === "subtitle") {
         return Environment.isWebOS()
@@ -2956,9 +3188,7 @@ export const PlayerScreen = {
         ? "No embedded audio tracks detected."
         : "MKV internal audio tracks are not exposed by the webOS web player.";
     }
-    return kind === "subtitle"
-      ? "No subtitle tracks available."
-      : "No audio tracks available.";
+    return kind === "subtitle" ? "No subtitle tracks available." : "No audio tracks available.";
   },
 
   getVideoTextTrackList() {
@@ -2982,14 +3212,14 @@ export const PlayerScreen = {
       const stream = candidate?.raw || candidate || null;
       const rawSubtitles = Array.isArray(stream?.subtitles) ? stream.subtitles : [];
       return rawSubtitles
-      .filter((subtitle) => Boolean(subtitle?.url))
-      .map((subtitle, index) => ({
-        id: subtitle.id || `${subtitle.lang || "unk"}-${index}-${subtitle.url}`,
-        url: subtitle.url,
-        lang: subtitle.lang || "unknown",
-        addonName: candidate?.addonName || "Stream",
-        addonLogo: candidate?.addonLogo || null
-      }));
+        .filter((subtitle) => Boolean(subtitle?.url))
+        .map((subtitle, index) => ({
+          id: subtitle.id || `${subtitle.lang || "unk"}-${index}-${subtitle.url}`,
+          url: subtitle.url,
+          lang: subtitle.lang || "unknown",
+          addonName: candidate?.addonName || "Stream",
+          addonLogo: candidate?.addonLogo || null
+        }));
     };
 
     const current = mapSubtitles(streamCandidate);
@@ -3013,7 +3243,9 @@ export const PlayerScreen = {
       if (!subtitle?.url) {
         return;
       }
-      const key = `${String(subtitle.url).trim()}::${String(subtitle.lang || "").trim().toLowerCase()}`;
+      const key = `${String(subtitle.url).trim()}::${String(subtitle.lang || "")
+        .trim()
+        .toLowerCase()}`;
       if (seen.has(key)) {
         return;
       }
@@ -3179,9 +3411,7 @@ export const PlayerScreen = {
       const mimeType = String(adaptationSet.getAttribute("mimeType") || "").toLowerCase();
       const representation = adaptationSet.getElementsByTagName("Representation")[0] || null;
       const codecs = String(
-        adaptationSet.getAttribute("codecs")
-        || representation?.getAttribute("codecs")
-        || ""
+        adaptationSet.getAttribute("codecs") || representation?.getAttribute("codecs") || ""
       ).toLowerCase();
       const roleValues = Array.from(adaptationSet.getElementsByTagName("Role"))
         .map((node) => String(node.getAttribute("value") || "").trim())
@@ -3189,19 +3419,18 @@ export const PlayerScreen = {
       const accessibilityValues = Array.from(adaptationSet.getElementsByTagName("Accessibility"))
         .map((node) => String(node.getAttribute("value") || "").trim())
         .filter(Boolean);
-      const audioChannelConfiguration = adaptationSet.getElementsByTagName("AudioChannelConfiguration")[0]
-        || representation?.getElementsByTagName("AudioChannelConfiguration")?.[0]
-        || null;
+      const audioChannelConfiguration =
+        adaptationSet.getElementsByTagName("AudioChannelConfiguration")[0] ||
+        representation?.getElementsByTagName("AudioChannelConfiguration")?.[0] ||
+        null;
       const language = String(
-        adaptationSet.getAttribute("lang")
-        || representation?.getAttribute("lang")
-        || ""
+        adaptationSet.getAttribute("lang") || representation?.getAttribute("lang") || ""
       ).trim();
       const label = String(
-        adaptationSet.getAttribute("label")
-        || representation?.getAttribute("label")
-        || roleValues[0]
-        || ""
+        adaptationSet.getAttribute("label") ||
+          representation?.getAttribute("label") ||
+          roleValues[0] ||
+          ""
       ).trim();
       const setId = String(adaptationSet.getAttribute("id") || setIndex).trim();
       const channels = String(audioChannelConfiguration?.getAttribute("value") || "").trim();
@@ -3209,12 +3438,13 @@ export const PlayerScreen = {
       const accessibility = accessibilityValues.join(" ");
 
       const isAudio = contentType === "audio" || mimeType.startsWith("audio/");
-      const isSubtitle = contentType === "text"
-        || mimeType.startsWith("text/")
-        || mimeType.includes("ttml")
-        || mimeType.includes("vtt")
-        || codecs.includes("stpp")
-        || codecs.includes("wvtt");
+      const isSubtitle =
+        contentType === "text" ||
+        mimeType.startsWith("text/") ||
+        mimeType.includes("ttml") ||
+        mimeType.includes("vtt") ||
+        codecs.includes("stpp") ||
+        codecs.includes("wvtt");
 
       if (isAudio) {
         audioTracks.push({
@@ -3281,11 +3511,15 @@ export const PlayerScreen = {
     this.refreshTrackDialogs();
 
     const probeUrl = masterUrl || runtimeUrl || playbackUrl || "";
-    const probeMimeType = typeof PlayerController.guessMediaMimeType === "function"
-      ? PlayerController.guessMediaMimeType(probeUrl)
-      : null;
-    const isAdaptiveManifest = (typeof PlayerController.isLikelyHlsMimeType === "function" && PlayerController.isLikelyHlsMimeType(probeMimeType))
-      || (typeof PlayerController.isLikelyDashMimeType === "function" && PlayerController.isLikelyDashMimeType(probeMimeType));
+    const probeMimeType =
+      typeof PlayerController.guessMediaMimeType === "function"
+        ? PlayerController.guessMediaMimeType(probeUrl)
+        : null;
+    const isAdaptiveManifest =
+      (typeof PlayerController.isLikelyHlsMimeType === "function" &&
+        PlayerController.isLikelyHlsMimeType(probeMimeType)) ||
+      (typeof PlayerController.isLikelyDashMimeType === "function" &&
+        PlayerController.isLikelyDashMimeType(probeMimeType));
 
     if (!isAdaptiveManifest) {
       if (loadToken === this.manifestLoadToken) {
@@ -3307,7 +3541,8 @@ export const PlayerScreen = {
       const headers = this.getCurrentStreamRequestHeaders(currentCandidate);
       const manifestFetchTimeoutMs = 5000;
       const fetchManifestText = async (url, requestHeaders = {}) => {
-        const requestController = typeof AbortController === "function" ? new AbortController() : null;
+        const requestController =
+          typeof AbortController === "function" ? new AbortController() : null;
         let requestTimeoutId = null;
         try {
           const timeoutPromise = new Promise((_, reject) => {
@@ -3340,7 +3575,12 @@ export const PlayerScreen = {
         }
       };
 
-      const urlCandidates = uniqueNonEmptyValues([masterUrl, runtimeUrl, playbackUrl, this.activePlaybackUrl]);
+      const urlCandidates = uniqueNonEmptyValues([
+        masterUrl,
+        runtimeUrl,
+        playbackUrl,
+        this.activePlaybackUrl
+      ]);
       let selectedParsed = null;
       let selectedMasterUrl = masterUrl;
 
@@ -3363,7 +3603,10 @@ export const PlayerScreen = {
           continue;
         }
 
-        const parsed = this.parseManifestTracks(fetchedManifest.text, fetchedManifest.finalUrl || candidateUrl);
+        const parsed = this.parseManifestTracks(
+          fetchedManifest.text,
+          fetchedManifest.finalUrl || candidateUrl
+        );
         const hasTracks = parsed.audioTracks.length || parsed.subtitleTracks.length;
         if (hasTracks) {
           selectedParsed = parsed;
@@ -3371,7 +3614,7 @@ export const PlayerScreen = {
           break;
         }
 
-        if (!selectedParsed && (parsed.variants.length > 0)) {
+        if (!selectedParsed && parsed.variants.length > 0) {
           selectedParsed = parsed;
           selectedMasterUrl = fetchedManifest.finalUrl || candidateUrl;
         }
@@ -3386,7 +3629,10 @@ export const PlayerScreen = {
             if (loadToken !== this.manifestLoadToken) {
               return;
             }
-            const nestedParsed = this.parseManifestTracks(variantFetched.text, variantFetched.finalUrl || variant.uri);
+            const nestedParsed = this.parseManifestTracks(
+              variantFetched.text,
+              variantFetched.finalUrl || variant.uri
+            );
             if (nestedParsed.audioTracks.length || nestedParsed.subtitleTracks.length) {
               selectedParsed = nestedParsed;
               selectedMasterUrl = variantFetched.finalUrl || variant.uri;
@@ -3402,7 +3648,10 @@ export const PlayerScreen = {
               if (loadToken !== this.manifestLoadToken) {
                 return;
               }
-              const nestedParsed = this.parseManifestTracks(variantFetchedNoHeaders.text, variantFetchedNoHeaders.finalUrl || variant.uri);
+              const nestedParsed = this.parseManifestTracks(
+                variantFetchedNoHeaders.text,
+                variantFetchedNoHeaders.finalUrl || variant.uri
+              );
               if (nestedParsed.audioTracks.length || nestedParsed.subtitleTracks.length) {
                 selectedParsed = nestedParsed;
                 selectedMasterUrl = variantFetchedNoHeaders.finalUrl || variant.uri;
@@ -3427,8 +3676,12 @@ export const PlayerScreen = {
       this.manifestAudioTracks = selectedParsed.audioTracks;
       this.manifestSubtitleTracks = selectedParsed.subtitleTracks;
       this.manifestVariants = selectedParsed.variants;
-      this.selectedManifestAudioTrackId = selectedParsed.audioTracks.find((track) => track.isDefault)?.id || selectedParsed.audioTracks[0]?.id || null;
-      this.selectedManifestSubtitleTrackId = selectedParsed.subtitleTracks.find((track) => track.isDefault)?.id || null;
+      this.selectedManifestAudioTrackId =
+        selectedParsed.audioTracks.find((track) => track.isDefault)?.id ||
+        selectedParsed.audioTracks[0]?.id ||
+        null;
+      this.selectedManifestSubtitleTrackId =
+        selectedParsed.subtitleTracks.find((track) => track.isDefault)?.id || null;
       this.refreshTrackDialogs();
       this.promoteHlsManifestSubtitlePlayback(selectedMasterUrl || masterUrl);
     } catch (_error) {
@@ -3480,7 +3733,9 @@ export const PlayerScreen = {
 
     let scopedCandidates = candidatePool;
     if (subtitleGroupId) {
-      const bySubtitle = candidatePool.filter((variant) => variant.subtitleGroupId === subtitleGroupId);
+      const bySubtitle = candidatePool.filter(
+        (variant) => variant.subtitleGroupId === subtitleGroupId
+      );
       if (bySubtitle.length) {
         scopedCandidates = bySubtitle;
       }
@@ -3491,9 +3746,10 @@ export const PlayerScreen = {
       }
     }
 
-    const capabilityProbe = typeof PlayerController.getPlaybackCapabilities === "function"
-      ? PlayerController.getPlaybackCapabilities()
-      : null;
+    const capabilityProbe =
+      typeof PlayerController.getPlaybackCapabilities === "function"
+        ? PlayerController.getPlaybackCapabilities()
+        : null;
     const supports = (key, fallback = true) => {
       if (!capabilityProbe) {
         return fallback;
@@ -3526,7 +3782,7 @@ export const PlayerScreen = {
         score += supports("dolbyVision", true) ? 18 : -100;
       }
       if (codecs.includes("hvc1") || codecs.includes("hev1")) {
-        score += (supports("mp4Hevc", true) || supports("mp4HevcMain10", true)) ? 14 : -90;
+        score += supports("mp4Hevc", true) || supports("mp4HevcMain10", true) ? 14 : -90;
       }
       if (codecs.includes("av01")) {
         score += supports("mp4Av1", true) ? 10 : -80;
@@ -3544,9 +3800,10 @@ export const PlayerScreen = {
       return score;
     };
 
-    return scopedCandidates
-      .slice()
-      .sort((left, right) => scoreVariant(right) - scoreVariant(left))[0] || null;
+    return (
+      scopedCandidates.slice().sort((left, right) => scoreVariant(right) - scoreVariant(left))[0] ||
+      null
+    );
   },
 
   applyManifestTrackSelection({ audioTrackId, subtitleTrackId } = {}) {
@@ -3557,11 +3814,16 @@ export const PlayerScreen = {
       this.selectedManifestSubtitleTrackId = subtitleTrackId;
     }
 
-    const selectedAudio = this.manifestAudioTracks.find((track) => track.id === this.selectedManifestAudioTrackId) || null;
-    const selectedSubtitle = this.manifestSubtitleTracks.find((track) => track.id === this.selectedManifestSubtitleTrackId) || null;
+    const selectedAudio =
+      this.manifestAudioTracks.find((track) => track.id === this.selectedManifestAudioTrackId) ||
+      null;
+    const selectedSubtitle =
+      this.manifestSubtitleTracks.find(
+        (track) => track.id === this.selectedManifestSubtitleTrackId
+      ) || null;
     const variant = this.pickManifestVariant({
       audioGroupId: selectedAudio?.groupId || null,
-      subtitleGroupId: selectedSubtitle ? (selectedSubtitle.groupId || null) : null
+      subtitleGroupId: selectedSubtitle ? selectedSubtitle.groupId || null : null
     });
 
     if (!variant?.uri) {
@@ -3577,9 +3839,10 @@ export const PlayerScreen = {
 
     const video = PlayerController.video;
     const restoreTimeSeconds = this.getPlaybackCurrentSeconds();
-    const usingAvPlay = typeof PlayerController.isUsingAvPlay === "function"
-      ? PlayerController.isUsingAvPlay()
-      : false;
+    const usingAvPlay =
+      typeof PlayerController.isUsingAvPlay === "function"
+        ? PlayerController.isUsingAvPlay()
+        : false;
     const restorePaused = Boolean(this.paused || (!usingAvPlay && video?.paused));
     this.pendingPlaybackRestore = {
       timeSeconds: Number.isFinite(restoreTimeSeconds) ? restoreTimeSeconds : 0,
@@ -3642,14 +3905,18 @@ export const PlayerScreen = {
           <div class="player-loading-gradient"></div>
           <div class="player-loading-center">
             <div class="player-loading-identity${loadingMeta.logoUrl ? " has-logo" : ""}">
-              ${loadingMeta.logoUrl ? `
+              ${
+                loadingMeta.logoUrl
+                  ? `
                 <div class="player-loading-logo-stack">
                   <img class="player-loading-logo player-loading-logo-base" src="${escapeAttribute(loadingMeta.logoUrl)}" alt="${escapeAttribute(loadingMeta.title || "logo")}" />
                   <div class="player-loading-logo-fill-clip hidden">
                     <img class="player-loading-logo player-loading-logo-fill" src="${escapeAttribute(loadingMeta.logoUrl)}" alt="" aria-hidden="true" />
                   </div>
                 </div>
-              ` : ""}
+              `
+                  : ""
+              }
               <div class="player-loading-title">${escapeHtml(loadingMeta.title || this.params.playerTitle || this.params.itemId || "Nuvio")}</div>
             </div>
             <div class="player-loading-subtitle${loadingMeta.subtitle ? "" : " hidden"}">${escapeHtml(loadingMeta.subtitle || "")}</div>
@@ -3747,46 +4014,54 @@ export const PlayerScreen = {
 
   cachePlayerUiRefs(root = null) {
     const uiRoot = root || this.container?.querySelector("#playerUiRoot");
-    this.uiRefs = uiRoot ? {
-      root: uiRoot,
-      loadingOverlay: uiRoot.querySelector("#playerLoadingOverlay"),
-      bufferingSpinner: uiRoot.querySelector("#playerBufferingSpinner"),
-      startupErrorOverlay: uiRoot.querySelector("#playerStartupErrorOverlay"),
-      torrentOverlay: uiRoot.querySelector("#playerTorrentOverlay"),
-      torrentOverlaySpeed: uiRoot.querySelector("#playerTorrentOverlay .player-torrent-overlay-speed"),
-      torrentOverlayDetail: uiRoot.querySelector("#playerTorrentOverlay .player-torrent-overlay-detail"),
-      loadingIdentity: uiRoot.querySelector(".player-loading-identity"),
-      loadingLogoStack: uiRoot.querySelector(".player-loading-logo-stack"),
-      loadingLogoBase: uiRoot.querySelector(".player-loading-logo-base"),
-      loadingLogoFillClip: uiRoot.querySelector(".player-loading-logo-fill-clip"),
-      loadingLogoFill: uiRoot.querySelector(".player-loading-logo-fill"),
-      loadingTitle: uiRoot.querySelector(".player-loading-title"),
-      loadingSubtitle: uiRoot.querySelector(".player-loading-subtitle"),
-      loadingStatus: uiRoot.querySelector("#playerLoadingOverlay .player-loading-status"),
-      bufferingStatus: uiRoot.querySelector("#playerBufferingSpinner .player-loading-status"),
-      parentalGuide: uiRoot.querySelector("#playerParentalGuide"),
-      skipIntro: uiRoot.querySelector("#playerSkipIntro"),
-      aspectToast: uiRoot.querySelector("#playerAspectToast"),
-      seekOverlay: uiRoot.querySelector("#playerSeekOverlay"),
-      seekDirection: uiRoot.querySelector("#playerSeekDirection"),
-      seekPreview: uiRoot.querySelector("#playerSeekPreview"),
-      seekFill: uiRoot.querySelector("#playerSeekFill"),
-      pauseOverlay: uiRoot.querySelector("#playerPauseOverlay"),
-      nextEpisodeCard: uiRoot.querySelector("#playerNextEpisodeCard"),
-      modalBackdrop: uiRoot.querySelector("#playerModalBackdrop"),
-      subtitleDialog: uiRoot.querySelector("#playerSubtitleDialog"),
-      audioDialog: uiRoot.querySelector("#playerAudioDialog"),
-      speedDialog: uiRoot.querySelector("#playerSpeedDialog"),
-      sourcesPanel: uiRoot.querySelector("#playerSourcesPanel"),
-      controlsOverlay: uiRoot.querySelector("#playerControlsOverlay"),
-      progressShell: uiRoot.querySelector("#playerProgressShell"),
-      clock: uiRoot.querySelector("#playerClock"),
-      endsAt: uiRoot.querySelector("#playerEndsAt"),
-      progressFill: uiRoot.querySelector("#playerProgressFill"),
-      controlButtons: uiRoot.querySelector("#playerControlButtons"),
-      timeLabel: uiRoot.querySelector("#playerTimeLabel"),
-      startupErrorButton: uiRoot.querySelector("#playerStartupErrorOverlay .player-startup-error-button")
-    } : null;
+    this.uiRefs = uiRoot
+      ? {
+          root: uiRoot,
+          loadingOverlay: uiRoot.querySelector("#playerLoadingOverlay"),
+          bufferingSpinner: uiRoot.querySelector("#playerBufferingSpinner"),
+          startupErrorOverlay: uiRoot.querySelector("#playerStartupErrorOverlay"),
+          torrentOverlay: uiRoot.querySelector("#playerTorrentOverlay"),
+          torrentOverlaySpeed: uiRoot.querySelector(
+            "#playerTorrentOverlay .player-torrent-overlay-speed"
+          ),
+          torrentOverlayDetail: uiRoot.querySelector(
+            "#playerTorrentOverlay .player-torrent-overlay-detail"
+          ),
+          loadingIdentity: uiRoot.querySelector(".player-loading-identity"),
+          loadingLogoStack: uiRoot.querySelector(".player-loading-logo-stack"),
+          loadingLogoBase: uiRoot.querySelector(".player-loading-logo-base"),
+          loadingLogoFillClip: uiRoot.querySelector(".player-loading-logo-fill-clip"),
+          loadingLogoFill: uiRoot.querySelector(".player-loading-logo-fill"),
+          loadingTitle: uiRoot.querySelector(".player-loading-title"),
+          loadingSubtitle: uiRoot.querySelector(".player-loading-subtitle"),
+          loadingStatus: uiRoot.querySelector("#playerLoadingOverlay .player-loading-status"),
+          bufferingStatus: uiRoot.querySelector("#playerBufferingSpinner .player-loading-status"),
+          parentalGuide: uiRoot.querySelector("#playerParentalGuide"),
+          skipIntro: uiRoot.querySelector("#playerSkipIntro"),
+          aspectToast: uiRoot.querySelector("#playerAspectToast"),
+          seekOverlay: uiRoot.querySelector("#playerSeekOverlay"),
+          seekDirection: uiRoot.querySelector("#playerSeekDirection"),
+          seekPreview: uiRoot.querySelector("#playerSeekPreview"),
+          seekFill: uiRoot.querySelector("#playerSeekFill"),
+          pauseOverlay: uiRoot.querySelector("#playerPauseOverlay"),
+          nextEpisodeCard: uiRoot.querySelector("#playerNextEpisodeCard"),
+          modalBackdrop: uiRoot.querySelector("#playerModalBackdrop"),
+          subtitleDialog: uiRoot.querySelector("#playerSubtitleDialog"),
+          audioDialog: uiRoot.querySelector("#playerAudioDialog"),
+          speedDialog: uiRoot.querySelector("#playerSpeedDialog"),
+          sourcesPanel: uiRoot.querySelector("#playerSourcesPanel"),
+          controlsOverlay: uiRoot.querySelector("#playerControlsOverlay"),
+          progressShell: uiRoot.querySelector("#playerProgressShell"),
+          clock: uiRoot.querySelector("#playerClock"),
+          endsAt: uiRoot.querySelector("#playerEndsAt"),
+          progressFill: uiRoot.querySelector("#playerProgressFill"),
+          controlButtons: uiRoot.querySelector("#playerControlButtons"),
+          timeLabel: uiRoot.querySelector("#playerTimeLabel"),
+          startupErrorButton: uiRoot.querySelector(
+            "#playerStartupErrorOverlay .player-startup-error-button"
+          )
+        }
+      : null;
     this.lastUiTickState = {
       progressWidth: "",
       clockText: "",
@@ -3806,7 +4081,13 @@ export const PlayerScreen = {
   getLoadingOverlayMeta() {
     const transition = this.nextEpisodeTransitionMeta || null;
     return {
-      title: String(transition?.title || this.params?.playerTitle || this.params?.itemTitle || this.params?.itemId || "Nuvio").trim(),
+      title: String(
+        transition?.title ||
+          this.params?.playerTitle ||
+          this.params?.itemTitle ||
+          this.params?.itemId ||
+          "Nuvio"
+      ).trim(),
       subtitle: String(transition?.subtitle || this.params?.playerSubtitle || "").trim(),
       logoUrl: String(transition?.logoUrl || this.params?.playerLogoUrl || "").trim(),
       backdropUrl: String(transition?.backdropUrl || this.params?.playerBackdropUrl || "").trim()
@@ -3837,7 +4118,12 @@ export const PlayerScreen = {
       }
     }
     if (title) {
-      title.textContent = loadingMeta.title || this.params?.playerTitle || this.params?.itemTitle || this.params?.itemId || "Nuvio";
+      title.textContent =
+        loadingMeta.title ||
+        this.params?.playerTitle ||
+        this.params?.itemTitle ||
+        this.params?.itemId ||
+        "Nuvio";
     }
     if (subtitle) {
       subtitle.textContent = loadingMeta.subtitle || "";
@@ -3845,7 +4131,9 @@ export const PlayerScreen = {
     }
     const backdrop = overlay.querySelector(".player-loading-backdrop");
     if (backdrop instanceof HTMLElement) {
-      backdrop.style.backgroundImage = loadingMeta.backdropUrl ? `url('${loadingMeta.backdropUrl.replace(/'/g, "%27")}')` : "";
+      backdrop.style.backgroundImage = loadingMeta.backdropUrl
+        ? `url('${loadingMeta.backdropUrl.replace(/'/g, "%27")}')`
+        : "";
     }
     this.syncLoadingOverlayStatus();
     this.syncLoadingOverlayProgress();
@@ -3880,11 +4168,16 @@ export const PlayerScreen = {
     if (!snapshot) {
       return "";
     }
-    const peers = Number.isFinite(Number(snapshot.peers)) ? Math.max(0, Math.trunc(Number(snapshot.peers))) : 0;
-    const seeds = Number.isFinite(Number(snapshot.seeds)) ? Math.max(0, Math.trunc(Number(snapshot.seeds))) : null;
-    const peerInfo = seeds != null
-      ? t("player_torrent_peer_info", [seeds, peers], `${seeds} seeds · ${peers} peers`)
-      : `${peers} peers`;
+    const peers = Number.isFinite(Number(snapshot.peers))
+      ? Math.max(0, Math.trunc(Number(snapshot.peers)))
+      : 0;
+    const seeds = Number.isFinite(Number(snapshot.seeds))
+      ? Math.max(0, Math.trunc(Number(snapshot.seeds)))
+      : null;
+    const peerInfo =
+      seeds != null
+        ? t("player_torrent_peer_info", [seeds, peers], `${seeds} seeds · ${peers} peers`)
+        : `${peers} peers`;
     const speed = formatBytesPerSecond(snapshot.downloadSpeed);
     if (!this.hasPresentedPlaybackFrame) {
       const buffered = formatBytes(snapshot.downloaded) || "0 B";
@@ -3897,7 +4190,13 @@ export const PlayerScreen = {
     // These TV runtimes expose P2P/EngineFS stats through the runtime,
     // so the overlay stays shared across WebOS and Tizen.
     const supportsP2pStatsOverlay = Environment.isWebOS() || Environment.isTizen();
-    if (!supportsP2pStatsOverlay || !this.currentEngineFsStream || TorrentSettingsStore.get().hideTorrentStats || this.isExternalFrameMode() || this.error) {
+    if (
+      !supportsP2pStatsOverlay ||
+      !this.currentEngineFsStream ||
+      TorrentSettingsStore.get().hideTorrentStats ||
+      this.isExternalFrameMode() ||
+      this.error
+    ) {
       return null;
     }
     const snapshot = stats ? this.getEngineFsStallSnapshot(stats) : null;
@@ -3906,19 +4205,37 @@ export const PlayerScreen = {
     }
     const downloadSpeed = formatBytesPerSecond(snapshot.downloadSpeed);
     const uploadSpeed = formatBytesPerSecond(snapshot.uploadSpeed);
-    const peers = Number.isFinite(Number(snapshot.peers)) ? Math.max(0, Math.trunc(Number(snapshot.peers))) : 0;
-    const seeds = Number.isFinite(Number(snapshot.seeds)) ? Math.max(0, Math.trunc(Number(snapshot.seeds))) : null;
-    const progress = Number(snapshot.progress);
-    const progressPercent = Number.isFinite(progress) && progress > 0
-      ? (progress <= 1 ? progress * 100 : progress <= 100 ? progress : null)
+    const peers = Number.isFinite(Number(snapshot.peers))
+      ? Math.max(0, Math.trunc(Number(snapshot.peers)))
+      : 0;
+    const seeds = Number.isFinite(Number(snapshot.seeds))
+      ? Math.max(0, Math.trunc(Number(snapshot.seeds)))
       : null;
-    const detailText = seeds != null && progressPercent != null
-      ? t("player_torrent_stats", [peers, seeds, Math.round(progressPercent)], `${peers} peers · ${seeds} seeds · ${Math.round(progressPercent)}%`)
-      : progressPercent != null
-        ? t("player_torrent_status", [`${peers} peers`, `${Math.round(progressPercent)}%`], `${peers} peers · ${Math.round(progressPercent)}%`)
-        : (seeds != null
-          ? t("player_torrent_peer_info", [seeds, peers], `${seeds} seeds · ${peers} peers`)
-          : `${peers} peers`);
+    const progress = Number(snapshot.progress);
+    const progressPercent =
+      Number.isFinite(progress) && progress > 0
+        ? progress <= 1
+          ? progress * 100
+          : progress <= 100
+            ? progress
+            : null
+        : null;
+    const detailText =
+      seeds != null && progressPercent != null
+        ? t(
+            "player_torrent_stats",
+            [peers, seeds, Math.round(progressPercent)],
+            `${peers} peers · ${seeds} seeds · ${Math.round(progressPercent)}%`
+          )
+        : progressPercent != null
+          ? t(
+              "player_torrent_status",
+              [`${peers} peers`, `${Math.round(progressPercent)}%`],
+              `${peers} peers · ${Math.round(progressPercent)}%`
+            )
+          : seeds != null
+            ? t("player_torrent_peer_info", [seeds, peers], `${seeds} seeds · ${peers} peers`)
+            : `${peers} peers`;
     const speedParts = [];
     if (downloadSpeed) {
       speedParts.push(`↓ ${downloadSpeed}`);
@@ -3983,7 +4300,8 @@ export const PlayerScreen = {
   },
 
   showStartupError(message = "", { mediaErrorCode = 0 } = {}) {
-    this.startupErrorMessage = String(message || "").trim() || t("player_error_playback_fallback", {}, "Playback error");
+    this.startupErrorMessage =
+      String(message || "").trim() || t("player_error_playback_fallback", {}, "Playback error");
     this.startupErrorMediaCode = Number(mediaErrorCode || 0);
     this.lastPlaybackErrorAt = 0;
     this.loadingVisible = false;
@@ -4019,7 +4337,11 @@ export const PlayerScreen = {
     this.focusStartupErrorButton();
   },
 
-  getStartupErrorMessage(mediaErrorCode = 0, detail = "", streamCandidate = this.getCurrentStreamCandidate()) {
+  getStartupErrorMessage(
+    mediaErrorCode = 0,
+    detail = "",
+    streamCandidate = this.getCurrentStreamCandidate()
+  ) {
     const code = Number(mediaErrorCode || 0);
     const baseMessage = this.mediaErrorMessage(code, detail, streamCandidate);
     const extra = String(detail || "").trim();
@@ -4053,7 +4375,9 @@ export const PlayerScreen = {
       overlay.innerHTML = "";
       return;
     }
-    const message = String(this.startupErrorMessage || "").trim() || t("player_error_playback_fallback", {}, "Playback error");
+    const message =
+      String(this.startupErrorMessage || "").trim() ||
+      t("player_error_playback_fallback", {}, "Playback error");
     overlay.innerHTML = `
       <div class="player-startup-error-shell">
         <div class="player-startup-error-title">${escapeHtml(t("player_error_title", {}, "Playback Error"))}</div>
@@ -4179,7 +4503,11 @@ export const PlayerScreen = {
         clamp(progress, 0, 1)
       );
     }
-    if (this.currentEngineFsStream && this.hasPresentedPlaybackFrame && !this.isExternalFrameMode()) {
+    if (
+      this.currentEngineFsStream &&
+      this.hasPresentedPlaybackFrame &&
+      !this.isExternalFrameMode()
+    ) {
       this.loadingLogoFillActive = true;
       this.loadingLogoFillTarget = 1;
     }
@@ -4196,13 +4524,18 @@ export const PlayerScreen = {
     if (fillClip) {
       fillClip.classList.toggle("hidden", !showFill);
       if (showFill) {
-        const visiblePercent = Math.round(clamp(this.loadingLogoFillProgress || 0, 0, 1) * 10000) / 100;
+        const visiblePercent =
+          Math.round(clamp(this.loadingLogoFillProgress || 0, 0, 1) * 10000) / 100;
         fillClip.style.width = `${visiblePercent}%`;
       } else {
         fillClip.style.width = "0%";
       }
     }
-    if (showFill && clamp(Number(this.loadingLogoFillProgress || 0), 0, 1) < clamp(Number(this.loadingLogoFillTarget || 0), 0, 1)) {
+    if (
+      showFill &&
+      clamp(Number(this.loadingLogoFillProgress || 0), 0, 1) <
+        clamp(Number(this.loadingLogoFillTarget || 0), 0, 1)
+    ) {
       this.scheduleLoadingLogoFillAnimation();
     }
   },
@@ -4215,15 +4548,15 @@ export const PlayerScreen = {
       return;
     }
     const canShowLoadingProgress = Boolean(
-      this.loadingVisible
-      && this.currentEngineFsStream
-      && !this.hasPresentedPlaybackFrame
-      && !this.isExternalFrameMode()
+      this.loadingVisible &&
+      this.currentEngineFsStream &&
+      !this.hasPresentedPlaybackFrame &&
+      !this.isExternalFrameMode()
     );
     const canShowTorrentOverlay = Boolean(
-      this.currentEngineFsStream
-      && !this.isExternalFrameMode()
-      && !TorrentSettingsStore.get().hideTorrentStats
+      this.currentEngineFsStream &&
+      !this.isExternalFrameMode() &&
+      !TorrentSettingsStore.get().hideTorrentStats
     );
     if (!canShowLoadingProgress && !canShowTorrentOverlay) {
       if (this.loadingProgress != null) {
@@ -4247,9 +4580,9 @@ export const PlayerScreen = {
     try {
       const stats = await this.fetchCurrentEngineFsStats({ timeoutMs: 1200 });
       if (
-        !this.currentEngineFsStream
-        || this.isExternalFrameMode()
-        || this.isStartupErrorVisible()
+        !this.currentEngineFsStream ||
+        this.isExternalFrameMode() ||
+        this.isStartupErrorVisible()
       ) {
         if (this.loadingProgress != null) {
           this.loadingProgress = null;
@@ -4354,7 +4687,10 @@ export const PlayerScreen = {
       currentStreamUrl: this.getCurrentStreamCandidate()?.url || null,
       showControls: Boolean(this.controlsVisible),
       showSeekOverlay: Boolean(this.seekOverlayVisible),
-      pendingPreviewSeekPosition: this.seekPreviewSeconds == null ? null : Math.round(Number(this.seekPreviewSeconds || 0) * 1000),
+      pendingPreviewSeekPosition:
+        this.seekPreviewSeconds == null
+          ? null
+          : Math.round(Number(this.seekPreviewSeconds || 0) * 1000),
       playbackSpeed: Number(PlayerController.video?.playbackRate || 1),
       showAudioOverlay: Boolean(this.audioDialogVisible),
       showSubtitleOverlay: Boolean(this.subtitleDialogVisible),
@@ -4391,10 +4727,12 @@ export const PlayerScreen = {
     const season = Number(this.params?.season || 0);
     const episode = Number(this.params?.episode || 0);
     if (Number.isFinite(season) && season > 0 && Number.isFinite(episode) && episode > 0) {
-      return entries.find((entry) => (
-        Number(entry?.season || 0) === season
-        && Number(entry?.episode || 0) === episode
-      )) || null;
+      return (
+        entries.find(
+          (entry) =>
+            Number(entry?.season || 0) === season && Number(entry?.episode || 0) === episode
+        ) || null
+      );
     }
 
     return null;
@@ -4404,56 +4742,59 @@ export const PlayerScreen = {
     const resolvedMeta = meta && typeof meta === "object" ? meta : {};
     const episodeEntry = this.resolvePauseOverlayEpisodeEntry(this.episodes);
     const metaEpisodeEntry = this.resolvePauseOverlayEpisodeEntry(resolvedMeta?.videos);
-    const title = cleanDisplayText(
-      this.params?.playerTitle
-      || this.params?.itemTitle
-      || resolvedMeta?.name
-      || this.params?.itemId
-      || "Untitled"
-    ) || "Untitled";
+    const title =
+      cleanDisplayText(
+        this.params?.playerTitle ||
+          this.params?.itemTitle ||
+          resolvedMeta?.name ||
+          this.params?.itemId ||
+          "Untitled"
+      ) || "Untitled";
     const releaseYear = cleanDisplayText(
-      this.params?.playerReleaseYear
-      || this.params?.releaseYear
-      || this.params?.year
-      || extractReleaseYear(resolvedMeta?.releaseInfo)
+      this.params?.playerReleaseYear ||
+        this.params?.releaseYear ||
+        this.params?.year ||
+        extractReleaseYear(resolvedMeta?.releaseInfo)
     );
-    const season = Number(this.params?.season ?? episodeEntry?.season ?? metaEpisodeEntry?.season ?? 0);
-    const episode = Number(this.params?.episode ?? episodeEntry?.episode ?? metaEpisodeEntry?.episode ?? 0);
-    const hasEpisodeContext = Number.isFinite(season) && season > 0 && Number.isFinite(episode) && episode > 0;
+    const season = Number(
+      this.params?.season ?? episodeEntry?.season ?? metaEpisodeEntry?.season ?? 0
+    );
+    const episode = Number(
+      this.params?.episode ?? episodeEntry?.episode ?? metaEpisodeEntry?.episode ?? 0
+    );
+    const hasEpisodeContext =
+      Number.isFinite(season) && season > 0 && Number.isFinite(episode) && episode > 0;
     const episodeCode = hasEpisodeContext ? `S${season}E${episode}` : "";
     const episodeTitle = cleanDisplayText(
-      this.getDisplayEpisodeTitle()
-      || this.params?.playerEpisodeTitle
-      || episodeEntry?.title
-      || metaEpisodeEntry?.title
-      || metaEpisodeEntry?.name
-      || ""
+      this.getDisplayEpisodeTitle() ||
+        this.params?.playerEpisodeTitle ||
+        episodeEntry?.title ||
+        metaEpisodeEntry?.title ||
+        metaEpisodeEntry?.name ||
+        ""
     );
     const description = cleanDisplayText(
-      this.params?.playerDescription
-      || this.params?.description
-      || this.params?.overview
-      || episodeEntry?.overview
-      || episodeEntry?.description
-      || metaEpisodeEntry?.overview
-      || metaEpisodeEntry?.description
-      || resolvedMeta?.description
-      || resolvedMeta?.overview
-      || ""
+      this.params?.playerDescription ||
+        this.params?.description ||
+        this.params?.overview ||
+        episodeEntry?.overview ||
+        episodeEntry?.description ||
+        metaEpisodeEntry?.overview ||
+        metaEpisodeEntry?.description ||
+        resolvedMeta?.description ||
+        resolvedMeta?.overview ||
+        ""
     );
     const backdropUrl = cleanDisplayText(
-      this.params?.playerBackdropUrl
-      || this.params?.backdrop
-      || resolvedMeta?.background
-      || resolvedMeta?.poster
-      || this.params?.poster
-      || ""
+      this.params?.playerBackdropUrl ||
+        this.params?.backdrop ||
+        resolvedMeta?.background ||
+        resolvedMeta?.poster ||
+        this.params?.poster ||
+        ""
     );
     const logoUrl = cleanDisplayText(
-      this.params?.playerLogoUrl
-      || resolvedMeta?.logo
-      || this.params?.logo
-      || ""
+      this.params?.playerLogoUrl || resolvedMeta?.logo || this.params?.logo || ""
     );
 
     return {
@@ -4485,7 +4826,11 @@ export const PlayerScreen = {
 
     try {
       const result = await metaRepository.getMetaFromAllAddons(itemType, itemId);
-      if (requestToken !== this.pauseOverlayMetaRequestToken || result?.status !== "success" || !result?.data) {
+      if (
+        requestToken !== this.pauseOverlayMetaRequestToken ||
+        result?.status !== "success" ||
+        !result?.data
+      ) {
         return;
       }
       this.pauseOverlayMeta = this.buildPauseOverlayMeta(result.data);
@@ -4505,23 +4850,25 @@ export const PlayerScreen = {
   },
 
   canShowPauseOverlay() {
-    return !this.isExternalFrameMode()
-      && this.paused
-      && !this.loadingVisible
-      && !this.seekOverlayVisible
-      && this.seekPreviewSeconds == null
-      && !this.isDialogOpen()
-      && !this.parentalGuideVisible
-      && !this.moreActionsVisible
-      && !this.isNextEpisodeCardVisible();
+    return (
+      !this.isExternalFrameMode() &&
+      this.paused &&
+      !this.loadingVisible &&
+      !this.seekOverlayVisible &&
+      this.seekPreviewSeconds == null &&
+      !this.isDialogOpen() &&
+      !this.parentalGuideVisible &&
+      !this.moreActionsVisible &&
+      !this.isNextEpisodeCardVisible()
+    );
   },
 
   syncNativePausedStateForPauseOverlay() {
     if (
-      this.isExternalFrameMode()
-      || this.loadingVisible
-      || this.startupAudioGateActive
-      || (typeof PlayerController.isUsingAvPlay === "function" && PlayerController.isUsingAvPlay())
+      this.isExternalFrameMode() ||
+      this.loadingVisible ||
+      this.startupAudioGateActive ||
+      (typeof PlayerController.isUsingAvPlay === "function" && PlayerController.isUsingAvPlay())
     ) {
       return false;
     }
@@ -4531,16 +4878,18 @@ export const PlayerScreen = {
       return false;
     }
 
-    const readyState = typeof PlayerController.getPlaybackReadyState === "function"
-      ? Number(PlayerController.getPlaybackReadyState() || 0)
-      : Number(video.readyState || 0);
+    const readyState =
+      typeof PlayerController.getPlaybackReadyState === "function"
+        ? Number(PlayerController.getPlaybackReadyState() || 0)
+        : Number(video.readyState || 0);
     if (readyState < 3) {
       return false;
     }
 
-    const ended = typeof PlayerController.isPlaybackEnded === "function"
-      ? PlayerController.isPlaybackEnded()
-      : Boolean(video.ended);
+    const ended =
+      typeof PlayerController.isPlaybackEnded === "function"
+        ? PlayerController.isPlaybackEnded()
+        : Boolean(video.ended);
     if (ended) {
       return false;
     }
@@ -4620,7 +4969,10 @@ export const PlayerScreen = {
     }
 
     const meta = this.pauseOverlayMeta || this.buildPauseOverlayMeta();
-    const clockText = String(this.lastUiTickState?.clockText || this.uiRefs?.clock?.textContent || "--:--").trim() || "--:--";
+    const clockText =
+      String(
+        this.lastUiTickState?.clockText || this.uiRefs?.clock?.textContent || "--:--"
+      ).trim() || "--:--";
     const castItems = Array.isArray(meta.cast) ? meta.cast.slice(0, MAX_PAUSE_OVERLAY_CAST) : [];
     overlay.innerHTML = `
       <div class="player-pause-overlay-top">
@@ -4633,24 +4985,37 @@ export const PlayerScreen = {
         ${meta.releaseYear || meta.episodeCode ? `<div class="player-pause-meta-line">${escapeHtml([meta.releaseYear, meta.episodeCode].filter(Boolean).join(" • "))}</div>` : ""}
         ${meta.episodeTitle ? `<div class="player-pause-episode-title">${escapeHtml(meta.episodeTitle)}</div>` : ""}
         ${meta.description ? `<div class="player-pause-description">${escapeHtml(meta.description)}</div>` : ""}
-        ${castItems.length ? `
+        ${
+          castItems.length
+            ? `
           <div class="player-pause-cast-section">
             <div class="player-pause-cast-label">${escapeHtml(t("pause_cast_label", {}, "Cast"))}</div>
             <div class="player-pause-cast-row">
-              ${castItems.map((member) => `
+              ${castItems
+                .map(
+                  (member) => `
                 <div class="player-pause-cast-chip">
                   <span>${escapeHtml(member.name || "")}</span>
                 </div>
-              `).join("")}
+              `
+                )
+                .join("")}
             </div>
           </div>
-        ` : ""}
+        `
+            : ""
+        }
       </div>
     `;
   },
 
   getDisplayEpisodeTitle() {
-    const rawEpisodeTitle = String(this.params?.playerEpisodeTitle || this.params?.episodeTitle || this.params?.playerSubtitle || "").trim();
+    const rawEpisodeTitle = String(
+      this.params?.playerEpisodeTitle ||
+        this.params?.episodeTitle ||
+        this.params?.playerSubtitle ||
+        ""
+    ).trim();
     if (!rawEpisodeTitle) {
       return "";
     }
@@ -4665,16 +5030,22 @@ export const PlayerScreen = {
   },
 
   getPlayerHeaderData() {
-    const title = String(this.params?.playerTitle || this.params?.itemTitle || this.params?.itemId || "Untitled").trim() || "Untitled";
+    const title =
+      String(
+        this.params?.playerTitle || this.params?.itemTitle || this.params?.itemId || "Untitled"
+      ).trim() || "Untitled";
     const season = this.params?.season == null ? null : Number(this.params.season);
     const episode = this.params?.episode == null ? null : Number(this.params.episode);
-    const hasEpisodeContext = Number.isFinite(season) && season > 0 && Number.isFinite(episode) && episode > 0;
+    const hasEpisodeContext =
+      Number.isFinite(season) && season > 0 && Number.isFinite(episode) && episode > 0;
     const episodeCode = hasEpisodeContext ? `S${season}E${episode}` : "";
     const episodeTitle = this.getDisplayEpisodeTitle();
     const subtitle = hasEpisodeContext
       ? [episodeCode, episodeTitle].filter(Boolean).join(" • ")
       : "";
-    const meta = String(this.params?.playerReleaseYear || this.params?.releaseYear || this.params?.year || "").trim();
+    const meta = String(
+      this.params?.playerReleaseYear || this.params?.releaseYear || this.params?.year || ""
+    ).trim();
     return { title, subtitle, meta };
   },
 
@@ -4700,11 +5071,14 @@ export const PlayerScreen = {
     let nextEpisode = null;
     const explicitVideoId = String(this.params?.nextEpisodeVideoId || "").trim();
     if (explicitVideoId && this.episodes.length) {
-      nextEpisode = this.episodes.find((episode) => String(episode?.id || "") === explicitVideoId) || null;
+      nextEpisode =
+        this.episodes.find((episode) => String(episode?.id || "") === explicitVideoId) || null;
     }
 
     if (!nextEpisode && this.params?.videoId && this.episodes.length) {
-      const currentIndex = this.episodes.findIndex((episode) => String(episode?.id || "") === String(this.params?.videoId || ""));
+      const currentIndex = this.episodes.findIndex(
+        (episode) => String(episode?.id || "") === String(this.params?.videoId || "")
+      );
       if (currentIndex >= 0) {
         nextEpisode = this.episodes[currentIndex + 1] || null;
       }
@@ -4714,9 +5088,11 @@ export const PlayerScreen = {
       const currentSeason = Number(this.params?.season || 0);
       const currentEpisode = Number(this.params?.episode || 0);
       if (currentSeason > 0 && currentEpisode > 0) {
-        const currentIndex = this.episodes.findIndex((episode) => (
-          Number(episode?.season || 0) === currentSeason && Number(episode?.episode || 0) === currentEpisode
-        ));
+        const currentIndex = this.episodes.findIndex(
+          (episode) =>
+            Number(episode?.season || 0) === currentSeason &&
+            Number(episode?.episode || 0) === currentEpisode
+        );
         if (currentIndex >= 0) {
           nextEpisode = this.episodes[currentIndex + 1] || null;
         }
@@ -4728,18 +5104,20 @@ export const PlayerScreen = {
       return null;
     }
 
-    const season = nextEpisode?.season ?? (this.params?.nextEpisodeSeason ?? null);
-    const episode = nextEpisode?.episode ?? (this.params?.nextEpisodeEpisode ?? null);
+    const season = nextEpisode?.season ?? this.params?.nextEpisodeSeason ?? null;
+    const episode = nextEpisode?.episode ?? this.params?.nextEpisodeEpisode ?? null;
     const episodeLabel = nextEpisode
       ? `S${nextEpisode.season}E${nextEpisode.episode}`
-      : (this.params?.nextEpisodeLabel || "");
-    const released = String(nextEpisode?.released || this.params?.nextEpisodeReleased || "").trim() || null;
+      : this.params?.nextEpisodeLabel || "";
+    const released =
+      String(nextEpisode?.released || this.params?.nextEpisodeReleased || "").trim() || null;
     return {
       videoId: nextVideoId,
       season: season == null ? null : Number(season),
       episode: episode == null ? null : Number(episode),
       episodeLabel: episodeLabel || null,
-      episodeTitle: String(nextEpisode?.title || this.params?.nextEpisodeTitle || "").trim() || null,
+      episodeTitle:
+        String(nextEpisode?.title || this.params?.nextEpisodeTitle || "").trim() || null,
       released,
       hasAired: this.hasEpisodeAired(released)
     };
@@ -4751,7 +5129,9 @@ export const PlayerScreen = {
     }
     const currentVideoId = String(this.params?.videoId || "").trim();
     if (currentVideoId) {
-      const byVideoId = this.episodes.find((episode) => String(episode?.id || "") === currentVideoId);
+      const byVideoId = this.episodes.find(
+        (episode) => String(episode?.id || "") === currentVideoId
+      );
       if (byVideoId) {
         return byVideoId;
       }
@@ -4762,10 +5142,13 @@ export const PlayerScreen = {
     if (currentSeason <= 0 || currentEpisode <= 0) {
       return null;
     }
-    return this.episodes.find((episode) => (
-      Number(episode?.season || 0) === currentSeason
-      && Number(episode?.episode || 0) === currentEpisode
-    )) || null;
+    return (
+      this.episodes.find(
+        (episode) =>
+          Number(episode?.season || 0) === currentSeason &&
+          Number(episode?.episode || 0) === currentEpisode
+      ) || null
+    );
   },
 
   buildStreamRouteParamsFromPlayer() {
@@ -4773,12 +5156,15 @@ export const PlayerScreen = {
     const currentEpisode = itemType === "series" ? this.resolveCurrentEpisodeEntry() : null;
     const nextEpisode = itemType === "series" ? this.resolveNextEpisodeInfo() : null;
     const currentPositionMs = Math.round(this.getPlaybackCurrentSeconds() * 1000);
-    const title = this.params?.playerTitle || this.params?.itemTitle || this.params?.itemId || "Untitled";
-    const backdrop = this.params?.playerBackdropUrl || this.params?.backdrop || this.params?.poster || null;
+    const title =
+      this.params?.playerTitle || this.params?.itemTitle || this.params?.itemId || "Untitled";
+    const backdrop =
+      this.params?.playerBackdropUrl || this.params?.backdrop || this.params?.poster || null;
     const logo = this.params?.playerLogoUrl || this.params?.logo || null;
-    const videoId = itemType === "series"
-      ? (this.params?.videoId || currentEpisode?.id || null)
-      : (this.params?.videoId || this.params?.itemId || null);
+    const videoId =
+      itemType === "series"
+        ? this.params?.videoId || currentEpisode?.id || null
+        : this.params?.videoId || this.params?.itemId || null;
 
     return {
       itemId: this.params?.itemId || null,
@@ -4787,7 +5173,7 @@ export const PlayerScreen = {
       returnToDetail: true,
       fromDetailRoute: Boolean(this.params?.fromDetailRoute),
       itemTitle: title,
-      itemSubtitle: itemType === "series" ? "" : (this.params?.playerSubtitle || ""),
+      itemSubtitle: itemType === "series" ? "" : this.params?.playerSubtitle || "",
       year: this.params?.playerReleaseYear || this.params?.year || "",
       backdrop,
       poster: this.params?.poster || backdrop,
@@ -4795,11 +5181,17 @@ export const PlayerScreen = {
       parentalWarnings: this.params?.parentalWarnings || null,
       parentalGuide: this.params?.parentalGuide || null,
       videoId,
-      season: itemType === "series" ? (this.params?.season ?? currentEpisode?.season ?? null) : null,
-      episode: itemType === "series" ? (this.params?.episode ?? currentEpisode?.episode ?? null) : null,
-      episodeTitle: itemType === "series"
-        ? (this.params?.playerEpisodeTitle || this.params?.playerSubtitle || currentEpisode?.title || "")
-        : "",
+      season:
+        itemType === "series" ? (this.params?.season ?? currentEpisode?.season ?? null) : null,
+      episode:
+        itemType === "series" ? (this.params?.episode ?? currentEpisode?.episode ?? null) : null,
+      episodeTitle:
+        itemType === "series"
+          ? this.params?.playerEpisodeTitle ||
+            this.params?.playerSubtitle ||
+            currentEpisode?.title ||
+            ""
+          : "",
       episodes: Array.isArray(this.episodes) ? this.episodes : [],
       nextEpisodeVideoId: nextEpisode?.videoId || null,
       nextEpisodeLabel: nextEpisode?.episodeLabel || null,
@@ -4807,29 +5199,33 @@ export const PlayerScreen = {
       nextEpisodeEpisode: nextEpisode?.episode ?? null,
       nextEpisodeTitle: nextEpisode?.episodeTitle || "",
       nextEpisodeReleased: nextEpisode?.released || "",
-      resumePositionMs: Number.isFinite(currentPositionMs) && currentPositionMs > 0 ? currentPositionMs : 0
+      resumePositionMs:
+        Number.isFinite(currentPositionMs) && currentPositionMs > 0 ? currentPositionMs : 0
     };
   },
 
   buildDetailRouteParamsFromPlayer() {
     const itemType = normalizeItemType(this.params?.itemType || "movie");
     const currentEpisode = itemType === "series" ? this.resolveCurrentEpisodeEntry() : null;
-    const preferredSeason = itemType === "series"
-      ? Number(this.params?.season ?? currentEpisode?.season ?? 0)
-      : 0;
+    const preferredSeason =
+      itemType === "series" ? Number(this.params?.season ?? currentEpisode?.season ?? 0) : 0;
     return {
       itemId: this.params?.itemId || null,
       itemType,
-      fallbackTitle: this.params?.playerTitle || this.params?.itemTitle || this.params?.itemId || "Untitled",
-      preferredSeason: Number.isFinite(preferredSeason) && preferredSeason > 0 ? preferredSeason : null
+      fallbackTitle:
+        this.params?.playerTitle || this.params?.itemTitle || this.params?.itemId || "Untitled",
+      preferredSeason:
+        Number.isFinite(preferredSeason) && preferredSeason > 0 ? preferredSeason : null
     };
   },
 
   buildStreamRouteParamsForEpisode(episode = null) {
     const itemType = normalizeItemType(this.params?.itemType || "movie");
     const targetEpisode = episode || null;
-    const title = this.params?.playerTitle || this.params?.itemTitle || this.params?.itemId || "Untitled";
-    const backdrop = this.params?.playerBackdropUrl || this.params?.backdrop || this.params?.poster || null;
+    const title =
+      this.params?.playerTitle || this.params?.itemTitle || this.params?.itemId || "Untitled";
+    const backdrop =
+      this.params?.playerBackdropUrl || this.params?.backdrop || this.params?.poster || null;
     const logo = this.params?.playerLogoUrl || this.params?.logo || null;
     return {
       itemId: this.params?.itemId || null,
@@ -4838,7 +5234,7 @@ export const PlayerScreen = {
       returnToDetail: true,
       fromDetailRoute: Boolean(this.params?.fromDetailRoute),
       itemTitle: title,
-      itemSubtitle: itemType === "series" ? "" : (this.params?.playerSubtitle || ""),
+      itemSubtitle: itemType === "series" ? "" : this.params?.playerSubtitle || "",
       year: this.params?.playerReleaseYear || this.params?.year || "",
       backdrop,
       poster: this.params?.poster || backdrop,
@@ -4848,9 +5244,8 @@ export const PlayerScreen = {
       videoId: targetEpisode?.videoId || targetEpisode?.id || null,
       season: targetEpisode?.season == null ? null : Number(targetEpisode.season),
       episode: targetEpisode?.episode == null ? null : Number(targetEpisode.episode),
-      episodeTitle: itemType === "series"
-        ? (targetEpisode?.episodeTitle || targetEpisode?.title || "")
-        : "",
+      episodeTitle:
+        itemType === "series" ? targetEpisode?.episodeTitle || targetEpisode?.title || "" : "",
       episodes: Array.isArray(this.episodes) ? this.episodes : []
     };
   },
@@ -4878,16 +5273,26 @@ export const PlayerScreen = {
     }
     const durationSeconds = Number(this.getPlaybackDurationSeconds() || 0);
     const currentSeconds = Number(this.getPlaybackCurrentSeconds() || 0);
-    if (!Number.isFinite(durationSeconds) || durationSeconds <= 0 || !Number.isFinite(currentSeconds) || currentSeconds < 0) {
+    if (
+      !Number.isFinite(durationSeconds) ||
+      durationSeconds <= 0 ||
+      !Number.isFinite(currentSeconds) ||
+      currentSeconds < 0
+    ) {
       return false;
     }
-    return (currentSeconds / durationSeconds) >= NEXT_EPISODE_THRESHOLD_PERCENT;
+    return currentSeconds / durationSeconds >= NEXT_EPISODE_THRESHOLD_PERCENT;
   },
 
   hasPlaybackReachedNaturalEnd() {
     const durationSeconds = Number(this.getPlaybackDurationSeconds() || 0);
     const currentSeconds = Number(this.getPlaybackCurrentSeconds() || 0);
-    if (!Number.isFinite(durationSeconds) || durationSeconds <= 0 || !Number.isFinite(currentSeconds) || currentSeconds < 0) {
+    if (
+      !Number.isFinite(durationSeconds) ||
+      durationSeconds <= 0 ||
+      !Number.isFinite(currentSeconds) ||
+      currentSeconds < 0
+    ) {
       return false;
     }
     const remainingSeconds = durationSeconds - currentSeconds;
@@ -4898,10 +5303,15 @@ export const PlayerScreen = {
   shouldPrefetchNextEpisodeStreams() {
     const durationSeconds = Number(this.getPlaybackDurationSeconds() || 0);
     const currentSeconds = Number(this.getPlaybackCurrentSeconds() || 0);
-    if (!Number.isFinite(durationSeconds) || durationSeconds <= 0 || !Number.isFinite(currentSeconds) || currentSeconds < 0) {
+    if (
+      !Number.isFinite(durationSeconds) ||
+      durationSeconds <= 0 ||
+      !Number.isFinite(currentSeconds) ||
+      currentSeconds < 0
+    ) {
       return false;
     }
-    return (currentSeconds / durationSeconds) >= NEXT_EPISODE_PREFETCH_PERCENT;
+    return currentSeconds / durationSeconds >= NEXT_EPISODE_PREFETCH_PERCENT;
   },
 
   getStreamCacheKey(videoId, itemType) {
@@ -4926,7 +5336,10 @@ export const PlayerScreen = {
     if (!nextEpisode?.videoId || nextEpisode.hasAired === false) {
       return false;
     }
-    const cached = this.getCachedPlayableStreamsForVideo(nextEpisode.videoId, this.params?.itemType || "series");
+    const cached = this.getCachedPlayableStreamsForVideo(
+      nextEpisode.videoId,
+      this.params?.itemType || "series"
+    );
     return Array.isArray(cached) && cached.length > 0;
   },
 
@@ -4940,8 +5353,12 @@ export const PlayerScreen = {
       return;
     }
     const cacheKey = this.getStreamCacheKey(nextEpisode.videoId, itemType);
-    const loadPromises = this.streamCandidatesLoadPromises || (this.streamCandidatesLoadPromises = new Map());
-    if (this.getCachedPlayableStreamsForVideo(nextEpisode.videoId, itemType) || loadPromises.has(cacheKey)) {
+    const loadPromises =
+      this.streamCandidatesLoadPromises || (this.streamCandidatesLoadPromises = new Map());
+    if (
+      this.getCachedPlayableStreamsForVideo(nextEpisode.videoId, itemType) ||
+      loadPromises.has(cacheKey)
+    ) {
       return;
     }
     void this.getPlayableStreamsForVideo(nextEpisode.videoId, itemType)
@@ -4970,20 +5387,21 @@ export const PlayerScreen = {
 
   isNextEpisodeCardVisible() {
     const nextEpisode = this.resolveNextEpisodeInfo();
-    const playableStreamsReady = nextEpisode?.hasAired === false || this.hasCachedPlayableStreamsForNextEpisode(nextEpisode);
+    const playableStreamsReady =
+      nextEpisode?.hasAired === false || this.hasCachedPlayableStreamsForNextEpisode(nextEpisode);
     return Boolean(
-      nextEpisode
-      && this.shouldShowNextEpisodeCard()
-      && playableStreamsReady
-      && !this.nextEpisodeCardDismissed
-      && !this.loadingVisible
-      && !this.subtitleDialogVisible
-      && !this.audioDialogVisible
-      && !this.speedDialogVisible
-      && !this.sourcesPanelVisible
-      && !this.episodePanelVisible
-      && !this.moreActionsVisible
-      && !this.nextEpisodeLaunching
+      nextEpisode &&
+      this.shouldShowNextEpisodeCard() &&
+      playableStreamsReady &&
+      !this.nextEpisodeCardDismissed &&
+      !this.loadingVisible &&
+      !this.subtitleDialogVisible &&
+      !this.audioDialogVisible &&
+      !this.speedDialogVisible &&
+      !this.sourcesPanelVisible &&
+      !this.episodePanelVisible &&
+      !this.moreActionsVisible &&
+      !this.nextEpisodeLaunching
     );
   },
 
@@ -4999,18 +5417,22 @@ export const PlayerScreen = {
       const cached = cache.get(cacheKey);
       return Array.isArray(cached) ? cached.map((stream) => ({ ...stream })) : [];
     }
-    const loadPromises = this.streamCandidatesLoadPromises || (this.streamCandidatesLoadPromises = new Map());
+    const loadPromises =
+      this.streamCandidatesLoadPromises || (this.streamCandidatesLoadPromises = new Map());
     if (loadPromises.has(cacheKey)) {
       const loaded = await loadPromises.get(cacheKey);
       return Array.isArray(loaded) ? loaded.map((stream) => ({ ...stream })) : [];
     }
 
-    const loadPromise = streamRepository.getStreamsFromAllAddons(normalizedType, normalizedVideoId)
+    const loadPromise = streamRepository
+      .getStreamsFromAllAddons(normalizedType, normalizedVideoId)
       .then((streamResult) => {
-        const streamItems = (streamResult?.status === "success")
-          ? flattenStreamGroups(streamResult)
-          : [];
-        cache.set(cacheKey, streamItems.map((stream) => ({ ...stream })));
+        const streamItems =
+          streamResult?.status === "success" ? flattenStreamGroups(streamResult) : [];
+        cache.set(
+          cacheKey,
+          streamItems.map((stream) => ({ ...stream }))
+        );
         return streamItems;
       })
       .finally(() => {
@@ -5025,7 +5447,12 @@ export const PlayerScreen = {
   async playNextEpisode() {
     const nextEpisode = this.resolveNextEpisodeInfo();
     const itemType = normalizeItemType(this.params?.itemType || "movie");
-    if (!nextEpisode?.videoId || itemType !== "series" || nextEpisode.hasAired === false || this.nextEpisodeLaunching) {
+    if (
+      !nextEpisode?.videoId ||
+      itemType !== "series" ||
+      nextEpisode.hasAired === false ||
+      this.nextEpisodeLaunching
+    ) {
       return;
     }
 
@@ -5034,7 +5461,8 @@ export const PlayerScreen = {
       title: this.params?.playerTitle || this.params?.itemTitle || this.params?.itemId || "Nuvio",
       subtitle: nextEpisode.episodeTitle || nextEpisode.episodeLabel || "",
       logoUrl: this.params?.playerLogoUrl || this.params?.logo || "",
-      backdropUrl: this.params?.playerBackdropUrl || this.params?.backdrop || this.params?.poster || ""
+      backdropUrl:
+        this.params?.playerBackdropUrl || this.params?.backdrop || this.params?.poster || ""
     };
     this.loadingVisible = true;
     this.updateLoadingVisibility();
@@ -5061,32 +5489,37 @@ export const PlayerScreen = {
         return;
       }
       const currentAddonName = this.getCurrentStreamCandidate()?.addonName || "";
-      const bestStreamCandidate = this.selectBestStreamCandidateForAddon(streamItems, currentAddonName)
-        || this.selectBestStreamCandidate(streamItems)
-        || streamItems[0];
+      const bestStreamCandidate =
+        this.selectBestStreamCandidateForAddon(streamItems, currentAddonName) ||
+        this.selectBestStreamCandidate(streamItems) ||
+        streamItems[0];
       const bestStream = bestStreamCandidate?.url || bestStreamCandidate?.externalUrl || null;
       await PlayerController.flushCurrentProgress({ forceCloudSync: true });
-      Router.navigate("player", {
-        streamUrl: bestStream,
-        itemId: this.params?.itemId,
-        itemType,
-        imdbId: this.params?.imdbId || null,
-        videoId: nextEpisode.videoId,
-        season: nextEpisode.season,
-        episode: nextEpisode.episode,
-        episodeLabel: nextEpisode.episodeLabel || null,
-        playerTitle: this.params?.playerTitle || this.params?.itemId,
-        playerSubtitle: nextEpisode.episodeTitle || nextEpisode.episodeLabel || "",
-        playerEpisodeTitle: nextEpisode.episodeTitle || "",
-        playerBackdropUrl: this.params?.playerBackdropUrl || null,
-        playerLogoUrl: this.params?.playerLogoUrl || null,
-        episodes: this.episodes || [],
-        streamCandidates: streamItems,
-        nextEpisodeVideoId: null,
-        nextEpisodeLabel: null
-      }, {
-        replaceHistory: true
-      });
+      Router.navigate(
+        "player",
+        {
+          streamUrl: bestStream,
+          itemId: this.params?.itemId,
+          itemType,
+          imdbId: this.params?.imdbId || null,
+          videoId: nextEpisode.videoId,
+          season: nextEpisode.season,
+          episode: nextEpisode.episode,
+          episodeLabel: nextEpisode.episodeLabel || null,
+          playerTitle: this.params?.playerTitle || this.params?.itemId,
+          playerSubtitle: nextEpisode.episodeTitle || nextEpisode.episodeLabel || "",
+          playerEpisodeTitle: nextEpisode.episodeTitle || "",
+          playerBackdropUrl: this.params?.playerBackdropUrl || null,
+          playerLogoUrl: this.params?.playerLogoUrl || null,
+          episodes: this.episodes || [],
+          streamCandidates: streamItems,
+          nextEpisodeVideoId: null,
+          nextEpisodeLabel: null
+        },
+        {
+          replaceHistory: true
+        }
+      );
     } catch (error) {
       console.warn("Next episode play failed", error);
       this.nextEpisodeLaunching = false;
@@ -5128,7 +5561,8 @@ export const PlayerScreen = {
     }
     try {
       this.audioContext = this.audioContext || new AudioContextCtor();
-      this.audioMediaSource = this.audioMediaSource || this.audioContext.createMediaElementSource(video);
+      this.audioMediaSource =
+        this.audioMediaSource || this.audioContext.createMediaElementSource(video);
       this.audioGainNode = this.audioGainNode || this.audioContext.createGain();
       this.audioMediaSource.connect(this.audioGainNode);
       this.audioGainNode.connect(this.audioContext.destination);
@@ -5142,8 +5576,9 @@ export const PlayerScreen = {
 
   applyAudioAmplification() {
     if (Number(this.audioAmplificationDb || 0) <= 0) {
-      this.audioAmplificationAvailable = supportsTvWebAudioAmplification()
-        && typeof (globalThis.AudioContext || globalThis.webkitAudioContext) === "function";
+      this.audioAmplificationAvailable =
+        supportsTvWebAudioAmplification() &&
+        typeof (globalThis.AudioContext || globalThis.webkitAudioContext) === "function";
       if (this.audioGainNode) {
         try {
           this.audioGainNode.gain.value = 1;
@@ -5182,7 +5617,9 @@ export const PlayerScreen = {
     const boldShadow = style.bold
       ? `0.45px 0 0 ${subtitleColor}, -0.45px 0 0 ${subtitleColor}, 0 0.45px 0 ${subtitleColor}, 0 -0.45px 0 ${subtitleColor}`
       : "";
-    const outlineShadow = style.outlineEnabled ? `0 0 2px ${outlineColor}, 0 0 4px ${outlineColor}` : "";
+    const outlineShadow = style.outlineEnabled
+      ? `0 0 2px ${outlineColor}, 0 0 4px ${outlineColor}`
+      : "";
     const subtitleShadow = [outlineShadow, boldShadow].filter(Boolean).join(", ") || "none";
     const subtitleFontSize = normalizeSubtitleFontSize(style.fontSize);
     uiRoot.style.setProperty("--player-subtitle-color", String(style.textColor || "#FFFFFF"));
@@ -5190,13 +5627,19 @@ export const PlayerScreen = {
     uiRoot.style.setProperty("--player-subtitle-font-size", `${subtitleFontSize}%`);
     uiRoot.style.setProperty("--player-subtitle-font-weight", subtitleFontWeight);
     uiRoot.style.setProperty("--player-subtitle-shadow", subtitleShadow);
-    uiRoot.style.setProperty("--player-subtitle-offset", `${(verticalOffset.residualOffset * -2).toFixed(2)}vh`);
+    uiRoot.style.setProperty(
+      "--player-subtitle-offset",
+      `${(verticalOffset.residualOffset * -2).toFixed(2)}vh`
+    );
     video.style.setProperty("--player-subtitle-color", String(style.textColor || "#FFFFFF"));
     video.style.setProperty("--player-subtitle-outline-color", outlineColor);
     video.style.setProperty("--player-subtitle-font-size", `${subtitleFontSize}%`);
     video.style.setProperty("--player-subtitle-font-weight", subtitleFontWeight);
     video.style.setProperty("--player-subtitle-shadow", subtitleShadow);
-    video.style.setProperty("--player-subtitle-offset", `${(verticalOffset.residualOffset * -2).toFixed(2)}vh`);
+    video.style.setProperty(
+      "--player-subtitle-offset",
+      `${(verticalOffset.residualOffset * -2).toFixed(2)}vh`
+    );
     this.refreshSubtitleCueStyles();
     if (refreshTrackRendering) {
       this.refreshSubtitleTrackRendering();
@@ -5364,8 +5807,8 @@ export const PlayerScreen = {
     const column = ((value - 1) % 3) + 1;
     const row = Math.ceil(value / 3);
     return {
-      line: row === 3 ? 10 : (row === 2 ? 50 : 90),
-      align: column === 1 ? "start" : (column === 3 ? "end" : "center")
+      line: row === 3 ? 10 : row === 2 ? 50 : 90,
+      align: column === 1 ? "start" : column === 3 ? "end" : "center"
     };
   },
 
@@ -5424,18 +5867,22 @@ export const PlayerScreen = {
     if (!track || !cue || typeof text !== "string") {
       return false;
     }
-    const CueCtor = typeof VTTCue === "function"
-      ? VTTCue
-      : (typeof TextTrackCue === "function" ? TextTrackCue : null);
+    const CueCtor =
+      typeof VTTCue === "function"
+        ? VTTCue
+        : typeof TextTrackCue === "function"
+          ? TextTrackCue
+          : null;
     if (!CueCtor || typeof track.removeCue !== "function" || typeof track.addCue !== "function") {
       return false;
     }
     try {
       const replacement = new CueCtor(cue.startTime, cue.endTime, text);
       this.copySubtitleCuePresentation(cue, replacement);
-      const snapshot = this.subtitleCueOriginalState instanceof WeakMap
-        ? this.subtitleCueOriginalState.get(cue)
-        : null;
+      const snapshot =
+        this.subtitleCueOriginalState instanceof WeakMap
+          ? this.subtitleCueOriginalState.get(cue)
+          : null;
       if (snapshot && this.subtitleCueOriginalState instanceof WeakMap) {
         this.subtitleCueOriginalState.set(replacement, snapshot);
       }
@@ -5526,7 +5973,10 @@ export const PlayerScreen = {
       if (!track) {
         return;
       }
-      if (typeof track.addEventListener === "function" && !this.subtitleCueStyleBindings.has(track)) {
+      if (
+        typeof track.addEventListener === "function" &&
+        !this.subtitleCueStyleBindings.has(track)
+      ) {
         const handler = () => {
           this.syncSubtitleCueStylesForTrack(track);
         };
@@ -5545,9 +5995,10 @@ export const PlayerScreen = {
     if (Environment.isWebOS()) {
       return;
     }
-    const restoreTrackMode = typeof requestAnimationFrame === "function"
-      ? requestAnimationFrame
-      : (callback) => setTimeout(callback, 16);
+    const restoreTrackMode =
+      typeof requestAnimationFrame === "function"
+        ? requestAnimationFrame
+        : (callback) => setTimeout(callback, 16);
     this.getSubtitleCueTrackList().forEach((track) => {
       if (!track || track.mode !== "showing") {
         return;
@@ -5566,9 +6017,11 @@ export const PlayerScreen = {
       });
     });
 
-    if (Environment.isWebOS()
-      && this.selectedEmbeddedSubtitleTrackIndex >= 0
-      && typeof PlayerController.setWebOsEmbeddedSubtitleTrack === "function") {
+    if (
+      Environment.isWebOS() &&
+      this.selectedEmbeddedSubtitleTrackIndex >= 0 &&
+      typeof PlayerController.setWebOsEmbeddedSubtitleTrack === "function"
+    ) {
       const selectedIndex = this.selectedEmbeddedSubtitleTrackIndex;
       setTimeout(() => {
         if (this.selectedEmbeddedSubtitleTrackIndex !== selectedIndex) {
@@ -5585,7 +6038,12 @@ export const PlayerScreen = {
     if (!modalBackdrop) {
       return;
     }
-    const hasModal = this.subtitleDialogVisible || this.audioDialogVisible || this.sourcesPanelVisible || this.episodePanelVisible || this.speedDialogVisible;
+    const hasModal =
+      this.subtitleDialogVisible ||
+      this.audioDialogVisible ||
+      this.sourcesPanelVisible ||
+      this.episodePanelVisible ||
+      this.speedDialogVisible;
     modalBackdrop.classList.toggle("hidden", !hasModal);
     controlsOverlay?.classList.toggle("modal-blocked", hasModal);
   },
@@ -5596,17 +6054,22 @@ export const PlayerScreen = {
       return;
     }
 
-    const isTizenAvPlayPlayback = () => Boolean(
-      Environment.isTizen()
-      && typeof PlayerController.isUsingAvPlay === "function"
-      && PlayerController.isUsingAvPlay()
-    );
+    const isTizenAvPlayPlayback = () =>
+      Boolean(
+        Environment.isTizen() &&
+        typeof PlayerController.isUsingAvPlay === "function" &&
+        PlayerController.isUsingAvPlay()
+      );
 
     const onWaiting = () => {
       if (this.isStartupErrorVisible()) {
         return;
       }
-      if (isTizenAvPlayPlayback() && this.hasPresentedPlaybackFrame && this.getPlaybackCurrentSeconds() > 0) {
+      if (
+        isTizenAvPlayPlayback() &&
+        this.hasPresentedPlaybackFrame &&
+        this.getPlaybackCurrentSeconds() > 0
+      ) {
         this.loadingVisible = false;
         this.updateLoadingVisibility();
         return;
@@ -5718,9 +6181,10 @@ export const PlayerScreen = {
         this.updateMediaSessionPlaybackState();
         return;
       }
-      const ended = typeof PlayerController.isPlaybackEnded === "function"
-        ? PlayerController.isPlaybackEnded()
-        : Boolean(video.ended);
+      const ended =
+        typeof PlayerController.isPlaybackEnded === "function"
+          ? PlayerController.isPlaybackEnded()
+          : Boolean(video.ended);
       if (ended) {
         return;
       }
@@ -5742,16 +6206,20 @@ export const PlayerScreen = {
         return;
       }
       if (
-        isTizenAvPlayPlayback()
-        && this.loadingVisible
-        && (!this.currentEngineFsStream || this.isEngineFsStartupReady())
+        isTizenAvPlayPlayback() &&
+        this.loadingVisible &&
+        (!this.currentEngineFsStream || this.isEngineFsStartupReady())
       ) {
         this.setLoadingLogoFillTarget(1);
         this.markPlaybackPresentedAfterAdvance();
         this.updateLoadingVisibility();
         this.scheduleLoadingCompletionCheck(180);
       }
-      if (this.currentEngineFsStream && !this.hasPresentedPlaybackFrame && this.isEngineFsStartupReady()) {
+      if (
+        this.currentEngineFsStream &&
+        !this.hasPresentedPlaybackFrame &&
+        this.isEngineFsStartupReady()
+      ) {
         this.setLoadingLogoFillTarget(1);
         this.markPlaybackPresentedAfterAdvance();
         this.updateLoadingVisibility();
@@ -5806,7 +6274,11 @@ export const PlayerScreen = {
 
     const onTrackListChanged = () => {
       this.refreshTrackDialogs();
-      if (this.trackDiscoveryInProgress && this.hasAudioTracksAvailable() && this.hasSubtitleTracksAvailable()) {
+      if (
+        this.trackDiscoveryInProgress &&
+        this.hasAudioTracksAvailable() &&
+        this.hasSubtitleTracksAvailable()
+      ) {
         this.trackDiscoveryInProgress = false;
         this.clearTrackDiscoveryTimer();
         this.refreshTrackDialogs();
@@ -5820,31 +6292,34 @@ export const PlayerScreen = {
       this.seekLoading = false;
       this.seekLoadingBaselineSeconds = null;
       const now = Date.now();
-      if ((now - Number(this.lastPlaybackErrorAt || 0)) < 120) {
+      if (now - Number(this.lastPlaybackErrorAt || 0) < 120) {
         return;
       }
       this.lastPlaybackErrorAt = now;
 
       const detailErrorCode = Number(event?.detail?.mediaErrorCode || 0);
-      const controllerErrorCode = typeof PlayerController.getLastPlaybackErrorCode === "function"
-        ? Number(PlayerController.getLastPlaybackErrorCode() || 0)
-        : 0;
-      const mediaErrorCode = detailErrorCode || Number(video?.error?.code || 0) || controllerErrorCode;
+      const controllerErrorCode =
+        typeof PlayerController.getLastPlaybackErrorCode === "function"
+          ? Number(PlayerController.getLastPlaybackErrorCode() || 0)
+          : 0;
+      const mediaErrorCode =
+        detailErrorCode || Number(video?.error?.code || 0) || controllerErrorCode;
       const avplayError = String(event?.detail?.avplayError || "").toLowerCase();
-      const currentSourceCandidate = this.getStreamCandidateByUrl(this.activePlaybackUrl) || this.getCurrentStreamCandidate();
+      const currentSourceCandidate =
+        this.getStreamCandidateByUrl(this.activePlaybackUrl) || this.getCurrentStreamCandidate();
       const currentEngineFsState = this.currentEngineFsStream || null;
       const publicEngineFsUrl = String(currentEngineFsState?.publicPlaybackUrl || "").trim();
-      const isLocalEngineFsNetworkFailure = currentEngineFsState?.baseUrlKind === "local-service"
-        && publicEngineFsUrl
-        && publicEngineFsUrl !== this.activePlaybackUrl
-        && (
-          mediaErrorCode === 2
-          || avplayError.includes("connection refused")
-          || avplayError.includes("network")
-          || avplayError.includes("failed")
-        );
+      const isLocalEngineFsNetworkFailure =
+        currentEngineFsState?.baseUrlKind === "local-service" &&
+        publicEngineFsUrl &&
+        publicEngineFsUrl !== this.activePlaybackUrl &&
+        (mediaErrorCode === 2 ||
+          avplayError.includes("connection refused") ||
+          avplayError.includes("network") ||
+          avplayError.includes("failed"));
       if (!this.hasPresentedPlaybackFrame && isLocalEngineFsNetworkFailure) {
-        const sourceCandidate = this.getStreamCandidateByUrl(this.activePlaybackUrl) || this.getCurrentStreamCandidate();
+        const sourceCandidate =
+          this.getStreamCandidateByUrl(this.activePlaybackUrl) || this.getCurrentStreamCandidate();
         const engineFs = {
           ...(sourceCandidate?.engineFs || currentEngineFsState),
           playbackUrl: publicEngineFsUrl,
@@ -5861,9 +6336,9 @@ export const PlayerScreen = {
               engineFs
             }
           });
-          this.streamCandidates = this.streamCandidates.map((entry) => (
+          this.streamCandidates = this.streamCandidates.map((entry) =>
             entry.id === sourceCandidate.id ? { ...entry, ...sourceCandidate } : entry
-          ));
+          );
         }
         this.lastPlaybackErrorAt = 0;
         this.loadingVisible = true;
@@ -5899,9 +6374,10 @@ export const PlayerScreen = {
         }
 
         this.markPlaybackSourceFailed(this.activePlaybackUrl);
-        const targetEngine = typeof PlayerController.getAlternativePlaybackEngine === "function"
-          ? PlayerController.getAlternativePlaybackEngine(this.activePlaybackUrl)
-          : null;
+        const targetEngine =
+          typeof PlayerController.getAlternativePlaybackEngine === "function"
+            ? PlayerController.getAlternativePlaybackEngine(this.activePlaybackUrl)
+            : null;
         if (targetEngine) {
           this.lastPlaybackErrorAt = 0;
           this.loadingVisible = true;
@@ -5922,7 +6398,11 @@ export const PlayerScreen = {
           return;
         }
         this.markPlaybackSourceFailed(this.activePlaybackUrl);
-        const startupErrorMessage = this.getStartupErrorMessage(mediaErrorCode, avplayError, currentSourceCandidate);
+        const startupErrorMessage = this.getStartupErrorMessage(
+          mediaErrorCode,
+          avplayError,
+          currentSourceCandidate
+        );
         this.clearPlaybackStallGuard();
         this.releaseStartupAudioGate({ resume: false });
         this.showStartupError(startupErrorMessage, { mediaErrorCode });
@@ -5945,11 +6425,14 @@ export const PlayerScreen = {
       this.setControlsVisible(true, { focus: false });
       this.sourcesError = `${this.mediaErrorMessage(mediaErrorCode, avplayError, currentSourceCandidate)}. Choose another source manually.`;
       if (this.currentEngineFsStream) {
-        logEngineFsDebug("EngineFS playback failed; keeping torrent alive until player exit or source change", {
-          reason: "playback-error",
-          infoHash: this.currentEngineFsStream.infoHash,
-          fileIdx: this.currentEngineFsStream.fileIdx
-        });
+        logEngineFsDebug(
+          "EngineFS playback failed; keeping torrent alive until player exit or source change",
+          {
+            reason: "playback-error",
+            infoHash: this.currentEngineFsStream.infoHash,
+            fileIdx: this.currentEngineFsStream.fileIdx
+          }
+        );
       }
       if (this.currentEngineFsStream) {
         this.renderSourcesPanel();
@@ -5984,7 +6467,9 @@ export const PlayerScreen = {
       this.videoListeners.push({ target: video, eventName, handler });
     });
 
-    const trackTargets = [this.getVideoTextTrackList(), this.getVideoAudioTrackList()].filter(Boolean);
+    const trackTargets = [this.getVideoTextTrackList(), this.getVideoAudioTrackList()].filter(
+      Boolean
+    );
     trackTargets.forEach((target) => {
       if (typeof target.addEventListener !== "function") {
         return;
@@ -6025,24 +6510,41 @@ export const PlayerScreen = {
       });
     }
 
-    base.push({ action: "subtitleDialog", icon: "assets/icons/ic_player_subtitles.svg", title: t("subtitle_dialog_title", {}, "Subtitles") });
+    base.push({
+      action: "subtitleDialog",
+      icon: "assets/icons/ic_player_subtitles.svg",
+      title: t("subtitle_dialog_title", {}, "Subtitles")
+    });
 
     base.push({
       action: "audioTrack",
-      icon: this.selectedAudioTrackIndex >= 0 || this.selectedManifestAudioTrackId
-        ? "assets/icons/ic_player_audio_filled.svg"
-        : "assets/icons/ic_player_audio_outline.svg",
+      icon:
+        this.selectedAudioTrackIndex >= 0 || this.selectedManifestAudioTrackId
+          ? "assets/icons/ic_player_audio_filled.svg"
+          : "assets/icons/ic_player_audio_outline.svg",
       useMask: true,
       title: t("audio_dialog_title", {}, "Audio")
     });
 
-    base.push({ action: "source", icon: "assets/icons/ic_player_source.svg", title: t("sources_title", {}, "Sources") });
+    base.push({
+      action: "source",
+      icon: "assets/icons/ic_player_source.svg",
+      title: t("sources_title", {}, "Sources")
+    });
 
     if (Array.isArray(uiState.episodesAll) && uiState.episodesAll.length) {
-      base.push({ action: "episodes", icon: "assets/icons/ic_player_episodes.svg", title: t("episodes_panel_title", {}, "Episodes") });
+      base.push({
+        action: "episodes",
+        icon: "assets/icons/ic_player_episodes.svg",
+        title: t("episodes_panel_title", {}, "Episodes")
+      });
     }
 
-    base.push({ action: "more", label: this.moreActionsVisible ? "<" : ">", title: t("player_more_actions_title", {}, "More Actions") });
+    base.push({
+      action: "more",
+      label: this.moreActionsVisible ? "<" : ">",
+      title: t("player_more_actions_title", {}, "More Actions")
+    });
 
     if (!this.moreActionsVisible) {
       return base;
@@ -6050,8 +6552,16 @@ export const PlayerScreen = {
 
     return [
       ...base.slice(0, Math.max(0, base.length - 1)),
-      { action: "speed", label: `${Number(PlayerController.video?.playbackRate || 1).toFixed(Number(PlayerController.video?.playbackRate || 1) % 1 ? 2 : 0)}x`, title: t("player_playback_speed", {}, "Playback speed") },
-      { action: "aspect", icon: "assets/icons/ic_player_aspect_ratio.svg", title: t("player_more_aspect_ratio", {}, "Aspect Ratio") },
+      {
+        action: "speed",
+        label: `${Number(PlayerController.video?.playbackRate || 1).toFixed(Number(PlayerController.video?.playbackRate || 1) % 1 ? 2 : 0)}x`,
+        title: t("player_playback_speed", {}, "Playback speed")
+      },
+      {
+        action: "aspect",
+        icon: "assets/icons/ic_player_aspect_ratio.svg",
+        title: t("player_more_aspect_ratio", {}, "Aspect Ratio")
+      },
       { action: "backFromMore", label: "<", title: t("player_go_back", {}, "Back") }
     ];
   },
@@ -6066,26 +6576,40 @@ export const PlayerScreen = {
     }
 
     const controls = this.getControlDefinitions();
-    if (this.stickyProgressFocus && this.controlsVisible && !this.isDialogOpen() && this.isSeekBarAvailable()) {
+    if (
+      this.stickyProgressFocus &&
+      this.controlsVisible &&
+      !this.isDialogOpen() &&
+      this.isSeekBarAvailable()
+    ) {
       this.controlFocusZone = "progress";
     }
     this.controlFocusIndex = clamp(this.controlFocusIndex, 0, Math.max(0, controls.length - 1));
 
-    wrap.innerHTML = controls.map((control) => `
+    wrap.innerHTML = controls
+      .map(
+        (control) => `
       <button class="player-control-btn focusable${control.primary ? " is-primary" : ""}"
               data-action="${control.action}"
               title="${escapeHtml(control.title || "")}">
-        ${control.icon
-          ? ((control.primary || control.useMask)
-            ? `<span class="player-control-icon player-control-icon-mask" style="-webkit-mask-image:url('${escapeHtml(control.icon)}');mask-image:url('${escapeHtml(control.icon)}');" aria-hidden="true"></span>`
-            : `<img class="player-control-icon" src="${control.icon}" alt="" aria-hidden="true" />`)
-          : `<span class="player-control-label">${escapeHtml(control.label || "")}</span>`}
+        ${
+          control.icon
+            ? control.primary || control.useMask
+              ? `<span class="player-control-icon player-control-icon-mask" style="-webkit-mask-image:url('${escapeHtml(control.icon)}');mask-image:url('${escapeHtml(control.icon)}');" aria-hidden="true"></span>`
+              : `<img class="player-control-icon" src="${control.icon}" alt="" aria-hidden="true" />`
+            : `<span class="player-control-label">${escapeHtml(control.label || "")}</span>`
+        }
       </button>
-    `).join("");
+    `
+      )
+      .join("");
 
     const buttons = Array.from(wrap.querySelectorAll(".player-control-btn"));
     buttons.forEach((button, index) => {
-      button.classList.toggle("focused", this.controlFocusZone === "buttons" && index === this.controlFocusIndex);
+      button.classList.toggle(
+        "focused",
+        this.controlFocusZone === "buttons" && index === this.controlFocusIndex
+      );
     });
     const progressShell = this.uiRefs?.progressShell;
     if (progressShell) {
@@ -6098,15 +6622,27 @@ export const PlayerScreen = {
           button.blur();
         }
       });
-      if (progressShell && document.activeElement !== progressShell && typeof progressShell.focus === "function") {
+      if (
+        progressShell &&
+        document.activeElement !== progressShell &&
+        typeof progressShell.focus === "function"
+      ) {
         progressShell.focus();
       }
     } else if (this.controlFocusZone === "buttons") {
-      if (progressShell && document.activeElement === progressShell && typeof progressShell.blur === "function") {
+      if (
+        progressShell &&
+        document.activeElement === progressShell &&
+        typeof progressShell.blur === "function"
+      ) {
         progressShell.blur();
       }
       const focusedButton = buttons[this.controlFocusIndex] || null;
-      if (focusedButton && document.activeElement !== focusedButton && typeof focusedButton.focus === "function") {
+      if (
+        focusedButton &&
+        document.activeElement !== focusedButton &&
+        typeof focusedButton.focus === "function"
+      ) {
         focusedButton.focus();
       }
     } else if (this.controlFocusZone === "skipIntro") {
@@ -6115,7 +6651,11 @@ export const PlayerScreen = {
           button.blur();
         }
       });
-      if (progressShell && document.activeElement === progressShell && typeof progressShell.blur === "function") {
+      if (
+        progressShell &&
+        document.activeElement === progressShell &&
+        typeof progressShell.blur === "function"
+      ) {
         progressShell.blur();
       }
     }
@@ -6124,7 +6664,13 @@ export const PlayerScreen = {
   },
 
   isDialogOpen() {
-    return this.subtitleDialogVisible || this.audioDialogVisible || this.sourcesPanelVisible || this.episodePanelVisible || this.speedDialogVisible;
+    return (
+      this.subtitleDialogVisible ||
+      this.audioDialogVisible ||
+      this.sourcesPanelVisible ||
+      this.episodePanelVisible ||
+      this.speedDialogVisible
+    );
   },
 
   setControlsVisible(visible, { focus = false } = {}) {
@@ -6156,7 +6702,7 @@ export const PlayerScreen = {
     this.controlFocusZone = "buttons";
     this.controlFocusIndex = 0;
     this.renderControlButtons();
-    const firstButton = this.container.querySelector('.player-control-btn[data-action]');
+    const firstButton = this.container.querySelector(".player-control-btn[data-action]");
     firstButton?.focus?.();
   },
 
@@ -6169,7 +6715,11 @@ export const PlayerScreen = {
       return;
     }
     const activeElement = document.activeElement;
-    if (activeElement && activeElement !== document.body && typeof activeElement.blur === "function") {
+    if (
+      activeElement &&
+      activeElement !== document.body &&
+      typeof activeElement.blur === "function"
+    ) {
       activeElement.blur();
     }
     this.stickyProgressFocus = true;
@@ -6187,7 +6737,9 @@ export const PlayerScreen = {
       if (!this.controlsVisible || this.controlFocusZone !== "progress") {
         return;
       }
-      const buttons = Array.from(this.uiRefs?.controlButtons?.querySelectorAll?.(".player-control-btn") || []);
+      const buttons = Array.from(
+        this.uiRefs?.controlButtons?.querySelectorAll?.(".player-control-btn") || []
+      );
       buttons.forEach((button) => {
         button.classList.remove("focused");
         if (typeof button.blur === "function") {
@@ -6212,13 +6764,18 @@ export const PlayerScreen = {
     if (this.seekLoading) {
       return !this.isExternalFrameMode() && !this.isStartupErrorVisible();
     }
-    if (!this.loadingVisible || !this.hasPresentedPlaybackFrame || this.isExternalFrameMode() || this.isStartupErrorVisible()) {
+    if (
+      !this.loadingVisible ||
+      !this.hasPresentedPlaybackFrame ||
+      this.isExternalFrameMode() ||
+      this.isStartupErrorVisible()
+    ) {
       return false;
     }
     const currentSeconds = Number(this.getPlaybackCurrentSeconds());
     const baselineSeconds = Number(this.bufferingSpinnerBaselineSeconds);
     if (Number.isFinite(currentSeconds) && Number.isFinite(baselineSeconds)) {
-      if (currentSeconds > (baselineSeconds + STARTUP_PLAYBACK_ADVANCE_EPSILON_SECONDS)) {
+      if (currentSeconds > baselineSeconds + STARTUP_PLAYBACK_ADVANCE_EPSILON_SECONDS) {
         return false;
       }
     }
@@ -6260,16 +6817,29 @@ export const PlayerScreen = {
 
   scheduleBufferingSpinnerRefresh(delayMs = BUFFERING_SPINNER_STALL_MS) {
     this.clearBufferingSpinnerTimer();
-    if (!this.loadingVisible || !this.hasPresentedPlaybackFrame || this.isExternalFrameMode() || this.isStartupErrorVisible()) {
+    if (
+      !this.loadingVisible ||
+      !this.hasPresentedPlaybackFrame ||
+      this.isExternalFrameMode() ||
+      this.isStartupErrorVisible()
+    ) {
       return;
     }
-    this.bufferingSpinnerTimer = setTimeout(() => {
-      this.bufferingSpinnerTimer = null;
-      if (!this.loadingVisible || !this.hasPresentedPlaybackFrame || this.isExternalFrameMode() || this.isStartupErrorVisible()) {
-        return;
-      }
-      this.updateLoadingVisibility();
-    }, Math.max(0, Number(delayMs || 0)));
+    this.bufferingSpinnerTimer = setTimeout(
+      () => {
+        this.bufferingSpinnerTimer = null;
+        if (
+          !this.loadingVisible ||
+          !this.hasPresentedPlaybackFrame ||
+          this.isExternalFrameMode() ||
+          this.isStartupErrorVisible()
+        ) {
+          return;
+        }
+        this.updateLoadingVisibility();
+      },
+      Math.max(0, Number(delayMs || 0))
+    );
   },
 
   enableStartupAudioGate() {
@@ -6286,7 +6856,11 @@ export const PlayerScreen = {
   },
 
   isPlaybackStartupSettled() {
-    if (!this.hasPresentedPlaybackFrame || this.pendingPlaybackRestore || this.startupAudioGateActive) {
+    if (
+      !this.hasPresentedPlaybackFrame ||
+      this.pendingPlaybackRestore ||
+      this.startupAudioGateActive
+    ) {
       return false;
     }
     return true;
@@ -6313,7 +6887,7 @@ export const PlayerScreen = {
       this.startupPlaybackBaselineSeconds = current;
       return false;
     }
-    if ((current - baseline) >= STARTUP_PLAYBACK_ADVANCE_EPSILON_SECONDS) {
+    if (current - baseline >= STARTUP_PLAYBACK_ADVANCE_EPSILON_SECONDS) {
       this.startupPlaybackHasAdvanced = true;
       return true;
     }
@@ -6342,10 +6916,10 @@ export const PlayerScreen = {
 
   isStartupLogoDismissReady() {
     return Boolean(
-      this.hasPresentedPlaybackFrame
-      && this.startupPlaybackHasAdvanced
-      && !this.pendingPlaybackRestore
-      && !this.startupAudioGateActive
+      this.hasPresentedPlaybackFrame &&
+      this.startupPlaybackHasAdvanced &&
+      !this.pendingPlaybackRestore &&
+      !this.startupAudioGateActive
     );
   },
 
@@ -6353,9 +6927,10 @@ export const PlayerScreen = {
     if (!this.startupAudioGateActive || this.pendingPlaybackRestore) {
       return false;
     }
-    const readyState = typeof PlayerController.getPlaybackReadyState === "function"
-      ? Number(PlayerController.getPlaybackReadyState() || 0)
-      : Number(PlayerController.video?.readyState || 0);
+    const readyState =
+      typeof PlayerController.getPlaybackReadyState === "function"
+        ? Number(PlayerController.getPlaybackReadyState() || 0)
+        : Number(PlayerController.video?.readyState || 0);
     return Number.isFinite(readyState) && readyState >= 3;
   },
 
@@ -6364,55 +6939,58 @@ export const PlayerScreen = {
     if (!this.loadingVisible || this.isExternalFrameMode()) {
       return;
     }
-    this.loadingCompletionTimer = setTimeout(() => {
-      this.loadingCompletionTimer = null;
-      if (!this.loadingVisible || this.isExternalFrameMode()) {
-        return;
-      }
-      if (this.isStartupGateReleaseReady()) {
-        this.releaseStartupAudioGate();
-        this.scheduleLoadingCompletionCheck(120, { force: true });
-        return;
-      }
-      const fillProgress = Number(this.loadingLogoFillProgress || 0);
-      if (fillProgress >= 1 && !this.isPlaybackStartupSettled()) {
-        this.markPlaybackPresentedAfterAdvance();
-        if (this.isStartupLogoDismissReady()) {
-          this.loadingVisible = false;
-          this.updateLoadingVisibility();
-          this.updateUiTick();
-          setTimeout(() => this.maybeShowParentalGuideOverlay(), 80);
+    this.loadingCompletionTimer = setTimeout(
+      () => {
+        this.loadingCompletionTimer = null;
+        if (!this.loadingVisible || this.isExternalFrameMode()) {
           return;
         }
+        if (this.isStartupGateReleaseReady()) {
+          this.releaseStartupAudioGate();
+          this.scheduleLoadingCompletionCheck(120, { force: true });
+          return;
+        }
+        const fillProgress = Number(this.loadingLogoFillProgress || 0);
+        if (fillProgress >= 1 && !this.isPlaybackStartupSettled()) {
+          this.markPlaybackPresentedAfterAdvance();
+          if (this.isStartupLogoDismissReady()) {
+            this.loadingVisible = false;
+            this.updateLoadingVisibility();
+            this.updateUiTick();
+            setTimeout(() => this.maybeShowParentalGuideOverlay(), 80);
+            return;
+          }
+          this.updateUiTick();
+          this.scheduleLoadingCompletionCheck(180, { force: true });
+          return;
+        }
+        if (!force && !this.isPlaybackStartupSettled()) {
+          this.scheduleLoadingCompletionCheck(250);
+          return;
+        }
+        if (this.loadingProgress != null && fillProgress < 1) {
+          this.loadingProgress = 1;
+          this.setLoadingLogoFillTarget(1);
+          this.scheduleLoadingCompletionCheck(180, { force: true });
+          return;
+        }
+        if (!this.markPlaybackPresentedAfterAdvance()) {
+          this.scheduleLoadingCompletionCheck(120, { force: true });
+          return;
+        }
+        const currentFillProgress = Number(this.loadingLogoFillProgress || 0);
+        const currentFillTarget = Number(this.loadingLogoFillTarget || 0);
+        if (currentFillTarget >= 1 && currentFillProgress < 0.995) {
+          this.scheduleLoadingCompletionCheck(120, { force: true });
+          return;
+        }
+        this.loadingVisible = false;
+        this.updateLoadingVisibility();
         this.updateUiTick();
-        this.scheduleLoadingCompletionCheck(180, { force: true });
-        return;
-      }
-      if (!force && !this.isPlaybackStartupSettled()) {
-        this.scheduleLoadingCompletionCheck(250);
-        return;
-      }
-      if (this.loadingProgress != null && fillProgress < 1) {
-        this.loadingProgress = 1;
-        this.setLoadingLogoFillTarget(1);
-        this.scheduleLoadingCompletionCheck(180, { force: true });
-        return;
-      }
-      if (!this.markPlaybackPresentedAfterAdvance()) {
-        this.scheduleLoadingCompletionCheck(120, { force: true });
-        return;
-      }
-      const currentFillProgress = Number(this.loadingLogoFillProgress || 0);
-      const currentFillTarget = Number(this.loadingLogoFillTarget || 0);
-      if (currentFillTarget >= 1 && currentFillProgress < 0.995) {
-        this.scheduleLoadingCompletionCheck(120, { force: true });
-        return;
-      }
-      this.loadingVisible = false;
-      this.updateLoadingVisibility();
-      this.updateUiTick();
-      setTimeout(() => this.maybeShowParentalGuideOverlay(), 80);
-    }, Math.max(0, Number(delayMs || 0)));
+        setTimeout(() => this.maybeShowParentalGuideOverlay(), 80);
+      },
+      Math.max(0, Number(delayMs || 0))
+    );
   },
 
   clearControlsAutoHide() {
@@ -6452,9 +7030,10 @@ export const PlayerScreen = {
   },
 
   isPlaybackFrameReady() {
-    const readyState = typeof PlayerController.getPlaybackReadyState === "function"
-      ? Number(PlayerController.getPlaybackReadyState() || 0)
-      : Number(PlayerController.video?.readyState || 0);
+    const readyState =
+      typeof PlayerController.getPlaybackReadyState === "function"
+        ? Number(PlayerController.getPlaybackReadyState() || 0)
+        : Number(PlayerController.video?.readyState || 0);
     return Number.isFinite(readyState) && readyState >= 2;
   },
 
@@ -6463,10 +7042,10 @@ export const PlayerScreen = {
       return true;
     }
     const currentSeconds = Number(this.getPlaybackCurrentSeconds() || 0);
-    return this.isPlaybackFrameReady()
-      || (this.hasKnownPlaybackDuration()
-      && Number.isFinite(currentSeconds)
-      && currentSeconds > 0.2);
+    return (
+      this.isPlaybackFrameReady() ||
+      (this.hasKnownPlaybackDuration() && Number.isFinite(currentSeconds) && currentSeconds > 0.2)
+    );
   },
 
   seekPlaybackSeconds(seconds) {
@@ -6500,9 +7079,7 @@ export const PlayerScreen = {
     }
     this.pendingPlaybackRestore = null;
     const currentSeconds = this.getPlaybackCurrentSeconds();
-    this.startupPlaybackBaselineSeconds = Number.isFinite(currentSeconds)
-      ? currentSeconds
-      : null;
+    this.startupPlaybackBaselineSeconds = Number.isFinite(currentSeconds) ? currentSeconds : null;
     this.startupPlaybackHasAdvanced = false;
     if (restore.paused) {
       PlayerController.pause();
@@ -6525,19 +7102,23 @@ export const PlayerScreen = {
     }
 
     const durationSeconds = this.getPlaybackDurationSeconds();
-    const targetSeconds = Number.isFinite(durationSeconds) && durationSeconds > 0
-      ? Math.max(0, Math.min(requestedSeconds, Math.max(0, durationSeconds - 3)))
-      : requestedSeconds;
+    const targetSeconds =
+      Number.isFinite(durationSeconds) && durationSeconds > 0
+        ? Math.max(0, Math.min(requestedSeconds, Math.max(0, durationSeconds - 3)))
+        : requestedSeconds;
     const currentSeconds = this.getPlaybackCurrentSeconds();
     const toleranceSeconds = Math.max(1.5, Math.min(8, targetSeconds * 0.03));
 
-    if (Number.isFinite(currentSeconds) && currentSeconds >= Math.max(0, targetSeconds - toleranceSeconds)) {
+    if (
+      Number.isFinite(currentSeconds) &&
+      currentSeconds >= Math.max(0, targetSeconds - toleranceSeconds)
+    ) {
       this.finalizePendingPlaybackRestore(restore);
       return;
     }
 
     const now = Date.now();
-    if (!force && (now - Number(restore.lastAttemptAt || 0)) < 700) {
+    if (!force && now - Number(restore.lastAttemptAt || 0) < 700) {
       return;
     }
 
@@ -6570,16 +7151,14 @@ export const PlayerScreen = {
     const showStartupOverlay = this.isStartupLoadingVisible();
     const showBufferingSpinner = this.isBufferingSpinnerVisible();
     const preserveProgressFocus = Boolean(
-      showStartupOverlay
-      && this.controlsVisible
-      && this.stickyProgressFocus
-      && this.controlFocusZone === "progress"
-      && this.hasPresentedPlaybackFrame
+      showStartupOverlay &&
+      this.controlsVisible &&
+      this.stickyProgressFocus &&
+      this.controlFocusZone === "progress" &&
+      this.hasPresentedPlaybackFrame
     );
     const preserveHiddenSeekOverlay = Boolean(
-      showStartupOverlay
-      && !this.controlsVisible
-      && this.isSeekOverlaySuppressingControls()
+      showStartupOverlay && !this.controlsVisible && this.isSeekOverlaySuppressingControls()
     );
     overlay.classList.toggle("hidden", !showStartupOverlay);
     overlay.classList.remove("seek-only", "logo-only");
@@ -6597,7 +7176,11 @@ export const PlayerScreen = {
     }
     if (showStartupOverlay) {
       this.dismissPauseOverlay();
-      if (!preserveProgressFocus && !preserveHiddenSeekOverlay && (this.seekOverlayVisible || this.seekPreviewSeconds != null)) {
+      if (
+        !preserveProgressFocus &&
+        !preserveHiddenSeekOverlay &&
+        (this.seekOverlayVisible || this.seekPreviewSeconds != null)
+      ) {
         this.cancelSeekPreview({ commit: false });
       }
       if (!preserveProgressFocus && this.controlFocusZone === "progress") {
@@ -6640,11 +7223,15 @@ export const PlayerScreen = {
       return;
     }
 
-    const titleLine = [nextEpisode.episodeLabel, nextEpisode.episodeTitle].filter(Boolean).join(" • ");
+    const titleLine = [nextEpisode.episodeLabel, nextEpisode.episodeTitle]
+      .filter(Boolean)
+      .join(" • ");
     const statusText = nextEpisode.hasAired
       ? t("next_episode_play", {}, "Play")
       : t("next_episode_unaired", {}, "Unaired");
-    const thumb = this.episodes.find((entry) => String(entry?.id || "") === String(nextEpisode.videoId || ""))?.thumbnail || "";
+    const thumb =
+      this.episodes.find((entry) => String(entry?.id || "") === String(nextEpisode.videoId || ""))
+        ?.thumbnail || "";
 
     card.innerHTML = `
       <div class="player-next-episode-card-inner${nextEpisode.hasAired ? " focusable is-playable" : ""}${!this.controlsVisible ? " is-selected" : ""}"${nextEpisode.hasAired ? ' data-player-pointer-action="nextEpisode"' : ""}>
@@ -6677,9 +7264,12 @@ export const PlayerScreen = {
     this.updateActiveSkipInterval(current);
     this.updateSkipIntroCountdown(Date.now());
     const duration = this.getPlaybackDurationSeconds();
-    const effectiveProgressSeconds = this.controlsVisible && this.controlFocusZone === "progress" && this.seekPreviewSeconds != null
-      ? Number(this.seekPreviewSeconds)
-      : current;
+    const effectiveProgressSeconds =
+      this.controlsVisible &&
+      this.controlFocusZone === "progress" &&
+      this.seekPreviewSeconds != null
+        ? Number(this.seekPreviewSeconds)
+        : current;
     const progress = duration > 0 ? clamp(effectiveProgressSeconds / duration, 0, 1) : 0;
     const uiRefs = this.uiRefs || {};
     const uiState = this.lastUiTickState || (this.lastUiTickState = {});
@@ -6709,9 +7299,14 @@ export const PlayerScreen = {
     const endsAt = uiRefs.endsAt;
     if (endsAt) {
       const remainingMs = Math.max(0, (Number(duration || 0) - Number(current || 0)) * 1000);
-      const nextEndsAtMinuteBucket = duration > 0 ? Math.floor((Date.now() + remainingMs) / 60000) : -1;
+      const nextEndsAtMinuteBucket =
+        duration > 0 ? Math.floor((Date.now() + remainingMs) / 60000) : -1;
       if (uiState.endsAtMinuteBucket !== nextEndsAtMinuteBucket) {
-        const nextEndsAtText = t("player_ends_at", [formatEndsAt(current, duration)], "Ends at %1$s");
+        const nextEndsAtText = t(
+          "player_ends_at",
+          [formatEndsAt(current, duration)],
+          "Ends at %1$s"
+        );
         endsAt.textContent = nextEndsAtText;
         uiState.endsAtText = nextEndsAtText;
         uiState.endsAtMinuteBucket = nextEndsAtMinuteBucket;
@@ -6723,9 +7318,12 @@ export const PlayerScreen = {
       if (overlayClock && overlayClock.textContent !== uiState.clockText) {
         overlayClock.textContent = uiState.clockText || "--:--";
       }
-      const overlayEndsAt = this.uiRefs?.pauseOverlay?.querySelector(".player-pause-overlay-ends-at");
+      const overlayEndsAt = this.uiRefs?.pauseOverlay?.querySelector(
+        ".player-pause-overlay-ends-at"
+      );
       if (overlayEndsAt && overlayEndsAt.textContent !== uiState.endsAtText) {
-        overlayEndsAt.textContent = uiState.endsAtText || t("player_ends_at", ["--:--"], "Ends at %1$s");
+        overlayEndsAt.textContent =
+          uiState.endsAtText || t("player_ends_at", ["--:--"], "Ends at %1$s");
       }
     }
 
@@ -6755,15 +7353,17 @@ export const PlayerScreen = {
     }
 
     const duration = this.getPlaybackDurationSeconds();
-    const currentPreview = this.seekPreviewSeconds != null
-      ? Number(this.seekPreviewSeconds)
-      : this.getPlaybackCurrentSeconds();
+    const currentPreview =
+      this.seekPreviewSeconds != null
+        ? Number(this.seekPreviewSeconds)
+        : this.getPlaybackCurrentSeconds();
 
     const shouldShowOverlay = this.seekOverlayVisible && !this.controlsVisible;
     overlay.classList.toggle("hidden", !shouldShowOverlay);
     const uiState = this.lastUiTickState || (this.lastUiTickState = {});
     const nextPreviewText = `${formatTime(currentPreview)} / ${formatTime(duration)}`;
-    const nextDirectionText = this.seekPreviewDirection < 0 ? "<<" : this.seekPreviewDirection > 0 ? ">>" : "";
+    const nextDirectionText =
+      this.seekPreviewDirection < 0 ? "<<" : this.seekPreviewDirection > 0 ? ">>" : "";
     if (uiState.seekPreviewText !== nextPreviewText) {
       previewNode.textContent = nextPreviewText;
       uiState.seekPreviewText = nextPreviewText;
@@ -6796,18 +7396,19 @@ export const PlayerScreen = {
     this.seekPreviewDirection = direction;
     this.seekRepeatCount += 1;
 
-    const stepSeconds = this.seekRepeatCount >= 18
-      ? 120
-      : this.seekRepeatCount >= 12
-        ? 60
-        : this.seekRepeatCount >= 7
-          ? 30
-          : this.seekRepeatCount >= 3
-            ? 20
-            : 10;
+    const stepSeconds =
+      this.seekRepeatCount >= 18
+        ? 120
+        : this.seekRepeatCount >= 12
+          ? 60
+          : this.seekRepeatCount >= 7
+            ? 30
+            : this.seekRepeatCount >= 3
+              ? 20
+              : 10;
     const duration = this.getPlaybackDurationSeconds();
     const base = this.seekPreviewSeconds == null ? currentTime : Number(this.seekPreviewSeconds);
-    let next = base + (direction * stepSeconds);
+    let next = base + direction * stepSeconds;
     if (duration > 0) {
       next = clamp(next, 0, duration);
     } else {
@@ -7102,7 +7703,16 @@ export const PlayerScreen = {
     }
   },
 
-  async playStreamByUrl(streamUrl, { preservePanel = false, resetSilentAudioState = true, preservePlaybackState = false, forceEngine = null, sourceCandidate: explicitSourceCandidate = null } = {}) {
+  async playStreamByUrl(
+    streamUrl,
+    {
+      preservePanel = false,
+      resetSilentAudioState = true,
+      preservePlaybackState = false,
+      forceEngine = null,
+      sourceCandidate: explicitSourceCandidate = null
+    } = {}
+  ) {
     if (this.isExternalFrameMode()) {
       return;
     }
@@ -7114,13 +7724,26 @@ export const PlayerScreen = {
     if (selectedIndex >= 0) {
       this.currentStreamIndex = selectedIndex;
     }
-    const sourceCandidate = explicitSourceCandidate || this.getStreamCandidateByUrl(streamUrl) || this.getCurrentStreamCandidate();
+    const sourceCandidate =
+      explicitSourceCandidate ||
+      this.getStreamCandidateByUrl(streamUrl) ||
+      this.getCurrentStreamCandidate();
     const nextEngineFsState = this.getEngineFsStateForStream(sourceCandidate);
-    const sameEngineFsState = this.isSameEngineFsState(this.currentEngineFsStream, nextEngineFsState);
-    if (this.currentEngineFsStream && !this.isSameEngineFsState(this.currentEngineFsStream, nextEngineFsState)) {
-      const removePreviousTorrent = !nextEngineFsState
-        || String(this.currentEngineFsStream.infoHash || "").toLowerCase() !== String(nextEngineFsState.infoHash || "").toLowerCase();
-      await this.releaseCurrentEngineFsStream("source-change", { removeTorrent: removePreviousTorrent });
+    const sameEngineFsState = this.isSameEngineFsState(
+      this.currentEngineFsStream,
+      nextEngineFsState
+    );
+    if (
+      this.currentEngineFsStream &&
+      !this.isSameEngineFsState(this.currentEngineFsStream, nextEngineFsState)
+    ) {
+      const removePreviousTorrent =
+        !nextEngineFsState ||
+        String(this.currentEngineFsStream.infoHash || "").toLowerCase() !==
+          String(nextEngineFsState.infoHash || "").toLowerCase();
+      await this.releaseCurrentEngineFsStream("source-change", {
+        removeTorrent: removePreviousTorrent
+      });
     }
     if (!sameEngineFsState) {
       if (this.engineFsStartupRetryTimer) {
@@ -7148,9 +7771,10 @@ export const PlayerScreen = {
     if (preservePlaybackState) {
       const restoreTimeSeconds = this.getPlaybackCurrentSeconds();
       const video = PlayerController.video;
-      const usingAvPlay = typeof PlayerController.isUsingAvPlay === "function"
-        ? PlayerController.isUsingAvPlay()
-        : false;
+      const usingAvPlay =
+        typeof PlayerController.isUsingAvPlay === "function"
+          ? PlayerController.isUsingAvPlay()
+          : false;
       this.pendingPlaybackRestore = {
         timeSeconds: Number.isFinite(restoreTimeSeconds) ? restoreTimeSeconds : 0,
         paused: Boolean(this.paused || (!usingAvPlay && video?.paused)),
@@ -7246,7 +7870,8 @@ export const PlayerScreen = {
       };
       const canUseEngineFs = WebOsEngineFsResolver.canResolveStream(streamCandidate);
       const canUseTizenP2p = TizenStreamingServerResolver.canResolveStream(streamCandidate);
-      const canUseP2p = Boolean(TorrentSettingsStore.get().p2pEnabled) && (canUseEngineFs || canUseTizenP2p);
+      const canUseP2p =
+        Boolean(TorrentSettingsStore.get().p2pEnabled) && (canUseEngineFs || canUseTizenP2p);
       let fallbackError = "";
 
       if (DirectDebridResolver.canResolveStream(streamCandidate, resolveContext)) {
@@ -7262,9 +7887,10 @@ export const PlayerScreen = {
             raw: { ...(streamCandidate.raw || {}), ...(result.stream.raw || {}) }
           });
         } else {
-          fallbackError = result.status === "not_cached"
-            ? t("stream.debrid.notCached", {}, "Not cached on this service.")
-            : result.status === "stale"
+          fallbackError =
+            result.status === "not_cached"
+              ? t("stream.debrid.notCached", {}, "Not cached on this service.")
+              : result.status === "stale"
                 ? t("stream.debrid.stale", {}, "This Debrid result expired. Refreshing streams.")
                 : t("stream.debrid.failed", {}, "Could not resolve this Debrid stream.");
         }
@@ -7292,16 +7918,26 @@ export const PlayerScreen = {
           console.warn("PlayerScreen: P2P resolve failed", {
             status: result.status,
             detail: result.detail || "",
-            infoHash: streamCandidate.infoHash || streamCandidate.raw?.infoHash || streamCandidate.clientResolve?.infoHash || streamCandidate.raw?.clientResolve?.infoHash || "",
+            infoHash:
+              streamCandidate.infoHash ||
+              streamCandidate.raw?.infoHash ||
+              streamCandidate.clientResolve?.infoHash ||
+              streamCandidate.raw?.clientResolve?.infoHash ||
+              "",
             fileIdx: streamCandidate.fileIdx ?? streamCandidate.raw?.fileIdx ?? null
           });
         }
       }
 
       if (!targetUrl) {
-        const startupMessage = fallbackError
-          || (canUseP2p
-            ? t("player_error_failed_start_torrent", [t("player_error_playback_fallback", {}, "Playback error")], "Failed to start torrent: %1$s")
+        const startupMessage =
+          fallbackError ||
+          (canUseP2p
+            ? t(
+                "player_error_failed_start_torrent",
+                [t("player_error_playback_fallback", {}, "Playback error")],
+                "Failed to start torrent: %1$s"
+              )
             : t("player_error_playback_fallback", {}, "Playback error"));
         if (!this.hasPresentedPlaybackFrame) {
           this.showStartupError(startupMessage);
@@ -7309,14 +7945,19 @@ export const PlayerScreen = {
         }
         this.sourcesError = canUseP2p
           ? t("stream.p2p.failed", {}, "Could not start this torrent stream.")
-          : (fallbackError || t("stream.debrid.unavailable", {}, "This Debrid source needs a configured Debrid account."));
+          : fallbackError ||
+            t(
+              "stream.debrid.unavailable",
+              {},
+              "This Debrid source needs a configured Debrid account."
+            );
         this.renderSourcesPanel();
         return;
       }
 
-      this.streamCandidates = this.streamCandidates.map((entry) => (
+      this.streamCandidates = this.streamCandidates.map((entry) =>
         entry.id === streamCandidate.id ? { ...entry, ...streamCandidate } : entry
-      ));
+      );
     }
     await this.playStreamByUrl(targetUrl, {
       ...options,
@@ -7356,7 +7997,11 @@ export const PlayerScreen = {
     }
   },
 
-  mediaErrorMessage(errorCode = 0, detail = "", streamCandidate = this.getCurrentStreamCandidate()) {
+  mediaErrorMessage(
+    errorCode = 0,
+    detail = "",
+    streamCandidate = this.getCurrentStreamCandidate()
+  ) {
     const code = Number(errorCode || 0);
     if (code === 1) return "Playback aborted";
     if (code === 2) return "Network error";
@@ -7367,10 +8012,10 @@ export const PlayerScreen = {
       }
       const text = String(detail || "").toLowerCase();
       if (
-        text.includes("no supported source")
-        || text.includes("no supported sources")
-        || text.includes("not supported")
-        || text.includes("unsupported")
+        text.includes("no supported source") ||
+        text.includes("no supported sources") ||
+        text.includes("not supported") ||
+        text.includes("unsupported")
       ) {
         return t("player_error_source_not_supported", {}, "Source not supported on this TV");
       }
@@ -7405,9 +8050,9 @@ export const PlayerScreen = {
     if (this.seekLoading) {
       const seekBaselineSeconds = Number(this.seekLoadingBaselineSeconds);
       if (
-        Number.isFinite(currentSeconds)
-        && Number.isFinite(seekBaselineSeconds)
-        && currentSeconds > (seekBaselineSeconds + STARTUP_PLAYBACK_ADVANCE_EPSILON_SECONDS)
+        Number.isFinite(currentSeconds) &&
+        Number.isFinite(seekBaselineSeconds) &&
+        currentSeconds > seekBaselineSeconds + STARTUP_PLAYBACK_ADVANCE_EPSILON_SECONDS
       ) {
         this.seekLoading = false;
         this.seekLoadingBaselineSeconds = null;
@@ -7425,9 +8070,16 @@ export const PlayerScreen = {
   getCurrentEngineFsStatsUrl() {
     const state = this.currentEngineFsStream || null;
     const playbackUrl = String(state?.playbackUrl || this.activePlaybackUrl || "").trim();
-    const infoHash = String(state?.infoHash || "").trim().toLowerCase();
+    const infoHash = String(state?.infoHash || "")
+      .trim()
+      .toLowerCase();
     const fileIdx = Number(state?.fileIdx);
-    if (!playbackUrl || !/^[0-9a-f]{40}$/.test(infoHash) || !Number.isFinite(fileIdx) || fileIdx < 0) {
+    if (
+      !playbackUrl ||
+      !/^[0-9a-f]{40}$/.test(infoHash) ||
+      !Number.isFinite(fileIdx) ||
+      fileIdx < 0
+    ) {
       return "";
     }
     try {
@@ -7531,19 +8183,23 @@ export const PlayerScreen = {
     const previous = this.lastEngineFsStallStats || null;
     this.lastEngineFsStallStats = snapshot;
 
-    const progressIncreased = previous
-      && snapshot.progress >= 0
-      && previous.progress >= 0
-      && snapshot.progress > previous.progress + 0.000001;
-    const downloadedIncreased = previous
-      && snapshot.downloaded >= 0
-      && previous.downloaded >= 0
-      && snapshot.downloaded > previous.downloaded;
-    const activelyDownloading = snapshot.downloadSpeed > 0 || progressIncreased || downloadedIncreased;
-    const swarmIsAlive = snapshot.peers > 0
-      || snapshot.unique > 0
-      || snapshot.connectionTries > 0
-      || snapshot.peerSearchRunning;
+    const progressIncreased =
+      previous &&
+      snapshot.progress >= 0 &&
+      previous.progress >= 0 &&
+      snapshot.progress > previous.progress + 0.000001;
+    const downloadedIncreased =
+      previous &&
+      snapshot.downloaded >= 0 &&
+      previous.downloaded >= 0 &&
+      snapshot.downloaded > previous.downloaded;
+    const activelyDownloading =
+      snapshot.downloadSpeed > 0 || progressIncreased || downloadedIncreased;
+    const swarmIsAlive =
+      snapshot.peers > 0 ||
+      snapshot.unique > 0 ||
+      snapshot.connectionTries > 0 ||
+      snapshot.peerSearchRunning;
 
     if (activelyDownloading) {
       return true;
@@ -7560,20 +8216,24 @@ export const PlayerScreen = {
 
     const previous = this.lastEngineFsStartupErrorStats || null;
     this.lastEngineFsStartupErrorStats = snapshot;
-    const progressIncreased = previous
-      && snapshot.progress >= 0
-      && previous.progress >= 0
-      && snapshot.progress > previous.progress + 0.000001;
-    const downloadedIncreased = previous
-      && snapshot.downloaded >= 0
-      && previous.downloaded >= 0
-      && snapshot.downloaded > previous.downloaded;
+    const progressIncreased =
+      previous &&
+      snapshot.progress >= 0 &&
+      previous.progress >= 0 &&
+      snapshot.progress > previous.progress + 0.000001;
+    const downloadedIncreased =
+      previous &&
+      snapshot.downloaded >= 0 &&
+      previous.downloaded >= 0 &&
+      snapshot.downloaded > previous.downloaded;
     const hasDownloadedData = snapshot.downloaded > 0;
-    const activelyDownloading = snapshot.downloadSpeed > 0 || progressIncreased || downloadedIncreased;
-    const swarmIsAlive = snapshot.peers > 0
-      || snapshot.unique > 0
-      || snapshot.connectionTries > 0
-      || snapshot.peerSearchRunning;
+    const activelyDownloading =
+      snapshot.downloadSpeed > 0 || progressIncreased || downloadedIncreased;
+    const swarmIsAlive =
+      snapshot.peers > 0 ||
+      snapshot.unique > 0 ||
+      snapshot.connectionTries > 0 ||
+      snapshot.peerSearchRunning;
 
     return retryCount < 10 && (activelyDownloading || hasDownloadedData || swarmIsAlive);
   },
@@ -7589,9 +8249,10 @@ export const PlayerScreen = {
 
     this.engineFsStartupErrorRetries = Number(this.engineFsStartupErrorRetries || 0) + 1;
     const retry = this.engineFsStartupErrorRetries;
-    const delayMs = Math.min(18000, 4500 + (retry * 2500));
+    const delayMs = Math.min(18000, 4500 + retry * 2500);
     const retryUrl = this.activePlaybackUrl;
-    const sourceCandidate = this.getStreamCandidateByUrl(retryUrl) || this.getCurrentStreamCandidate();
+    const sourceCandidate =
+      this.getStreamCandidateByUrl(retryUrl) || this.getCurrentStreamCandidate();
     const snapshot = this.getEngineFsStallSnapshot(stats);
 
     this.lastPlaybackErrorAt = 0;
@@ -7614,7 +8275,11 @@ export const PlayerScreen = {
 
     this.engineFsStartupRetryTimer = setTimeout(() => {
       this.engineFsStartupRetryTimer = null;
-      if (this.hasPresentedPlaybackFrame || this.activePlaybackUrl !== retryUrl || !this.currentEngineFsStream) {
+      if (
+        this.hasPresentedPlaybackFrame ||
+        this.activePlaybackUrl !== retryUrl ||
+        !this.currentEngineFsStream
+      ) {
         return;
       }
       void this.playStreamByUrl(retryUrl, {
@@ -7649,18 +8314,20 @@ export const PlayerScreen = {
       return;
     }
     const startup = !this.hasPresentedPlaybackFrame;
-    const timeoutMs = Number.isFinite(Number(timeoutOverrideMs)) && Number(timeoutOverrideMs) > 0
-      ? Number(timeoutOverrideMs)
-      : this.getPlaybackStallTimeoutMs({ startup });
+    const timeoutMs =
+      Number.isFinite(Number(timeoutOverrideMs)) && Number(timeoutOverrideMs) > 0
+        ? Number(timeoutOverrideMs)
+        : this.getPlaybackStallTimeoutMs({ startup });
     this.playbackStallTimer = setTimeout(async () => {
       this.playbackStallTimer = null;
       if (this.isExternalFrameMode() || !this.loadingVisible || !this.activePlaybackUrl) {
         return;
       }
 
-      const readyState = typeof PlayerController.getPlaybackReadyState === "function"
-        ? Number(PlayerController.getPlaybackReadyState() || 0)
-        : Number(PlayerController.video?.readyState || 0);
+      const readyState =
+        typeof PlayerController.getPlaybackReadyState === "function"
+          ? Number(PlayerController.getPlaybackReadyState() || 0)
+          : Number(PlayerController.video?.readyState || 0);
       if (startup) {
         if (this.markPlaybackPresentedAfterAdvance()) {
           this.loadingVisible = false;
@@ -7694,9 +8361,10 @@ export const PlayerScreen = {
         }
       }
 
-      const targetEngine = typeof PlayerController.getAlternativePlaybackEngine === "function"
-        ? PlayerController.getAlternativePlaybackEngine(this.activePlaybackUrl)
-        : null;
+      const targetEngine =
+        typeof PlayerController.getAlternativePlaybackEngine === "function"
+          ? PlayerController.getAlternativePlaybackEngine(this.activePlaybackUrl)
+          : null;
       if (targetEngine) {
         console.warn("Playback stalled; switching player engine", {
           url: this.activePlaybackUrl,
@@ -7715,15 +8383,23 @@ export const PlayerScreen = {
       if (startup) {
         this.markPlaybackSourceFailed(this.activePlaybackUrl);
         const mediaErrorCode = Number(PlayerController.getLastPlaybackErrorCode?.() || 0);
-        const sourceCandidate = this.getStreamCandidateByUrl(this.activePlaybackUrl) || this.getCurrentStreamCandidate();
-        const startupErrorMessage = this.getStartupErrorMessage(mediaErrorCode, "", sourceCandidate);
+        const sourceCandidate =
+          this.getStreamCandidateByUrl(this.activePlaybackUrl) || this.getCurrentStreamCandidate();
+        const startupErrorMessage = this.getStartupErrorMessage(
+          mediaErrorCode,
+          "",
+          sourceCandidate
+        );
         this.showStartupError(startupErrorMessage, { mediaErrorCode });
         if (this.currentEngineFsStream) {
-          logEngineFsDebug("EngineFS playback stalled during startup; keeping torrent alive until player exit or source change", {
-            reason: "playback-stall",
-            infoHash: this.currentEngineFsStream.infoHash,
-            fileIdx: this.currentEngineFsStream.fileIdx
-          });
+          logEngineFsDebug(
+            "EngineFS playback stalled during startup; keeping torrent alive until player exit or source change",
+            {
+              reason: "playback-stall",
+              infoHash: this.currentEngineFsStream.infoHash,
+              fileIdx: this.currentEngineFsStream.fileIdx
+            }
+          );
         }
         return;
       }
@@ -7735,15 +8411,19 @@ export const PlayerScreen = {
       this.updateMediaSessionPlaybackState();
       this.setControlsVisible(true, { focus: false });
       {
-        const sourceCandidate = this.getStreamCandidateByUrl(this.activePlaybackUrl) || this.getCurrentStreamCandidate();
+        const sourceCandidate =
+          this.getStreamCandidateByUrl(this.activePlaybackUrl) || this.getCurrentStreamCandidate();
         this.sourcesError = `${this.mediaErrorMessage(PlayerController.getLastPlaybackErrorCode?.() || 0, "", sourceCandidate)}. Choose another source manually.`;
       }
       if (this.currentEngineFsStream) {
-        logEngineFsDebug("EngineFS playback stalled; keeping torrent alive until player exit or source change", {
-          reason: "playback-stall",
-          infoHash: this.currentEngineFsStream.infoHash,
-          fileIdx: this.currentEngineFsStream.fileIdx
-        });
+        logEngineFsDebug(
+          "EngineFS playback stalled; keeping torrent alive until player exit or source change",
+          {
+            reason: "playback-stall",
+            infoHash: this.currentEngineFsStream.infoHash,
+            fileIdx: this.currentEngineFsStream.fileIdx
+          }
+        );
       }
       if (this.currentEngineFsStream) {
         this.renderSourcesPanel();
@@ -7789,27 +8469,30 @@ export const PlayerScreen = {
   hasAudioTracksAvailable() {
     let dashCount = 0;
     try {
-      dashCount = typeof PlayerController.getDashAudioTracks === "function"
-        ? PlayerController.getDashAudioTracks().length
-        : 0;
+      dashCount =
+        typeof PlayerController.getDashAudioTracks === "function"
+          ? PlayerController.getDashAudioTracks().length
+          : 0;
     } catch (_) {
       dashCount = 0;
     }
 
     let avplayCount = 0;
     try {
-      avplayCount = typeof PlayerController.getAvPlayAudioTracks === "function"
-        ? PlayerController.getAvPlayAudioTracks().length
-        : 0;
+      avplayCount =
+        typeof PlayerController.getAvPlayAudioTracks === "function"
+          ? PlayerController.getAvPlayAudioTracks().length
+          : 0;
     } catch (_) {
       avplayCount = 0;
     }
 
     let hlsCount = 0;
     try {
-      hlsCount = typeof PlayerController.getHlsAudioTracks === "function"
-        ? PlayerController.getHlsAudioTracks().length
-        : 0;
+      hlsCount =
+        typeof PlayerController.getHlsAudioTracks === "function"
+          ? PlayerController.getHlsAudioTracks().length
+          : 0;
     } catch (_) {
       hlsCount = 0;
     }
@@ -7820,39 +8503,44 @@ export const PlayerScreen = {
     } catch (_) {
       nativeCount = 0;
     }
-    return dashCount > 0
-      || avplayCount > 0
-      || hlsCount > 0
-      || nativeCount > 0
-      || (this.canDiscoverEmbeddedAudioTracks() && this.embeddedAudioTracks.length > 0)
-      || this.manifestAudioTracks.length > 0
-      || Boolean(this.getImplicitAudioEntry());
+    return (
+      dashCount > 0 ||
+      avplayCount > 0 ||
+      hlsCount > 0 ||
+      nativeCount > 0 ||
+      (this.canDiscoverEmbeddedAudioTracks() && this.embeddedAudioTracks.length > 0) ||
+      this.manifestAudioTracks.length > 0 ||
+      Boolean(this.getImplicitAudioEntry())
+    );
   },
 
   hasSubtitleTracksAvailable() {
     let dashCount = 0;
     try {
-      dashCount = typeof PlayerController.getDashTextTracks === "function"
-        ? PlayerController.getDashTextTracks().length
-        : 0;
+      dashCount =
+        typeof PlayerController.getDashTextTracks === "function"
+          ? PlayerController.getDashTextTracks().length
+          : 0;
     } catch (_) {
       dashCount = 0;
     }
 
     let avplayCount = 0;
     try {
-      avplayCount = typeof PlayerController.getAvPlaySubtitleTracks === "function"
-        ? PlayerController.getAvPlaySubtitleTracks().length
-        : 0;
+      avplayCount =
+        typeof PlayerController.getAvPlaySubtitleTracks === "function"
+          ? PlayerController.getAvPlaySubtitleTracks().length
+          : 0;
     } catch (_) {
       avplayCount = 0;
     }
 
     let hlsCount = 0;
     try {
-      hlsCount = typeof PlayerController.getHlsSubtitleTracks === "function"
-        ? PlayerController.getHlsSubtitleTracks().length
-        : 0;
+      hlsCount =
+        typeof PlayerController.getHlsSubtitleTracks === "function"
+          ? PlayerController.getHlsSubtitleTracks().length
+          : 0;
     } catch (_) {
       hlsCount = 0;
     }
@@ -7862,13 +8550,15 @@ export const PlayerScreen = {
     } catch (_) {
       nativeCount = 0;
     }
-    return dashCount > 0
-      || avplayCount > 0
-      || hlsCount > 0
-      || nativeCount > 0
-      || this.shouldUseEmbeddedSubtitleTracks()
-      || this.manifestSubtitleTracks.length > 0
-      || this.subtitles.length > 0;
+    return (
+      dashCount > 0 ||
+      avplayCount > 0 ||
+      hlsCount > 0 ||
+      nativeCount > 0 ||
+      this.shouldUseEmbeddedSubtitleTracks() ||
+      this.manifestSubtitleTracks.length > 0 ||
+      this.subtitles.length > 0
+    );
   },
 
   clearTrackDiscoveryTimer() {
@@ -7883,7 +8573,8 @@ export const PlayerScreen = {
     this.trackDiscoveryToken = token;
     this.trackDiscoveryInProgress = true;
     this.trackDiscoveryStartedAt = Date.now();
-    this.trackDiscoveryDeadline = this.trackDiscoveryStartedAt + Math.max(500, Number(durationMs || 0));
+    this.trackDiscoveryDeadline =
+      this.trackDiscoveryStartedAt + Math.max(500, Number(durationMs || 0));
     this.clearTrackDiscoveryTimer();
 
     const tick = () => {
@@ -7892,24 +8583,27 @@ export const PlayerScreen = {
       }
 
       const now = Date.now();
-      const shouldRetryEmbeddedSubtitles = this.canDiscoverEmbeddedSubtitleTracks()
-        && this.embeddedSubtitleTracks.length <= 0
-        && !this.embeddedSubtitleLoading;
+      const shouldRetryEmbeddedSubtitles =
+        this.canDiscoverEmbeddedSubtitleTracks() &&
+        this.embeddedSubtitleTracks.length <= 0 &&
+        !this.embeddedSubtitleLoading;
       if (
-        shouldRetryEmbeddedSubtitles
-        && (now - Number(this.lastEmbeddedTrackRetryAt || 0)) >= 1200
+        shouldRetryEmbeddedSubtitles &&
+        now - Number(this.lastEmbeddedTrackRetryAt || 0) >= 1200
       ) {
         this.lastEmbeddedTrackRetryAt = now;
         this.loadEmbeddedSubtitleTracks();
       }
 
-      const doneByData = this.hasSubtitleTracksAvailable()
-        || (this.hasAudioTracksAvailable() && !shouldRetryEmbeddedSubtitles);
-      const doneByIdle = !this.subtitleLoading
-        && !this.embeddedSubtitleLoading
-        && !this.manifestLoading
-        && !shouldRetryEmbeddedSubtitles
-        && (now - Number(this.trackDiscoveryStartedAt || 0)) >= 1200;
+      const doneByData =
+        this.hasSubtitleTracksAvailable() ||
+        (this.hasAudioTracksAvailable() && !shouldRetryEmbeddedSubtitles);
+      const doneByIdle =
+        !this.subtitleLoading &&
+        !this.embeddedSubtitleLoading &&
+        !this.manifestLoading &&
+        !shouldRetryEmbeddedSubtitles &&
+        now - Number(this.trackDiscoveryStartedAt || 0) >= 1200;
       const doneByTimeout = now >= this.trackDiscoveryDeadline;
       this.refreshTrackDialogs();
 
@@ -7928,7 +8622,7 @@ export const PlayerScreen = {
 
   ensureTrackDataWarmup(force = false) {
     const now = Date.now();
-    if (!force && (now - Number(this.lastTrackWarmupAt || 0)) < 1200) {
+    if (!force && now - Number(this.lastTrackWarmupAt || 0) < 1200) {
       return;
     }
     if (!force && (this.subtitleLoading || this.embeddedSubtitleLoading || this.manifestLoading)) {
@@ -7938,7 +8632,9 @@ export const PlayerScreen = {
     this.lastTrackWarmupAt = now;
     this.loadSubtitles();
     this.loadEmbeddedSubtitleTracks();
-    this.loadManifestTrackDataForCurrentStream(this.activePlaybackUrl || this.getCurrentStreamCandidate()?.url || null);
+    this.loadManifestTrackDataForCurrentStream(
+      this.activePlaybackUrl || this.getCurrentStreamCandidate()?.url || null
+    );
     this.startTrackDiscoveryWindow();
   },
 
@@ -7960,19 +8656,19 @@ export const PlayerScreen = {
   async loadEmbeddedSubtitleTracks() {
     const probeUrl = this.getTrackProbeUrl();
     if (
-      probeUrl
-      && this.embeddedTrackRequestPromise
-      && this.embeddedTrackRequestUrl === probeUrl
-      && this.embeddedSubtitleLoading
+      probeUrl &&
+      this.embeddedTrackRequestPromise &&
+      this.embeddedTrackRequestUrl === probeUrl &&
+      this.embeddedSubtitleLoading
     ) {
       return this.embeddedTrackRequestPromise;
     }
 
     const requestToken = (this.embeddedSubtitleLoadToken || 0) + 1;
     const preserveExistingTracks = Boolean(
-      probeUrl
-      && probeUrl === this.lastEmbeddedTrackProbeUrl
-      && (this.embeddedSubtitleTracks.length > 0 || this.embeddedAudioTracks.length > 0)
+      probeUrl &&
+      probeUrl === this.lastEmbeddedTrackProbeUrl &&
+      (this.embeddedSubtitleTracks.length > 0 || this.embeddedAudioTracks.length > 0)
     );
     this.embeddedSubtitleLoadToken = requestToken;
     this.embeddedSubtitleLoading = true;
@@ -7998,14 +8694,20 @@ export const PlayerScreen = {
       }
 
       this.lastEmbeddedTrackProbeUrl = probeUrl;
-      this.embeddedSubtitleTracks = canLoadSubtitleTracks ? this.normalizeEmbeddedSubtitleTracks(tracks) : [];
-      this.embeddedAudioTracks = canLoadAudioTracks ? this.normalizeEmbeddedAudioTracks(tracks) : [];
-      const selectedEmbeddedSubtitleTrack = typeof PlayerController.getSelectedWebOsEmbeddedSubtitleTrackIndex === "function"
-        ? PlayerController.getSelectedWebOsEmbeddedSubtitleTrackIndex()
-        : -1;
-      const selectedEmbeddedAudioTrack = typeof PlayerController.getSelectedWebOsEmbeddedAudioTrackIndex === "function"
-        ? PlayerController.getSelectedWebOsEmbeddedAudioTrackIndex()
-        : -1;
+      this.embeddedSubtitleTracks = canLoadSubtitleTracks
+        ? this.normalizeEmbeddedSubtitleTracks(tracks)
+        : [];
+      this.embeddedAudioTracks = canLoadAudioTracks
+        ? this.normalizeEmbeddedAudioTracks(tracks)
+        : [];
+      const selectedEmbeddedSubtitleTrack =
+        typeof PlayerController.getSelectedWebOsEmbeddedSubtitleTrackIndex === "function"
+          ? PlayerController.getSelectedWebOsEmbeddedSubtitleTrackIndex()
+          : -1;
+      const selectedEmbeddedAudioTrack =
+        typeof PlayerController.getSelectedWebOsEmbeddedAudioTrackIndex === "function"
+          ? PlayerController.getSelectedWebOsEmbeddedAudioTrackIndex()
+          : -1;
       this.selectedEmbeddedSubtitleTrackIndex = Number.isFinite(selectedEmbeddedSubtitleTrack)
         ? selectedEmbeddedSubtitleTrack
         : -1;
@@ -8013,29 +8715,31 @@ export const PlayerScreen = {
         ? selectedEmbeddedAudioTrack
         : -1;
       this.refreshTrackDialogs();
-    })().catch((error) => {
-      console.warn("Embedded subtitle discovery failed", error);
-      if (requestToken !== this.embeddedSubtitleLoadToken) {
-        return;
-      }
-      if (!preserveExistingTracks) {
-        this.embeddedSubtitleTracks = [];
-        this.embeddedAudioTracks = [];
-        this.selectedEmbeddedSubtitleTrackIndex = -1;
-        this.selectedEmbeddedAudioTrackIndex = -1;
-      }
-      this.refreshTrackDialogs();
-    }).finally(() => {
-      if (requestToken === this.embeddedSubtitleLoadToken) {
-        this.embeddedSubtitleLoading = false;
-        this.embeddedAudioLoading = false;
+    })()
+      .catch((error) => {
+        console.warn("Embedded subtitle discovery failed", error);
+        if (requestToken !== this.embeddedSubtitleLoadToken) {
+          return;
+        }
+        if (!preserveExistingTracks) {
+          this.embeddedSubtitleTracks = [];
+          this.embeddedAudioTracks = [];
+          this.selectedEmbeddedSubtitleTrackIndex = -1;
+          this.selectedEmbeddedAudioTrackIndex = -1;
+        }
         this.refreshTrackDialogs();
-      }
-      if (this.embeddedTrackRequestPromise === requestPromise) {
-        this.embeddedTrackRequestPromise = null;
-        this.embeddedTrackRequestUrl = "";
-      }
-    });
+      })
+      .finally(() => {
+        if (requestToken === this.embeddedSubtitleLoadToken) {
+          this.embeddedSubtitleLoading = false;
+          this.embeddedAudioLoading = false;
+          this.refreshTrackDialogs();
+        }
+        if (this.embeddedTrackRequestPromise === requestPromise) {
+          this.embeddedTrackRequestPromise = null;
+          this.embeddedTrackRequestUrl = "";
+        }
+      });
 
     this.embeddedTrackRequestPromise = requestPromise;
     this.embeddedTrackRequestUrl = probeUrl;
@@ -8087,10 +8791,10 @@ export const PlayerScreen = {
   ensureEmbeddedTrackLookupCache() {
     const cache = this.trackDialogCache || (this.trackDialogCache = createTrackDialogCache());
     if (
-      cache.embeddedAudioByNativeIndex
-      && cache.embeddedAudioByEmbeddedIndex
-      && cache.embeddedSubtitleByNativeIndex
-      && cache.embeddedSubtitleByEmbeddedIndex
+      cache.embeddedAudioByNativeIndex &&
+      cache.embeddedAudioByEmbeddedIndex &&
+      cache.embeddedSubtitleByNativeIndex &&
+      cache.embeddedSubtitleByEmbeddedIndex
     ) {
       return cache;
     }
@@ -8138,7 +8842,9 @@ export const PlayerScreen = {
     if (!Number.isFinite(targetIndex) || targetIndex < 0) {
       return null;
     }
-    return this.ensureEmbeddedTrackLookupCache().embeddedAudioByNativeIndex.get(targetIndex) || null;
+    return (
+      this.ensureEmbeddedTrackLookupCache().embeddedAudioByNativeIndex.get(targetIndex) || null
+    );
   },
 
   getEmbeddedAudioTrackByEmbeddedIndex(index) {
@@ -8146,7 +8852,9 @@ export const PlayerScreen = {
     if (!Number.isFinite(targetIndex) || targetIndex < 0) {
       return null;
     }
-    return this.ensureEmbeddedTrackLookupCache().embeddedAudioByEmbeddedIndex.get(targetIndex) || null;
+    return (
+      this.ensureEmbeddedTrackLookupCache().embeddedAudioByEmbeddedIndex.get(targetIndex) || null
+    );
   },
 
   getEmbeddedSubtitleTrackByNativeIndex(index) {
@@ -8154,7 +8862,9 @@ export const PlayerScreen = {
     if (!Number.isFinite(targetIndex) || targetIndex < 0) {
       return null;
     }
-    return this.ensureEmbeddedTrackLookupCache().embeddedSubtitleByNativeIndex.get(targetIndex) || null;
+    return (
+      this.ensureEmbeddedTrackLookupCache().embeddedSubtitleByNativeIndex.get(targetIndex) || null
+    );
   },
 
   getEmbeddedSubtitleTrackByEmbeddedIndex(index) {
@@ -8162,13 +8872,17 @@ export const PlayerScreen = {
     if (!Number.isFinite(targetIndex) || targetIndex < 0) {
       return null;
     }
-    return this.ensureEmbeddedTrackLookupCache().embeddedSubtitleByEmbeddedIndex.get(targetIndex) || null;
+    return (
+      this.ensureEmbeddedTrackLookupCache().embeddedSubtitleByEmbeddedIndex.get(targetIndex) || null
+    );
   },
 
   buildSubtitleTrackSignature(track = {}, fallbackIndex = -1) {
-    const normalizedLanguage = normalizeTrackLanguageCode(
-      track?.language || track?.lang || track?.srclang || ""
-    ) || String(track?.language || track?.lang || track?.srclang || "").trim().toLowerCase();
+    const normalizedLanguage =
+      normalizeTrackLanguageCode(track?.language || track?.lang || track?.srclang || "") ||
+      String(track?.language || track?.lang || track?.srclang || "")
+        .trim()
+        .toLowerCase();
     const normalizedLabel = cleanDisplayText(track?.label || track?.name || "")
       .trim()
       .toLowerCase();
@@ -8214,7 +8928,9 @@ export const PlayerScreen = {
       label: cleanDisplayText(embeddedTrack.label) || track?.label || subtitleLabel(index),
       language: embeddedTrack.language || track?.language || "",
       forced: Boolean(track?.forced) || Boolean(embeddedTrack.forced),
-      secondary: embeddedTrack.secondary || String(embeddedTrack.language || track?.language || "").toUpperCase()
+      secondary:
+        embeddedTrack.secondary ||
+        String(embeddedTrack.language || track?.language || "").toUpperCase()
     };
   },
 
@@ -8262,37 +8978,56 @@ export const PlayerScreen = {
   mergeHlsAudioTrackMetadata(track, index) {
     const hlsLanguage = normalizeTrackLanguageCode(getTrackLanguageValue(track));
     const hlsName = cleanDisplayText(track?.name || track?.label || "");
-    const manifestTrack = this.manifestAudioTracks.find((entry) => {
-      const manifestLanguage = normalizeTrackLanguageCode(getTrackLanguageValue(entry));
-      const manifestName = cleanDisplayText(entry?.name || entry?.label || "");
-      if (hlsLanguage && manifestLanguage && hlsLanguage === manifestLanguage) {
-        return true;
-      }
-      if (hlsName && manifestName && normalizeComparableText(hlsName) === normalizeComparableText(manifestName)) {
-        return true;
-      }
-      return false;
-    }) || this.manifestAudioTracks[index] || null;
+    const manifestTrack =
+      this.manifestAudioTracks.find((entry) => {
+        const manifestLanguage = normalizeTrackLanguageCode(getTrackLanguageValue(entry));
+        const manifestName = cleanDisplayText(entry?.name || entry?.label || "");
+        if (hlsLanguage && manifestLanguage && hlsLanguage === manifestLanguage) {
+          return true;
+        }
+        if (
+          hlsName &&
+          manifestName &&
+          normalizeComparableText(hlsName) === normalizeComparableText(manifestName)
+        ) {
+          return true;
+        }
+        return false;
+      }) ||
+      this.manifestAudioTracks[index] ||
+      null;
     if (!manifestTrack) {
       return track;
     }
     return {
       ...track,
-      label: cleanDisplayText(manifestTrack.label || manifestTrack.name) || track?.label || track?.name || "",
-      name: cleanDisplayText(manifestTrack.name || manifestTrack.label) || track?.name || track?.label || "",
+      label:
+        cleanDisplayText(manifestTrack.label || manifestTrack.name) ||
+        track?.label ||
+        track?.name ||
+        "",
+      name:
+        cleanDisplayText(manifestTrack.name || manifestTrack.label) ||
+        track?.name ||
+        track?.label ||
+        "",
       language: manifestTrack.language || track?.language || track?.lang || "",
       lang: manifestTrack.language || track?.lang || track?.language || "",
       channels: manifestTrack.channels || track?.channels || track?.channelCount || "",
       channelCount: manifestTrack.channels || track?.channelCount || track?.channels || "",
       characteristics: manifestTrack.characteristics || track?.characteristics || "",
-      isDefault: Boolean(manifestTrack.isDefault) || Boolean(track?.isDefault) || Boolean(track?.default),
+      isDefault:
+        Boolean(manifestTrack.isDefault) || Boolean(track?.isDefault) || Boolean(track?.default),
       autoselect: Boolean(manifestTrack.autoselect) || Boolean(track?.autoselect),
       uri: manifestTrack.uri || track?.url || track?.uri || null
     };
   },
 
   revokeExternalSubtitleObjectUrls() {
-    if (!Array.isArray(this.externalSubtitleObjectUrls) || !this.externalSubtitleObjectUrls.length) {
+    if (
+      !Array.isArray(this.externalSubtitleObjectUrls) ||
+      !this.externalSubtitleObjectUrls.length
+    ) {
       return;
     }
     this.externalSubtitleObjectUrls.forEach((url) => {
@@ -8347,9 +9082,7 @@ export const PlayerScreen = {
       return `<${tag}>`;
     };
 
-    const normalized = source
-      .replace(/\\[Nn]/g, "\n")
-      .replace(/\\h/g, " ");
+    const normalized = source.replace(/\\[Nn]/g, "\n").replace(/\\h/g, " ");
 
     const converted = normalized.replace(/\{[^}]*\}/g, (block) => {
       if (!preserveBasicStyle) {
@@ -8388,38 +9121,48 @@ export const PlayerScreen = {
   },
 
   applySubtitleAssAlignmentToVtt(content) {
-    const normalized = String(content || "").replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+    const normalized = String(content || "")
+      .replace(/\r\n/g, "\n")
+      .replace(/\r/g, "\n");
     if (!this.hasSubtitleAssSyntax(normalized)) {
       return normalized;
     }
-    return normalized.split(/\n{2,}/).map((block) => {
-      const alignment = this.getSubtitleAssAlignment(block);
-      const settings = this.buildVttAlignmentSettings(alignment);
-      if (!settings) {
-        return this.sanitizeSubtitleText(block, { preserveBasicStyle: true });
-      }
+    return normalized
+      .split(/\n{2,}/)
+      .map((block) => {
+        const alignment = this.getSubtitleAssAlignment(block);
+        const settings = this.buildVttAlignmentSettings(alignment);
+        if (!settings) {
+          return this.sanitizeSubtitleText(block, { preserveBasicStyle: true });
+        }
 
-      const lines = block.split("\n");
-      const timingIndex = lines.findIndex((line) => line.includes("-->"));
-      if (timingIndex < 0) {
-        return this.sanitizeSubtitleText(block, { preserveBasicStyle: true });
-      }
+        const lines = block.split("\n");
+        const timingIndex = lines.findIndex((line) => line.includes("-->"));
+        if (timingIndex < 0) {
+          return this.sanitizeSubtitleText(block, { preserveBasicStyle: true });
+        }
 
-      const timingLine = lines[timingIndex];
-      const alignmentSettings = this.getSubtitleAssAlignmentSettings(alignment);
-      const nextTimingLine = [
-        /\sline:/i.test(timingLine) ? "" : `line:${alignmentSettings.line}%`,
-        /\salign:/i.test(timingLine) ? "" : `align:${alignmentSettings.align}`
-      ].filter(Boolean).join(" ");
-      if (nextTimingLine) {
-        lines[timingIndex] = `${timingLine} ${nextTimingLine}`;
-      }
-      return this.sanitizeSubtitleText(lines.join("\n"), { preserveBasicStyle: true });
-    }).join("\n\n");
+        const timingLine = lines[timingIndex];
+        const alignmentSettings = this.getSubtitleAssAlignmentSettings(alignment);
+        const nextTimingLine = [
+          /\sline:/i.test(timingLine) ? "" : `line:${alignmentSettings.line}%`,
+          /\salign:/i.test(timingLine) ? "" : `align:${alignmentSettings.align}`
+        ]
+          .filter(Boolean)
+          .join(" ");
+        if (nextTimingLine) {
+          lines[timingIndex] = `${timingLine} ${nextTimingLine}`;
+        }
+        return this.sanitizeSubtitleText(lines.join("\n"), { preserveBasicStyle: true });
+      })
+      .join("\n\n");
   },
 
   convertSrtToVtt(content) {
-    const raw = String(content || "").replace(/^\uFEFF/, "").replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+    const raw = String(content || "")
+      .replace(/^\uFEFF/, "")
+      .replace(/\r\n/g, "\n")
+      .replace(/\r/g, "\n");
     if (!raw.trim()) {
       return "WEBVTT\n\n";
     }
@@ -8439,9 +9182,8 @@ export const PlayerScreen = {
     if (/^(blob:|data:)/i.test(original)) {
       return original;
     }
-    const requestController = typeof AbortController === "function" && Number(timeoutMs) > 0
-      ? new AbortController()
-      : null;
+    const requestController =
+      typeof AbortController === "function" && Number(timeoutMs) > 0 ? new AbortController() : null;
     let requestTimeoutId = null;
     try {
       const requestPromise = fetch(original, {
@@ -8449,30 +9191,34 @@ export const PlayerScreen = {
         headers: this.getSubtitleRequestHeaders(),
         ...(requestController ? { signal: requestController.signal } : {})
       });
-      const response = Number(timeoutMs) > 0
-        ? await Promise.race([
-          requestPromise,
-          new Promise((_, reject) => {
-            requestTimeoutId = setTimeout(() => {
-              try {
-                requestController?.abort();
-              } catch (_) {
-                // Ignore abort failures.
-              }
-              reject(new Error("Subtitle request timed out"));
-            }, Number(timeoutMs));
-          })
-        ])
-        : await requestPromise;
+      const response =
+        Number(timeoutMs) > 0
+          ? await Promise.race([
+              requestPromise,
+              new Promise((_, reject) => {
+                requestTimeoutId = setTimeout(() => {
+                  try {
+                    requestController?.abort();
+                  } catch (_) {
+                    // Ignore abort failures.
+                  }
+                  reject(new Error("Subtitle request timed out"));
+                }, Number(timeoutMs));
+              })
+            ])
+          : await requestPromise;
       if (!response.ok) {
         return original;
       }
       const body = await response.text();
       const contentType = String(response.headers?.get("content-type") || "").toLowerCase();
-      const shouldConvertToVtt = this.isLikelySrtSubtitleUrl(original)
-        || contentType.includes("subrip")
-        || (!contentType.includes("vtt") && !/^\s*WEBVTT/i.test(body));
-      const vttText = shouldConvertToVtt ? this.convertSrtToVtt(body) : this.applySubtitleAssAlignmentToVtt(body);
+      const shouldConvertToVtt =
+        this.isLikelySrtSubtitleUrl(original) ||
+        contentType.includes("subrip") ||
+        (!contentType.includes("vtt") && !/^\s*WEBVTT/i.test(body));
+      const vttText = shouldConvertToVtt
+        ? this.convertSrtToVtt(body)
+        : this.applySubtitleAssAlignmentToVtt(body);
       const objectUrl = URL.createObjectURL(new Blob([vttText], { type: "text/vtt" }));
       this.externalSubtitleObjectUrls.push(objectUrl);
       return objectUrl;
@@ -8547,55 +9293,68 @@ export const PlayerScreen = {
   syncTrackState() {
     const textTracks = this.getTextTracks();
     const audioTracks = this.getAudioTracks();
-    const dashAudioTracks = typeof PlayerController.getDashAudioTracks === "function"
-      ? PlayerController.getDashAudioTracks()
-      : [];
-    const dashSubtitleTracks = typeof PlayerController.getDashTextTracks === "function"
-      ? PlayerController.getDashTextTracks()
-      : [];
-    const avplayAudioTracks = typeof PlayerController.getAvPlayAudioTracks === "function"
-      ? PlayerController.getAvPlayAudioTracks()
-      : [];
-    const avplaySubtitleTracks = typeof PlayerController.getAvPlaySubtitleTracks === "function"
-      ? PlayerController.getAvPlaySubtitleTracks()
-      : [];
-    const selectedEmbeddedSubtitleTrack = typeof PlayerController.getSelectedWebOsEmbeddedSubtitleTrackIndex === "function"
-      ? PlayerController.getSelectedWebOsEmbeddedSubtitleTrackIndex()
-      : -1;
-    const hlsAudioTracks = typeof PlayerController.getHlsAudioTracks === "function"
-      ? PlayerController.getHlsAudioTracks()
-      : [];
-    const hlsSubtitleTracks = typeof PlayerController.getHlsSubtitleTracks === "function"
-      ? PlayerController.getHlsSubtitleTracks()
-      : [];
+    const dashAudioTracks =
+      typeof PlayerController.getDashAudioTracks === "function"
+        ? PlayerController.getDashAudioTracks()
+        : [];
+    const dashSubtitleTracks =
+      typeof PlayerController.getDashTextTracks === "function"
+        ? PlayerController.getDashTextTracks()
+        : [];
+    const avplayAudioTracks =
+      typeof PlayerController.getAvPlayAudioTracks === "function"
+        ? PlayerController.getAvPlayAudioTracks()
+        : [];
+    const avplaySubtitleTracks =
+      typeof PlayerController.getAvPlaySubtitleTracks === "function"
+        ? PlayerController.getAvPlaySubtitleTracks()
+        : [];
+    const selectedEmbeddedSubtitleTrack =
+      typeof PlayerController.getSelectedWebOsEmbeddedSubtitleTrackIndex === "function"
+        ? PlayerController.getSelectedWebOsEmbeddedSubtitleTrackIndex()
+        : -1;
+    const hlsAudioTracks =
+      typeof PlayerController.getHlsAudioTracks === "function"
+        ? PlayerController.getHlsAudioTracks()
+        : [];
+    const hlsSubtitleTracks =
+      typeof PlayerController.getHlsSubtitleTracks === "function"
+        ? PlayerController.getHlsSubtitleTracks()
+        : [];
 
     if (!this.externalTrackNodes.length) {
       this.builtInSubtitleCount = textTracks.length;
-    } else if ((!Number.isFinite(this.builtInSubtitleCount) || this.builtInSubtitleCount <= 0) && textTracks.length > this.externalTrackNodes.length) {
+    } else if (
+      (!Number.isFinite(this.builtInSubtitleCount) || this.builtInSubtitleCount <= 0) &&
+      textTracks.length > this.externalTrackNodes.length
+    ) {
       this.builtInSubtitleCount = textTracks.length - this.externalTrackNodes.length;
     }
 
     if (avplaySubtitleTracks.length) {
       this.selectedEmbeddedSubtitleTrackIndex = -1;
-      const selectedAvPlaySubtitleTrack = typeof PlayerController.getSelectedAvPlaySubtitleTrackIndex === "function"
-        ? PlayerController.getSelectedAvPlaySubtitleTrackIndex()
-        : -1;
+      const selectedAvPlaySubtitleTrack =
+        typeof PlayerController.getSelectedAvPlaySubtitleTrackIndex === "function"
+          ? PlayerController.getSelectedAvPlaySubtitleTrackIndex()
+          : -1;
       this.selectedSubtitleTrackIndex = Number.isFinite(selectedAvPlaySubtitleTrack)
         ? selectedAvPlaySubtitleTrack
         : -1;
     } else if (dashSubtitleTracks.length) {
       this.selectedEmbeddedSubtitleTrackIndex = -1;
-      const selectedDashSubtitleTrack = typeof PlayerController.getSelectedDashTextTrackIndex === "function"
-        ? PlayerController.getSelectedDashTextTrackIndex()
-        : -1;
+      const selectedDashSubtitleTrack =
+        typeof PlayerController.getSelectedDashTextTrackIndex === "function"
+          ? PlayerController.getSelectedDashTextTrackIndex()
+          : -1;
       this.selectedSubtitleTrackIndex = Number.isFinite(selectedDashSubtitleTrack)
         ? selectedDashSubtitleTrack
         : -1;
     } else if (hlsSubtitleTracks.length) {
       this.selectedEmbeddedSubtitleTrackIndex = -1;
-      const selectedHlsSubtitleTrack = typeof PlayerController.getSelectedHlsSubtitleTrackIndex === "function"
-        ? PlayerController.getSelectedHlsSubtitleTrackIndex()
-        : -1;
+      const selectedHlsSubtitleTrack =
+        typeof PlayerController.getSelectedHlsSubtitleTrackIndex === "function"
+          ? PlayerController.getSelectedHlsSubtitleTrackIndex()
+          : -1;
       this.selectedSubtitleTrackIndex = Number.isFinite(selectedHlsSubtitleTrack)
         ? selectedHlsSubtitleTrack
         : -1;
@@ -8607,67 +9366,86 @@ export const PlayerScreen = {
       this.selectedSubtitleTrackIndex = -1;
     } else {
       this.selectedEmbeddedSubtitleTrackIndex = -1;
-      this.selectedSubtitleTrackIndex = textTracks.findIndex((track) => track?.mode && track.mode !== "disabled");
+      this.selectedSubtitleTrackIndex = textTracks.findIndex(
+        (track) => track?.mode && track.mode !== "disabled"
+      );
     }
 
     if (avplayAudioTracks.length) {
-      const selectedAvPlayAudioTrack = typeof PlayerController.getSelectedAvPlayAudioTrackIndex === "function"
-        ? PlayerController.getSelectedAvPlayAudioTrackIndex()
-        : -1;
+      const selectedAvPlayAudioTrack =
+        typeof PlayerController.getSelectedAvPlayAudioTrackIndex === "function"
+          ? PlayerController.getSelectedAvPlayAudioTrackIndex()
+          : -1;
       const fallbackTrackIndex = Number(avplayAudioTracks[0]?.avplayTrackIndex);
-      this.selectedAudioTrackIndex = selectedAvPlayAudioTrack >= 0
-        ? selectedAvPlayAudioTrack
-        : (Number.isFinite(fallbackTrackIndex) ? fallbackTrackIndex : 0);
+      this.selectedAudioTrackIndex =
+        selectedAvPlayAudioTrack >= 0
+          ? selectedAvPlayAudioTrack
+          : Number.isFinite(fallbackTrackIndex)
+            ? fallbackTrackIndex
+            : 0;
       this.invalidateTrackDialogCaches();
       return;
     }
 
     if (dashAudioTracks.length) {
-      const selectedDashAudioTrack = typeof PlayerController.getSelectedDashAudioTrackIndex === "function"
-        ? PlayerController.getSelectedDashAudioTrackIndex()
-        : -1;
+      const selectedDashAudioTrack =
+        typeof PlayerController.getSelectedDashAudioTrackIndex === "function"
+          ? PlayerController.getSelectedDashAudioTrackIndex()
+          : -1;
       this.selectedAudioTrackIndex = selectedDashAudioTrack >= 0 ? selectedDashAudioTrack : 0;
       this.invalidateTrackDialogCaches();
       return;
     }
 
     if (hlsAudioTracks.length) {
-      const selectedHlsAudioTrack = typeof PlayerController.getSelectedHlsAudioTrackIndex === "function"
-        ? PlayerController.getSelectedHlsAudioTrackIndex()
-        : -1;
+      const selectedHlsAudioTrack =
+        typeof PlayerController.getSelectedHlsAudioTrackIndex === "function"
+          ? PlayerController.getSelectedHlsAudioTrackIndex()
+          : -1;
       const defaultHlsAudioTrack = hlsAudioTracks.findIndex((track) => Boolean(track?.default));
-      this.selectedAudioTrackIndex = selectedHlsAudioTrack >= 0
-        ? selectedHlsAudioTrack
-        : (defaultHlsAudioTrack >= 0 ? defaultHlsAudioTrack : 0);
+      this.selectedAudioTrackIndex =
+        selectedHlsAudioTrack >= 0
+          ? selectedHlsAudioTrack
+          : defaultHlsAudioTrack >= 0
+            ? defaultHlsAudioTrack
+            : 0;
       this.invalidateTrackDialogCaches();
       return;
     }
 
-    this.selectedAudioTrackIndex = audioTracks.findIndex((track) => Boolean(track?.enabled || track?.selected));
+    this.selectedAudioTrackIndex = audioTracks.findIndex((track) =>
+      Boolean(track?.enabled || track?.selected)
+    );
     this.invalidateTrackDialogCaches();
   },
 
   getSubtitleEntries(tab = this.subtitleDialogTab) {
     const textTracks = this.getTextTracks();
     const builtInBoundary = this.resolveBuiltInSubtitleBoundary(textTracks);
-    const dashSubtitleTracks = typeof PlayerController.getDashTextTracks === "function"
-      ? PlayerController.getDashTextTracks()
-      : [];
-    const selectedDashSubtitleTrack = typeof PlayerController.getSelectedDashTextTrackIndex === "function"
-      ? PlayerController.getSelectedDashTextTrackIndex()
-      : -1;
-    const avplaySubtitleTracks = typeof PlayerController.getAvPlaySubtitleTracks === "function"
-      ? PlayerController.getAvPlaySubtitleTracks()
-      : [];
-    const selectedAvPlaySubtitleTrack = typeof PlayerController.getSelectedAvPlaySubtitleTrackIndex === "function"
-      ? PlayerController.getSelectedAvPlaySubtitleTrackIndex()
-      : -1;
-    const hlsSubtitleTracks = typeof PlayerController.getHlsSubtitleTracks === "function"
-      ? PlayerController.getHlsSubtitleTracks()
-      : [];
-    const selectedHlsSubtitleTrack = typeof PlayerController.getSelectedHlsSubtitleTrackIndex === "function"
-      ? PlayerController.getSelectedHlsSubtitleTrackIndex()
-      : -1;
+    const dashSubtitleTracks =
+      typeof PlayerController.getDashTextTracks === "function"
+        ? PlayerController.getDashTextTracks()
+        : [];
+    const selectedDashSubtitleTrack =
+      typeof PlayerController.getSelectedDashTextTrackIndex === "function"
+        ? PlayerController.getSelectedDashTextTrackIndex()
+        : -1;
+    const avplaySubtitleTracks =
+      typeof PlayerController.getAvPlaySubtitleTracks === "function"
+        ? PlayerController.getAvPlaySubtitleTracks()
+        : [];
+    const selectedAvPlaySubtitleTrack =
+      typeof PlayerController.getSelectedAvPlaySubtitleTrackIndex === "function"
+        ? PlayerController.getSelectedAvPlaySubtitleTrackIndex()
+        : -1;
+    const hlsSubtitleTracks =
+      typeof PlayerController.getHlsSubtitleTracks === "function"
+        ? PlayerController.getHlsSubtitleTracks()
+        : [];
+    const selectedHlsSubtitleTrack =
+      typeof PlayerController.getSelectedHlsSubtitleTrackIndex === "function"
+        ? PlayerController.getSelectedHlsSubtitleTrackIndex()
+        : -1;
     const embeddedSubtitleTracks = this.shouldUseEmbeddedSubtitleTracks()
       ? this.embeddedSubtitleTracks
       : [];
@@ -8677,13 +9455,14 @@ export const PlayerScreen = {
       embeddedSubtitleTracks
     );
     const addonTracks = textTracks.filter((_, index) => index >= builtInBoundary);
-    const trackDiscoveryPending = this.embeddedSubtitleLoading
-      || (this.isCurrentSourceAdaptiveManifest()
-        && (this.trackDiscoveryInProgress || this.subtitleLoading || this.manifestLoading));
+    const trackDiscoveryPending =
+      this.embeddedSubtitleLoading ||
+      (this.isCurrentSourceAdaptiveManifest() &&
+        (this.trackDiscoveryInProgress || this.subtitleLoading || this.manifestLoading));
 
     if (tab === "builtIn") {
-	      if (avplaySubtitleTracks.length) {
-	        return [
+      if (avplaySubtitleTracks.length) {
+        return [
           {
             id: "subtitle-off",
             label: t("subtitle_none", {}, "None"),
@@ -8695,7 +9474,9 @@ export const PlayerScreen = {
           ...avplaySubtitleTracks.map((track, index) => {
             const mergedTrack = this.mergeAvPlaySubtitleTrackMetadata(track, index);
             const avplayTrackIndex = Number(track?.avplayTrackIndex);
-            const normalizedTrackIndex = Number.isFinite(avplayTrackIndex) ? avplayTrackIndex : index;
+            const normalizedTrackIndex = Number.isFinite(avplayTrackIndex)
+              ? avplayTrackIndex
+              : index;
             const display = formatSubtitleTrackDisplay(mergedTrack, index);
             return {
               id: `subtitle-avplay-${normalizedTrackIndex}`,
@@ -8770,42 +9551,47 @@ export const PlayerScreen = {
       }
 
       const entries = [
-          {
-            id: "subtitle-off",
-            label: t("subtitle_none", {}, "None"),
-            secondary: "",
-            selected: this.selectedSubtitleTrackIndex < 0 && this.selectedEmbeddedSubtitleTrackIndex < 0 && !this.selectedManifestSubtitleTrackId,
-            trackIndex: -1
-          },
-          ...embeddedSubtitleTracks.map((track, index) => {
-            const display = formatSubtitleTrackDisplay(track, index);
-            return {
-              id: `subtitle-embedded-${track.embeddedTrackIndex}`,
-              label: display.label,
-              language: display.language,
-              secondary: display.secondary,
-              languageKey: display.languageKey,
-              languageLabel: display.languageLabel,
-              isForced: isForcedSubtitleTrack(track),
-              selected: track.embeddedTrackIndex === this.selectedEmbeddedSubtitleTrackIndex,
-              trackIndex: null,
-              embeddedSubtitleTrackIndex: track.embeddedTrackIndex
-            };
-          }),
-          ...builtInTracks.map((track, index) => {
-            const display = formatSubtitleTrackDisplay(track, index);
-            return {
-              id: `subtitle-built-${index}`,
-              label: display.label,
-              language: display.language,
-              secondary: display.secondary,
-              languageKey: display.languageKey,
-              languageLabel: display.languageLabel,
-              isForced: isForcedSubtitleTrack(track),
-              selected: this.selectedEmbeddedSubtitleTrackIndex < 0 && index === this.selectedSubtitleTrackIndex,
-              trackIndex: index
-            };
-          }),
+        {
+          id: "subtitle-off",
+          label: t("subtitle_none", {}, "None"),
+          secondary: "",
+          selected:
+            this.selectedSubtitleTrackIndex < 0 &&
+            this.selectedEmbeddedSubtitleTrackIndex < 0 &&
+            !this.selectedManifestSubtitleTrackId,
+          trackIndex: -1
+        },
+        ...embeddedSubtitleTracks.map((track, index) => {
+          const display = formatSubtitleTrackDisplay(track, index);
+          return {
+            id: `subtitle-embedded-${track.embeddedTrackIndex}`,
+            label: display.label,
+            language: display.language,
+            secondary: display.secondary,
+            languageKey: display.languageKey,
+            languageLabel: display.languageLabel,
+            isForced: isForcedSubtitleTrack(track),
+            selected: track.embeddedTrackIndex === this.selectedEmbeddedSubtitleTrackIndex,
+            trackIndex: null,
+            embeddedSubtitleTrackIndex: track.embeddedTrackIndex
+          };
+        }),
+        ...builtInTracks.map((track, index) => {
+          const display = formatSubtitleTrackDisplay(track, index);
+          return {
+            id: `subtitle-built-${index}`,
+            label: display.label,
+            language: display.language,
+            secondary: display.secondary,
+            languageKey: display.languageKey,
+            languageLabel: display.languageLabel,
+            isForced: isForcedSubtitleTrack(track),
+            selected:
+              this.selectedEmbeddedSubtitleTrackIndex < 0 &&
+              index === this.selectedSubtitleTrackIndex,
+            trackIndex: index
+          };
+        }),
         ...this.manifestSubtitleTracks.map((track, index) => {
           const display = formatSubtitleTrackDisplay(track, index);
           return {
@@ -8854,8 +9640,10 @@ export const PlayerScreen = {
             languageKey: display.languageKey,
             languageLabel: display.languageLabel,
             isForced: isForcedSubtitleTrack(subtitle),
-            selected: this.selectedAddonSubtitleId === subtitleId
-              || (this.selectedAddonSubtitleId == null && absoluteIndex === this.selectedSubtitleTrackIndex),
+            selected:
+              this.selectedAddonSubtitleId === subtitleId ||
+              (this.selectedAddonSubtitleId == null &&
+                absoluteIndex === this.selectedSubtitleTrackIndex),
             trackIndex: null,
             subtitleIndex: index,
             fallbackAddonSubtitle: true
@@ -8933,7 +9721,9 @@ export const PlayerScreen = {
     if (cachedOptions) {
       return cachedOptions;
     }
-    const builtInEntries = this.getSubtitleEntries("builtIn").filter((entry) => !entry?.disabled || entry?.id === "subtitle-off");
+    const builtInEntries = this.getSubtitleEntries("builtIn").filter(
+      (entry) => !entry?.disabled || entry?.id === "subtitle-off"
+    );
     const addonEntries = this.getSubtitleEntries("addons").filter((entry) => !entry?.disabled);
     const options = [];
 
@@ -9078,11 +9868,15 @@ export const PlayerScreen = {
       if (preferredDelta !== 0) {
         return preferredDelta;
       }
-      const labelDelta = String(left.label || "").localeCompare(String(right.label || ""), locale, { sensitivity: "base" });
+      const labelDelta = String(left.label || "").localeCompare(String(right.label || ""), locale, {
+        sensitivity: "base"
+      });
       if (labelDelta !== 0) {
         return labelDelta;
       }
-      return String(left.key || "").localeCompare(String(right.key || ""), "en", { sensitivity: "base" });
+      return String(left.key || "").localeCompare(String(right.key || ""), "en", {
+        sensitivity: "base"
+      });
     });
     this.trackDialogCache.subtitleLanguageRail = values;
     return values;
@@ -9090,7 +9884,8 @@ export const PlayerScreen = {
 
   syncSubtitleOptionIndexForFocusedLanguage() {
     const languages = this.getSubtitleLanguageRailItems();
-    const activeLanguage = languages[this.subtitleLanguageRailIndex]?.key || SUBTITLE_LANGUAGE_OFF_KEY;
+    const activeLanguage =
+      languages[this.subtitleLanguageRailIndex]?.key || SUBTITLE_LANGUAGE_OFF_KEY;
     const options = this.getSubtitleOptionsForLanguage(activeLanguage);
     const selectedIndex = options.findIndex((item) => item.selected);
     this.subtitleOptionRailIndex = Math.max(0, selectedIndex >= 0 ? selectedIndex : 0);
@@ -9143,7 +9938,9 @@ export const PlayerScreen = {
     const viewBottom = viewTop + Number(rail.clientHeight || 0);
     let nextScrollTop = viewTop;
     if (center) {
-      nextScrollTop = nodeTop - Math.max(0, (Number(rail.clientHeight || 0) - Number(node.offsetHeight || 0)) / 2);
+      nextScrollTop =
+        nodeTop -
+        Math.max(0, (Number(rail.clientHeight || 0) - Number(node.offsetHeight || 0)) / 2);
     } else if (nodeTop < viewTop + margin) {
       nextScrollTop = nodeTop - margin;
     } else if (nodeBottom > viewBottom - margin) {
@@ -9159,11 +9956,19 @@ export const PlayerScreen = {
     if (!dialog || !this.subtitleDialogVisible) {
       return;
     }
-    const selectedLanguageNode = dialog.querySelector(".player-subtitle-language-rail .player-dialog-item.selected");
-    const focusedLanguageNode = dialog.querySelector(".player-subtitle-language-rail .player-dialog-item.focused");
+    const selectedLanguageNode = dialog.querySelector(
+      ".player-subtitle-language-rail .player-dialog-item.selected"
+    );
+    const focusedLanguageNode = dialog.querySelector(
+      ".player-subtitle-language-rail .player-dialog-item.focused"
+    );
     const languageNode = focusedLanguageNode || selectedLanguageNode;
-    const optionNode = dialog.querySelector(".player-subtitle-options-rail .player-dialog-item.focused");
-    const styleNode = dialog.querySelector(".player-subtitle-style-rail .player-dialog-item.focused");
+    const optionNode = dialog.querySelector(
+      ".player-subtitle-options-rail .player-dialog-item.focused"
+    );
+    const styleNode = dialog.querySelector(
+      ".player-subtitle-style-rail .player-dialog-item.focused"
+    );
 
     if (this.subtitleFocusedRail === "language") {
       this.scrollSubtitleRailNodeIntoView(languageNode);
@@ -9184,17 +9989,28 @@ export const PlayerScreen = {
     const sourceRank = { internal: 0, addon: 1, off: 2 };
     const locale = typeof I18n.getLocale === "function" ? I18n.getLocale() : undefined;
     const filteredOptions = this.collectSubtitleOptionItems()
-      .filter((entry) => entry.languageKey === normalizedLanguageKey && entry.languageKey !== SUBTITLE_LANGUAGE_OFF_KEY)
+      .filter(
+        (entry) =>
+          entry.languageKey === normalizedLanguageKey &&
+          entry.languageKey !== SUBTITLE_LANGUAGE_OFF_KEY
+      )
       .sort((left, right) => {
-        const sourceDelta = (sourceRank[left.sourceType] ?? 99) - (sourceRank[right.sourceType] ?? 99);
+        const sourceDelta =
+          (sourceRank[left.sourceType] ?? 99) - (sourceRank[right.sourceType] ?? 99);
         if (sourceDelta !== 0) {
           return sourceDelta;
         }
-        const secondaryDelta = String(left.secondary || "").localeCompare(String(right.secondary || ""), locale, { sensitivity: "base" });
+        const secondaryDelta = String(left.secondary || "").localeCompare(
+          String(right.secondary || ""),
+          locale,
+          { sensitivity: "base" }
+        );
         if (secondaryDelta !== 0) {
           return secondaryDelta;
         }
-        return String(left.title || "").localeCompare(String(right.title || ""), locale, { sensitivity: "base" });
+        return String(left.title || "").localeCompare(String(right.title || ""), locale, {
+          sensitivity: "base"
+        });
       });
     optionsByLanguage?.set(normalizedLanguageKey, filteredOptions);
     return filteredOptions;
@@ -9206,22 +10022,23 @@ export const PlayerScreen = {
 
   isAudioPreferenceDiscoveryPending() {
     return Boolean(
-      this.embeddedAudioLoading
-      || this.manifestLoading
-      || this.trackDiscoveryInProgress
-      || (!this.getAudioEntries().length && this.isTrackDiscoveryWindowPending())
+      this.embeddedAudioLoading ||
+      this.manifestLoading ||
+      this.trackDiscoveryInProgress ||
+      (!this.getAudioEntries().length && this.isTrackDiscoveryWindowPending())
     );
   },
 
   isSubtitlePreferenceDiscoveryPending() {
-    const hasSubtitleOptions = this.collectSubtitleOptionItems()
-      .some((entry) => entry.languageKey !== SUBTITLE_LANGUAGE_OFF_KEY);
+    const hasSubtitleOptions = this.collectSubtitleOptionItems().some(
+      (entry) => entry.languageKey !== SUBTITLE_LANGUAGE_OFF_KEY
+    );
     return Boolean(
-      this.subtitleLoading
-      || this.embeddedSubtitleLoading
-      || this.manifestLoading
-      || this.trackDiscoveryInProgress
-      || (!hasSubtitleOptions && this.isTrackDiscoveryWindowPending())
+      this.subtitleLoading ||
+      this.embeddedSubtitleLoading ||
+      this.manifestLoading ||
+      this.trackDiscoveryInProgress ||
+      (!hasSubtitleOptions && this.isTrackDiscoveryWindowPending())
     );
   },
 
@@ -9231,17 +10048,24 @@ export const PlayerScreen = {
       return SUBTITLE_LANGUAGE_OFF_KEY;
     }
 
-    const configured = extractSubtitleLanguageSetting(settings.subtitleStyle?.preferredLanguage || settings.subtitleLanguage || "off").trim().toLowerCase();
+    const configured = extractSubtitleLanguageSetting(
+      settings.subtitleStyle?.preferredLanguage || settings.subtitleLanguage || "off"
+    )
+      .trim()
+      .toLowerCase();
     if (!configured || configured === "off" || configured === "none" || configured === "forced") {
       return SUBTITLE_LANGUAGE_OFF_KEY;
     }
 
     if (configured === "system") {
-      const locale = typeof I18n.getLocale === "function"
-        ? I18n.getLocale()
-        : (globalThis.navigator?.language || "");
+      const locale =
+        typeof I18n.getLocale === "function"
+          ? I18n.getLocale()
+          : globalThis.navigator?.language || "";
       const systemLanguage = normalizeTrackLanguageCode(locale);
-      return systemLanguage ? normalizeSubtitleLanguageKey(systemLanguage) : SUBTITLE_LANGUAGE_OFF_KEY;
+      return systemLanguage
+        ? normalizeSubtitleLanguageKey(systemLanguage)
+        : SUBTITLE_LANGUAGE_OFF_KEY;
     }
 
     return normalizeSubtitleLanguageKey(configured);
@@ -9255,19 +10079,29 @@ export const PlayerScreen = {
 
     const values = [
       settings.subtitleStyle?.preferredLanguage || settings.subtitleLanguage || "off",
-      settings.subtitleStyle?.secondaryPreferredLanguage || settings.secondarySubtitleLanguage || "off"
+      settings.subtitleStyle?.secondaryPreferredLanguage ||
+        settings.secondarySubtitleLanguage ||
+        "off"
     ];
 
     const targets = values
       .map((value) => {
-        const configured = String(value || "off").trim().toLowerCase();
-        if (!configured || configured === "off" || configured === "none" || configured === "forced") {
+        const configured = String(value || "off")
+          .trim()
+          .toLowerCase();
+        if (
+          !configured ||
+          configured === "off" ||
+          configured === "none" ||
+          configured === "forced"
+        ) {
           return "";
         }
         if (configured === "system") {
-          const locale = typeof I18n.getLocale === "function"
-            ? I18n.getLocale()
-            : (globalThis.navigator?.language || "");
+          const locale =
+            typeof I18n.getLocale === "function"
+              ? I18n.getLocale()
+              : globalThis.navigator?.language || "";
           return normalizeSubtitleLanguageKey(normalizeTrackLanguageCode(locale) || "");
         }
         return normalizeSubtitleLanguageKey(configured);
@@ -9278,11 +10112,23 @@ export const PlayerScreen = {
   },
 
   shouldUseStartupForcedSubtitles(settings = PlayerSettingsStore.get()) {
-    const preferred = extractSubtitleLanguageSetting(settings.subtitleStyle?.preferredLanguage || settings.subtitleLanguage || "off").trim().toLowerCase();
-    const secondary = extractSubtitleLanguageSetting(settings.subtitleStyle?.secondaryPreferredLanguage || settings.secondarySubtitleLanguage || "off").trim().toLowerCase();
-    return Boolean(settings.subtitleStyle?.useForcedSubtitles || settings.useForcedSubtitles)
-      || preferred === "forced"
-      || secondary === "forced";
+    const preferred = extractSubtitleLanguageSetting(
+      settings.subtitleStyle?.preferredLanguage || settings.subtitleLanguage || "off"
+    )
+      .trim()
+      .toLowerCase();
+    const secondary = extractSubtitleLanguageSetting(
+      settings.subtitleStyle?.secondaryPreferredLanguage ||
+        settings.secondarySubtitleLanguage ||
+        "off"
+    )
+      .trim()
+      .toLowerCase();
+    return (
+      Boolean(settings.subtitleStyle?.useForcedSubtitles || settings.useForcedSubtitles) ||
+      preferred === "forced" ||
+      secondary === "forced"
+    );
   },
 
   getStartupForcedSubtitleLanguageTarget() {
@@ -9292,14 +10138,26 @@ export const PlayerScreen = {
     }
 
     const explicitTargets = this.getStartupPreferredSubtitleLanguageTargets();
-    const selectedAudioOption = this.collectAudioOptionItems().find((entry) => entry.selected && entry.languageKey);
+    const selectedAudioOption = this.collectAudioOptionItems().find(
+      (entry) => entry.selected && entry.languageKey
+    );
     const primaryTarget = explicitTargets[0] || null;
-    if (primaryTarget && selectedAudioOption && this.matchesStartupAudioTarget(selectedAudioOption, primaryTarget)) {
+    if (
+      primaryTarget &&
+      selectedAudioOption &&
+      this.matchesStartupAudioTarget(selectedAudioOption, primaryTarget)
+    ) {
       return primaryTarget;
     }
 
     const preferredAudioTargets = this.getStartupPreferredAudioLanguageTargets();
-    if (!primaryTarget && selectedAudioOption && preferredAudioTargets.some((target) => this.matchesStartupAudioTarget(selectedAudioOption, target))) {
+    if (
+      !primaryTarget &&
+      selectedAudioOption &&
+      preferredAudioTargets.some((target) =>
+        this.matchesStartupAudioTarget(selectedAudioOption, target)
+      )
+    ) {
       return selectedAudioOption.languageKey;
     }
 
@@ -9323,15 +10181,18 @@ export const PlayerScreen = {
 
   getStartupPreferredAudioLanguageTargets() {
     const settings = PlayerSettingsStore.get();
-    const configured = String(settings.preferredAudioLanguage || "system").trim().toLowerCase();
+    const configured = String(settings.preferredAudioLanguage || "system")
+      .trim()
+      .toLowerCase();
     if (!configured || configured === "off" || configured === "none") {
       return [];
     }
 
     if (configured === "system") {
-      const locale = typeof I18n.getLocale === "function"
-        ? I18n.getLocale()
-        : (globalThis.navigator?.language || "");
+      const locale =
+        typeof I18n.getLocale === "function"
+          ? I18n.getLocale()
+          : globalThis.navigator?.language || "";
       const systemLanguage = normalizeTrackLanguageCode(locale);
       return systemLanguage ? [systemLanguage] : [];
     }
@@ -9344,10 +10205,7 @@ export const PlayerScreen = {
     return this.getAudioEntries().map((entry, index) => {
       const track = entry?.track || {};
       const languageKey = normalizeTrackLanguageCode(
-        getTrackLanguageValue(track)
-        || track?.label
-        || track?.name
-        || ""
+        getTrackLanguageValue(track) || track?.label || track?.name || ""
       );
       return {
         id: entry?.id || `audio-option-${index}`,
@@ -9411,7 +10269,10 @@ export const PlayerScreen = {
 
     const isStillLoading = this.isAudioPreferenceDiscoveryPending();
     const selectedOption = this.collectAudioOptionItems().find((entry) => entry.selected);
-    if (selectedOption && preferredTargets.some((target) => this.matchesStartupAudioTarget(selectedOption, target))) {
+    if (
+      selectedOption &&
+      preferredTargets.some((target) => this.matchesStartupAudioTarget(selectedOption, target))
+    ) {
       this.startupAudioPreferenceApplied = true;
       return true;
     }
@@ -9432,31 +10293,40 @@ export const PlayerScreen = {
     }
 
     const appliedOption = this.collectAudioOptionItems().find((entry) => entry.selected);
-    const applied = Boolean(appliedOption && preferredTargets.some((target) => this.matchesStartupAudioTarget(appliedOption, target)));
+    const applied = Boolean(
+      appliedOption &&
+      preferredTargets.some((target) => this.matchesStartupAudioTarget(appliedOption, target))
+    );
     this.startupAudioPreferenceApplied = applied;
     return applied;
   },
 
-  findStartupPreferredSubtitleOption(targets = this.getStartupPreferredSubtitleLanguageTargets(), mode = "language") {
+  findStartupPreferredSubtitleOption(
+    targets = this.getStartupPreferredSubtitleLanguageTargets(),
+    mode = "language"
+  ) {
     const normalizedTargets = Array.isArray(targets) ? targets.filter(Boolean) : [];
     if (!normalizedTargets.length) {
       return null;
     }
 
-    const options = this.collectSubtitleOptionItems().filter((entry) => entry.languageKey !== SUBTITLE_LANGUAGE_OFF_KEY);
+    const options = this.collectSubtitleOptionItems().filter(
+      (entry) => entry.languageKey !== SUBTITLE_LANGUAGE_OFF_KEY
+    );
     const matchTarget = (entry, target) => this.matchesStartupSubtitleTarget(entry, target);
-    const findMatch = (target, { sourceType = null, forced = null } = {}) => options.find((entry) => {
-      if (sourceType && entry.sourceType !== sourceType) {
-        return false;
-      }
-      if (forced === true && !entry.isForced) {
-        return false;
-      }
-      if (forced === false && entry.isForced) {
-        return false;
-      }
-      return matchTarget(entry, target);
-    });
+    const findMatch = (target, { sourceType = null, forced = null } = {}) =>
+      options.find((entry) => {
+        if (sourceType && entry.sourceType !== sourceType) {
+          return false;
+        }
+        if (forced === true && !entry.isForced) {
+          return false;
+        }
+        if (forced === false && entry.isForced) {
+          return false;
+        }
+        return matchTarget(entry, target);
+      });
 
     for (const target of normalizedTargets) {
       if (mode === "audio-forced") {
@@ -9494,7 +10364,9 @@ export const PlayerScreen = {
     const normalizedTitle = normalizeComparableText(entry.title || "");
     const normalizedLabel = normalizeComparableText(entry.languageLabel || "");
     const targetLabel = normalizeComparableText(subtitleLanguageLabel(target));
-    return Boolean(targetLabel && (normalizedTitle === targetLabel || normalizedLabel === targetLabel));
+    return Boolean(
+      targetLabel && (normalizedTitle === targetLabel || normalizedLabel === targetLabel)
+    );
   },
 
   applyStartupSubtitlePreference() {
@@ -9503,21 +10375,34 @@ export const PlayerScreen = {
     }
 
     const preferenceMode = this.getStartupSubtitlePreferenceMode();
-    const forcedTarget = preferenceMode === "audio-forced"
-      ? this.getStartupForcedSubtitleLanguageTarget()
-      : null;
-    const preferredTargets = preferenceMode === "audio-forced"
-      ? (forcedTarget ? [forcedTarget] : this.getStartupPreferredSubtitleLanguageTargets())
-      : this.getStartupPreferredSubtitleLanguageTargets();
+    const forcedTarget =
+      preferenceMode === "audio-forced" ? this.getStartupForcedSubtitleLanguageTarget() : null;
+    const preferredTargets =
+      preferenceMode === "audio-forced"
+        ? forcedTarget
+          ? [forcedTarget]
+          : this.getStartupPreferredSubtitleLanguageTargets()
+        : this.getStartupPreferredSubtitleLanguageTargets();
     const isStillLoading = this.isSubtitlePreferenceDiscoveryPending();
 
-    if (this.shouldUseStartupForcedSubtitles() && !this.collectAudioOptionItems().some((entry) => entry.selected && entry.languageKey) && this.isAudioPreferenceDiscoveryPending()) {
+    if (
+      this.shouldUseStartupForcedSubtitles() &&
+      !this.collectAudioOptionItems().some((entry) => entry.selected && entry.languageKey) &&
+      this.isAudioPreferenceDiscoveryPending()
+    ) {
       return false;
     }
 
     if (preferenceMode === "off") {
-      if (this.selectedSubtitleTrackIndex >= 0 || this.selectedEmbeddedSubtitleTrackIndex >= 0 || this.selectedAddonSubtitleId || this.selectedManifestSubtitleTrackId) {
-        const offEntry = this.getSubtitleEntries("builtIn").find((entry) => entry.id === "subtitle-off") || { trackIndex: -1 };
+      if (
+        this.selectedSubtitleTrackIndex >= 0 ||
+        this.selectedEmbeddedSubtitleTrackIndex >= 0 ||
+        this.selectedAddonSubtitleId ||
+        this.selectedManifestSubtitleTrackId
+      ) {
+        const offEntry = this.getSubtitleEntries("builtIn").find(
+          (entry) => entry.id === "subtitle-off"
+        ) || { trackIndex: -1 };
         this.startupSubtitlePreferenceApplying = true;
         try {
           this.applySubtitleEntry(offEntry);
@@ -9534,8 +10419,13 @@ export const PlayerScreen = {
       return false;
     }
 
-    const selectedOption = this.collectSubtitleOptionItems().find((entry) => entry.selected && entry.languageKey !== SUBTITLE_LANGUAGE_OFF_KEY);
-    const preferredOption = this.findStartupPreferredSubtitleOption(preferredTargets, preferenceMode);
+    const selectedOption = this.collectSubtitleOptionItems().find(
+      (entry) => entry.selected && entry.languageKey !== SUBTITLE_LANGUAGE_OFF_KEY
+    );
+    const preferredOption = this.findStartupPreferredSubtitleOption(
+      preferredTargets,
+      preferenceMode
+    );
     if (selectedOption && preferredOption?.id === selectedOption.id) {
       this.startupSubtitlePreferenceApplied = true;
       return true;
@@ -9544,7 +10434,9 @@ export const PlayerScreen = {
     if (!preferredOption?.entry) {
       if (!isStillLoading) {
         if (preferenceMode === "audio-forced" || selectedOption) {
-          const offEntry = this.getSubtitleEntries("builtIn").find((entry) => entry.id === "subtitle-off") || { trackIndex: -1 };
+          const offEntry = this.getSubtitleEntries("builtIn").find(
+            (entry) => entry.id === "subtitle-off"
+          ) || { trackIndex: -1 };
           this.startupSubtitlePreferenceApplying = true;
           try {
             this.applySubtitleEntry(offEntry);
@@ -9565,8 +10457,13 @@ export const PlayerScreen = {
       this.startupSubtitlePreferenceApplying = false;
     }
 
-    const appliedOption = this.collectSubtitleOptionItems().find((entry) => entry.selected && entry.languageKey !== SUBTITLE_LANGUAGE_OFF_KEY);
-    const applied = Boolean(appliedOption && preferredTargets.some((target) => this.matchesStartupSubtitleTarget(appliedOption, target)));
+    const appliedOption = this.collectSubtitleOptionItems().find(
+      (entry) => entry.selected && entry.languageKey !== SUBTITLE_LANGUAGE_OFF_KEY
+    );
+    const applied = Boolean(
+      appliedOption &&
+      preferredTargets.some((target) => this.matchesStartupSubtitleTarget(appliedOption, target))
+    );
     this.startupSubtitlePreferenceApplied = applied;
     return applied;
   },
@@ -9574,13 +10471,43 @@ export const PlayerScreen = {
   getSubtitleStyleControls() {
     const style = this.subtitleStyleSettings || {};
     return [
-      { id: "delay", label: t("subtitle_tab_delay", {}, "Delay"), value: formatSubtitleDelay(this.subtitleDelayMs) },
-      { id: "fontSize", label: t("subtitle_style_font_size", {}, "Font Size"), value: `${normalizeSubtitleFontSize(style.fontSize)}%` },
-      { id: "bold", label: t("subtitle_style_bold", {}, "Bold"), value: style.bold ? t("subtitle_style_on", {}, "On") : t("subtitle_style_off", {}, "Off") },
-      { id: "textColor", label: t("subtitle_style_text_color", {}, "Text Color"), value: styleChipLabel(style.textColor || "#FFFFFF") },
-      { id: "outlineEnabled", label: t("subtitle_style_outline", {}, "Outline"), value: style.outlineEnabled ? t("subtitle_style_on", {}, "On") : t("subtitle_style_off", {}, "Off") },
-      { id: "outlineColor", label: t("subtitle_style_outline_color", {}, "Outline Color"), value: styleChipLabel(style.outlineColor || "#000000") },
-      { id: "verticalOffset", label: t("subtitle_style_bottom_offset", {}, "Bottom Offset"), value: formatSubtitleVerticalOffset(style.verticalOffset) },
+      {
+        id: "delay",
+        label: t("subtitle_tab_delay", {}, "Delay"),
+        value: formatSubtitleDelay(this.subtitleDelayMs)
+      },
+      {
+        id: "fontSize",
+        label: t("subtitle_style_font_size", {}, "Font Size"),
+        value: `${normalizeSubtitleFontSize(style.fontSize)}%`
+      },
+      {
+        id: "bold",
+        label: t("subtitle_style_bold", {}, "Bold"),
+        value: style.bold ? t("subtitle_style_on", {}, "On") : t("subtitle_style_off", {}, "Off")
+      },
+      {
+        id: "textColor",
+        label: t("subtitle_style_text_color", {}, "Text Color"),
+        value: styleChipLabel(style.textColor || "#FFFFFF")
+      },
+      {
+        id: "outlineEnabled",
+        label: t("subtitle_style_outline", {}, "Outline"),
+        value: style.outlineEnabled
+          ? t("subtitle_style_on", {}, "On")
+          : t("subtitle_style_off", {}, "Off")
+      },
+      {
+        id: "outlineColor",
+        label: t("subtitle_style_outline_color", {}, "Outline Color"),
+        value: styleChipLabel(style.outlineColor || "#000000")
+      },
+      {
+        id: "verticalOffset",
+        label: t("subtitle_style_bottom_offset", {}, "Bottom Offset"),
+        value: formatSubtitleVerticalOffset(style.verticalOffset)
+      },
       { id: "reset", label: t("subtitle_style_defaults", {}, "Reset Defaults"), value: "" }
     ];
   },
@@ -9588,21 +10515,37 @@ export const PlayerScreen = {
   adjustSubtitleStyleControl(controlId, delta = 0) {
     const style = { ...(this.subtitleStyleSettings || {}) };
     if (controlId === "delay") {
-      this.subtitleDelayMs = clamp(Number(this.subtitleDelayMs || 0) + (delta * SUBTITLE_DELAY_STEP_MS), -5000, 5000);
+      this.subtitleDelayMs = clamp(
+        Number(this.subtitleDelayMs || 0) + delta * SUBTITLE_DELAY_STEP_MS,
+        -5000,
+        5000
+      );
     } else if (controlId === "fontSize") {
-      style.fontSize = normalizeSubtitleFontSize(Number(style.fontSize || 100) + (delta * SUBTITLE_FONT_STEP));
+      style.fontSize = normalizeSubtitleFontSize(
+        Number(style.fontSize || 100) + delta * SUBTITLE_FONT_STEP
+      );
     } else if (controlId === "bold" && delta !== 0) {
       style.bold = !style.bold;
     } else if (controlId === "textColor" && delta !== 0) {
-      const currentIndex = Math.max(0, SUBTITLE_TEXT_COLORS.indexOf(String(style.textColor || "#FFFFFF").toUpperCase()));
-      style.textColor = SUBTITLE_TEXT_COLORS[clamp(currentIndex + delta, 0, SUBTITLE_TEXT_COLORS.length - 1)];
+      const currentIndex = Math.max(
+        0,
+        SUBTITLE_TEXT_COLORS.indexOf(String(style.textColor || "#FFFFFF").toUpperCase())
+      );
+      style.textColor =
+        SUBTITLE_TEXT_COLORS[clamp(currentIndex + delta, 0, SUBTITLE_TEXT_COLORS.length - 1)];
     } else if (controlId === "outlineEnabled" && delta !== 0) {
       style.outlineEnabled = !style.outlineEnabled;
     } else if (controlId === "outlineColor" && delta !== 0) {
-      const currentIndex = Math.max(0, SUBTITLE_OUTLINE_COLORS.indexOf(String(style.outlineColor || "#000000").toUpperCase()));
-      style.outlineColor = SUBTITLE_OUTLINE_COLORS[clamp(currentIndex + delta, 0, SUBTITLE_OUTLINE_COLORS.length - 1)];
+      const currentIndex = Math.max(
+        0,
+        SUBTITLE_OUTLINE_COLORS.indexOf(String(style.outlineColor || "#000000").toUpperCase())
+      );
+      style.outlineColor =
+        SUBTITLE_OUTLINE_COLORS[clamp(currentIndex + delta, 0, SUBTITLE_OUTLINE_COLORS.length - 1)];
     } else if (controlId === "verticalOffset") {
-      style.verticalOffset = normalizeSubtitleVerticalOffset(Number(style.verticalOffset || 0) + (delta * SUBTITLE_VERTICAL_OFFSET_STEP));
+      style.verticalOffset = normalizeSubtitleVerticalOffset(
+        Number(style.verticalOffset || 0) + delta * SUBTITLE_VERTICAL_OFFSET_STEP
+      );
     } else if (controlId === "reset") {
       const defaults = PlayerSettingsStore.get().subtitleStyle;
       this.subtitleDelayMs = 0;
@@ -9630,11 +10573,15 @@ export const PlayerScreen = {
     this.sourcesPanelVisible = false;
     const languageRail = this.getSubtitleLanguageRailItems();
     const selectedLanguageKey = this.getSelectedSubtitleLanguageKey();
-    this.subtitleLanguageRailIndex = Math.max(0, languageRail.findIndex((item) => item.key === selectedLanguageKey));
+    this.subtitleLanguageRailIndex = Math.max(
+      0,
+      languageRail.findIndex((item) => item.key === selectedLanguageKey)
+    );
     this.syncSubtitleOptionIndexForFocusedLanguage();
     this.subtitleStyleRailIndex = 0;
     this.subtitleStyleControlSide = "minus";
-    this.subtitleFocusedRail = selectedLanguageKey === SUBTITLE_LANGUAGE_OFF_KEY ? "language" : "options";
+    this.subtitleFocusedRail =
+      selectedLanguageKey === SUBTITLE_LANGUAGE_OFF_KEY ? "language" : "options";
     this.subtitleDialogScrollMode = "start";
     this.setControlsVisible(true, { focus: false });
     this.renderSubtitleDialog();
@@ -9670,21 +10617,30 @@ export const PlayerScreen = {
     }
 
     let applied = false;
-    if (Environment.isTizen() && typeof PlayerController.isUsingAvPlay === "function" && PlayerController.isUsingAvPlay()) {
+    if (
+      Environment.isTizen() &&
+      typeof PlayerController.isUsingAvPlay === "function" &&
+      PlayerController.isUsingAvPlay()
+    ) {
       const nativeTrackIndex = Number(embeddedTrack?.nativeTrackIndex);
-      applied = typeof PlayerController.setAvPlaySubtitleTrack === "function" && Number.isFinite(nativeTrackIndex)
-        ? PlayerController.setAvPlaySubtitleTrack(nativeTrackIndex)
-        : false;
+      applied =
+        typeof PlayerController.setAvPlaySubtitleTrack === "function" &&
+        Number.isFinite(nativeTrackIndex)
+          ? PlayerController.setAvPlaySubtitleTrack(nativeTrackIndex)
+          : false;
     } else {
-      applied = typeof PlayerController.setWebOsEmbeddedSubtitleTrack === "function"
-        ? PlayerController.setWebOsEmbeddedSubtitleTrack(targetTrackIndex)
-        : false;
+      applied =
+        typeof PlayerController.setWebOsEmbeddedSubtitleTrack === "function"
+          ? PlayerController.setWebOsEmbeddedSubtitleTrack(targetTrackIndex)
+          : false;
     }
     if (!applied) {
       return false;
     }
 
-    this.selectedEmbeddedSubtitleTrackIndex = Number.isFinite(targetTrackIndex) ? targetTrackIndex : -1;
+    this.selectedEmbeddedSubtitleTrackIndex = Number.isFinite(targetTrackIndex)
+      ? targetTrackIndex
+      : -1;
     this.selectedSubtitleTrackIndex = -1;
     this.selectedAddonSubtitleId = null;
     this.selectedManifestSubtitleTrackId = null;
@@ -9700,7 +10656,10 @@ export const PlayerScreen = {
       return;
     }
 
-    const isEmbeddedEntry = Object.prototype.hasOwnProperty.call(entry, "embeddedSubtitleTrackIndex");
+    const isEmbeddedEntry = Object.prototype.hasOwnProperty.call(
+      entry,
+      "embeddedSubtitleTrackIndex"
+    );
     if (!isEmbeddedEntry) {
       this.disableEmbeddedSubtitleSelection();
     }
@@ -9718,9 +10677,10 @@ export const PlayerScreen = {
 
     if (Object.prototype.hasOwnProperty.call(entry, "avplaySubtitleTrackIndex")) {
       const targetTrackIndex = Number(entry.avplaySubtitleTrackIndex);
-      const applied = typeof PlayerController.setAvPlaySubtitleTrack === "function"
-        ? PlayerController.setAvPlaySubtitleTrack(targetTrackIndex)
-        : false;
+      const applied =
+        typeof PlayerController.setAvPlaySubtitleTrack === "function"
+          ? PlayerController.setAvPlaySubtitleTrack(targetTrackIndex)
+          : false;
       if (!applied) {
         return;
       }
@@ -9737,9 +10697,10 @@ export const PlayerScreen = {
 
     if (Object.prototype.hasOwnProperty.call(entry, "dashSubtitleTrackIndex")) {
       const targetTrackIndex = Number(entry.dashSubtitleTrackIndex);
-      const applied = typeof PlayerController.setDashTextTrack === "function"
-        ? PlayerController.setDashTextTrack(targetTrackIndex)
-        : false;
+      const applied =
+        typeof PlayerController.setDashTextTrack === "function"
+          ? PlayerController.setDashTextTrack(targetTrackIndex)
+          : false;
       if (!applied) {
         return;
       }
@@ -9756,9 +10717,10 @@ export const PlayerScreen = {
 
     if (Object.prototype.hasOwnProperty.call(entry, "hlsSubtitleTrackIndex")) {
       const targetTrackIndex = Number(entry.hlsSubtitleTrackIndex);
-      const applied = typeof PlayerController.setHlsSubtitleTrack === "function"
-        ? PlayerController.setHlsSubtitleTrack(targetTrackIndex)
-        : false;
+      const applied =
+        typeof PlayerController.setHlsSubtitleTrack === "function"
+          ? PlayerController.setHlsSubtitleTrack(targetTrackIndex)
+          : false;
       if (!applied) {
         return;
       }
@@ -9814,9 +10776,10 @@ export const PlayerScreen = {
       this.selectedManifestSubtitleTrackId = null;
     }
 
-    const appliedByController = typeof PlayerController.setNativeTextTrack === "function"
-      ? PlayerController.setNativeTextTrack(targetIndex)
-      : false;
+    const appliedByController =
+      typeof PlayerController.setNativeTextTrack === "function"
+        ? PlayerController.setNativeTextTrack(targetIndex)
+        : false;
     if (appliedByController) {
       this.selectedAddonSubtitleId = null;
       this.selectedSubtitleTrackIndex = targetIndex;
@@ -9862,22 +10825,27 @@ export const PlayerScreen = {
     }
     const subtitleId = subtitle.id || subtitle.url || `subtitle-${subtitleIndex}`;
 
-    const usingAvPlay = typeof PlayerController.isUsingAvPlay === "function"
-      ? PlayerController.isUsingAvPlay()
-      : false;
+    const usingAvPlay =
+      typeof PlayerController.isUsingAvPlay === "function"
+        ? PlayerController.isUsingAvPlay()
+        : false;
     if (usingAvPlay) {
       let avPlaySubtitleUrl = subtitle.url;
       try {
-        avPlaySubtitleUrl = await this.resolveSubtitlePlaybackUrl(subtitle.url) || subtitle.url;
+        avPlaySubtitleUrl = (await this.resolveSubtitlePlaybackUrl(subtitle.url)) || subtitle.url;
       } catch (_) {
         avPlaySubtitleUrl = subtitle.url;
       }
-      const applied = typeof PlayerController.setAvPlayExternalSubtitle === "function"
-        ? PlayerController.setAvPlayExternalSubtitle(avPlaySubtitleUrl)
-        : false;
-      const fallbackApplied = !applied && avPlaySubtitleUrl !== subtitle.url && typeof PlayerController.setAvPlayExternalSubtitle === "function"
-        ? PlayerController.setAvPlayExternalSubtitle(subtitle.url)
-        : false;
+      const applied =
+        typeof PlayerController.setAvPlayExternalSubtitle === "function"
+          ? PlayerController.setAvPlayExternalSubtitle(avPlaySubtitleUrl)
+          : false;
+      const fallbackApplied =
+        !applied &&
+        avPlaySubtitleUrl !== subtitle.url &&
+        typeof PlayerController.setAvPlayExternalSubtitle === "function"
+          ? PlayerController.setAvPlayExternalSubtitle(subtitle.url)
+          : false;
       if (applied || fallbackApplied) {
         this.selectedAddonSubtitleId = subtitleId;
         this.selectedSubtitleTrackIndex = -1;
@@ -9928,9 +10896,13 @@ export const PlayerScreen = {
 
     const activateTrack = () => this.activateMountedExternalSubtitleTrack(track);
     track.addEventListener("load", activateTrack, { once: true });
-    track.addEventListener("error", () => {
-      console.warn("Subtitle track failed to load", { subtitleUrl: subtitle.url });
-    }, { once: true });
+    track.addEventListener(
+      "error",
+      () => {
+        console.warn("Subtitle track failed to load", { subtitleUrl: subtitle.url });
+      },
+      { once: true }
+    );
 
     const preferredIndex = this.builtInSubtitleCount;
     this.selectedAddonSubtitleId = subtitleId;
@@ -9947,20 +10919,23 @@ export const PlayerScreen = {
 
     let activationAttempts = 0;
     const scheduleActivation = () => {
-      this.subtitleSelectionTimer = setTimeout(() => {
-        activationAttempts += 1;
-        const activated = activateTrack();
-        if (!activated && activationAttempts < 6) {
-          scheduleActivation();
-          return;
-        }
-        if (!activated) {
-          this.selectedSubtitleTrackIndex = -1;
-          this.refreshTrackDialogs();
-          return;
-        }
-        this.refreshSubtitleCueStyles();
-      }, activationAttempts === 0 ? 80 : 140);
+      this.subtitleSelectionTimer = setTimeout(
+        () => {
+          activationAttempts += 1;
+          const activated = activateTrack();
+          if (!activated && activationAttempts < 6) {
+            scheduleActivation();
+            return;
+          }
+          if (!activated) {
+            this.selectedSubtitleTrackIndex = -1;
+            this.refreshTrackDialogs();
+            return;
+          }
+          this.refreshSubtitleCueStyles();
+        },
+        activationAttempts === 0 ? 80 : 140
+      );
     };
     scheduleActivation();
   },
@@ -9978,13 +10953,27 @@ export const PlayerScreen = {
     }
 
     const languages = this.getSubtitleLanguageRailItems();
-    this.subtitleLanguageRailIndex = clamp(this.subtitleLanguageRailIndex, 0, Math.max(0, languages.length - 1));
-    const activeLanguage = languages[this.subtitleLanguageRailIndex]?.key || SUBTITLE_LANGUAGE_OFF_KEY;
+    this.subtitleLanguageRailIndex = clamp(
+      this.subtitleLanguageRailIndex,
+      0,
+      Math.max(0, languages.length - 1)
+    );
+    const activeLanguage =
+      languages[this.subtitleLanguageRailIndex]?.key || SUBTITLE_LANGUAGE_OFF_KEY;
     const options = this.getSubtitleOptionsForLanguage(activeLanguage);
-    this.subtitleOptionRailIndex = clamp(this.subtitleOptionRailIndex, 0, Math.max(0, options.length - 1));
+    this.subtitleOptionRailIndex = clamp(
+      this.subtitleOptionRailIndex,
+      0,
+      Math.max(0, options.length - 1)
+    );
     const styleItems = this.getSubtitleStyleControls();
-    this.subtitleStyleRailIndex = clamp(this.subtitleStyleRailIndex, 0, Math.max(0, styleItems.length - 1));
-    const subtitleLoadingVisible = this.embeddedSubtitleLoading && this.canDiscoverEmbeddedSubtitleTracks();
+    this.subtitleStyleRailIndex = clamp(
+      this.subtitleStyleRailIndex,
+      0,
+      Math.max(0, styleItems.length - 1)
+    );
+    const subtitleLoadingVisible =
+      this.embeddedSubtitleLoading && this.canDiscoverEmbeddedSubtitleTracks();
     const showOptionsRail = activeLanguage !== SUBTITLE_LANGUAGE_OFF_KEY || subtitleLoadingVisible;
     const focusedStyleSide = this.subtitleStyleControlSide === "plus" ? "plus" : "minus";
     const emptySubtitleOptionsMarkup = subtitleLoadingVisible
@@ -9995,25 +10984,39 @@ export const PlayerScreen = {
       <div class="player-dialog-title">${escapeHtml(t("subtitle_dialog_title", {}, "Subtitles"))}</div>
       <div class="player-subtitle-overlay-grid">
         <div class="player-subtitle-rail player-subtitle-language-rail">
-          ${languages.map((item, index) => `
+          ${languages
+            .map(
+              (item, index) => `
           <div class="player-dialog-item focusable${item.selected ? " selected" : ""}${this.subtitleFocusedRail === "language" && index === this.subtitleLanguageRailIndex ? " focused" : ""}" data-subtitle-rail="language" data-subtitle-index="${index}">
               <div class="player-dialog-item-main">${escapeHtml(item.label)}</div>
               <div class="player-dialog-item-sub">${item.key === SUBTITLE_LANGUAGE_OFF_KEY && subtitleLoadingVisible ? escapeHtml(t("subtitle_loading_builtin", {}, "Loading subtitle tracks...")) : ""}</div>
               <div class="player-dialog-item-check">${item.selected ? "&#10003;" : ""}</div>
             </div>
-          `).join("")}
+          `
+            )
+            .join("")}
         </div>
         <div class="player-subtitle-rail player-subtitle-options-rail${showOptionsRail ? "" : " hidden"}">
-          ${options.length ? options.map((item, index) => `
+          ${
+            options.length
+              ? options
+                  .map(
+                    (item, index) => `
             <div class="player-dialog-item focusable${item.selected ? " selected" : ""}${this.subtitleFocusedRail === "options" && index === this.subtitleOptionRailIndex ? " focused" : ""}" data-subtitle-rail="options" data-subtitle-index="${index}">
               <div class="player-dialog-item-main">${escapeHtml(item.title || "")}</div>
               <div class="player-dialog-item-sub">${escapeHtml(item.secondary || "")}</div>
               <div class="player-dialog-item-check">${item.selected ? "&#10003;" : ""}</div>
             </div>
-          `).join("") : emptySubtitleOptionsMarkup}
+          `
+                  )
+                  .join("")
+              : emptySubtitleOptionsMarkup
+          }
         </div>
         <div class="player-subtitle-rail player-subtitle-style-rail${showOptionsRail ? "" : " hidden"}">
-          ${styleItems.map((item, index) => `
+          ${styleItems
+            .map(
+              (item, index) => `
             <div class="player-dialog-item player-dialog-style-item${this.subtitleFocusedRail === "style" && index === this.subtitleStyleRailIndex ? " focused" : ""}" data-subtitle-rail="style" data-subtitle-index="${index}">
               <button class="player-dialog-step player-dialog-step-minus focusable${this.subtitleFocusedRail === "style" && index === this.subtitleStyleRailIndex && focusedStyleSide === "minus" ? " focused" : ""}" type="button" data-subtitle-style-action="decrease" data-subtitle-rail="style" data-subtitle-index="${index}" data-style-id="${escapeAttribute(item.id)}" aria-label="${escapeAttribute(`${item.label} -`)}">&#8722;</button>
               <div class="player-dialog-item-center">
@@ -10022,7 +11025,9 @@ export const PlayerScreen = {
               </div>
               <button class="player-dialog-step player-dialog-step-plus focusable${this.subtitleFocusedRail === "style" && index === this.subtitleStyleRailIndex && focusedStyleSide === "plus" ? " focused" : ""}" type="button" data-subtitle-style-action="increase" data-subtitle-rail="style" data-subtitle-index="${index}" data-style-id="${escapeAttribute(item.id)}" aria-label="${escapeAttribute(`${item.label} +`)}">&#43;</button>
             </div>
-          `).join("")}
+          `
+            )
+            .join("")}
         </div>
       </div>
     `;
@@ -10032,31 +11037,56 @@ export const PlayerScreen = {
   handleSubtitleDialogKey(event) {
     const keyCode = Number(event?.keyCode || 0);
     const languages = this.getSubtitleLanguageRailItems();
-    const activeLanguage = languages[this.subtitleLanguageRailIndex]?.key || SUBTITLE_LANGUAGE_OFF_KEY;
+    const activeLanguage =
+      languages[this.subtitleLanguageRailIndex]?.key || SUBTITLE_LANGUAGE_OFF_KEY;
     const options = this.getSubtitleOptionsForLanguage(activeLanguage);
     const styleItems = this.getSubtitleStyleControls();
     const styleItem = styleItems[this.subtitleStyleRailIndex];
-    
+
     if (keyCode === 38) {
       if (this.subtitleFocusedRail === "language") {
-        this.subtitleLanguageRailIndex = clamp(this.subtitleLanguageRailIndex - 1, 0, Math.max(0, languages.length - 1));
+        this.subtitleLanguageRailIndex = clamp(
+          this.subtitleLanguageRailIndex - 1,
+          0,
+          Math.max(0, languages.length - 1)
+        );
         this.syncSubtitleOptionIndexForFocusedLanguage();
       } else if (this.subtitleFocusedRail === "options") {
-        this.subtitleOptionRailIndex = clamp(this.subtitleOptionRailIndex - 1, 0, Math.max(0, options.length - 1));
+        this.subtitleOptionRailIndex = clamp(
+          this.subtitleOptionRailIndex - 1,
+          0,
+          Math.max(0, options.length - 1)
+        );
       } else {
-        this.subtitleStyleRailIndex = clamp(this.subtitleStyleRailIndex - 1, 0, Math.max(0, styleItems.length - 1));
+        this.subtitleStyleRailIndex = clamp(
+          this.subtitleStyleRailIndex - 1,
+          0,
+          Math.max(0, styleItems.length - 1)
+        );
       }
       this.renderSubtitleDialog();
       return true;
     }
     if (keyCode === 40) {
       if (this.subtitleFocusedRail === "language") {
-        this.subtitleLanguageRailIndex = clamp(this.subtitleLanguageRailIndex + 1, 0, Math.max(0, languages.length - 1));
+        this.subtitleLanguageRailIndex = clamp(
+          this.subtitleLanguageRailIndex + 1,
+          0,
+          Math.max(0, languages.length - 1)
+        );
         this.syncSubtitleOptionIndexForFocusedLanguage();
       } else if (this.subtitleFocusedRail === "options") {
-        this.subtitleOptionRailIndex = clamp(this.subtitleOptionRailIndex + 1, 0, Math.max(0, options.length - 1));
+        this.subtitleOptionRailIndex = clamp(
+          this.subtitleOptionRailIndex + 1,
+          0,
+          Math.max(0, options.length - 1)
+        );
       } else {
-        this.subtitleStyleRailIndex = clamp(this.subtitleStyleRailIndex + 1, 0, Math.max(0, styleItems.length - 1));
+        this.subtitleStyleRailIndex = clamp(
+          this.subtitleStyleRailIndex + 1,
+          0,
+          Math.max(0, styleItems.length - 1)
+        );
       }
       this.renderSubtitleDialog();
       return true;
@@ -10082,7 +11112,11 @@ export const PlayerScreen = {
       return true;
     }
     if (keyCode === 39) {
-      if (this.subtitleFocusedRail === "language" && activeLanguage !== SUBTITLE_LANGUAGE_OFF_KEY && options.length) {
+      if (
+        this.subtitleFocusedRail === "language" &&
+        activeLanguage !== SUBTITLE_LANGUAGE_OFF_KEY &&
+        options.length
+      ) {
         this.subtitleFocusedRail = "options";
         this.renderSubtitleDialog();
         return true;
@@ -10109,9 +11143,15 @@ export const PlayerScreen = {
           return true;
         }
         if (language.key === SUBTITLE_LANGUAGE_OFF_KEY) {
-          this.applySubtitleEntry(this.getSubtitleEntries("builtIn").find((entry) => entry.id === "subtitle-off") || { trackIndex: -1 });
+          this.applySubtitleEntry(
+            this.getSubtitleEntries("builtIn").find((entry) => entry.id === "subtitle-off") || {
+              trackIndex: -1
+            }
+          );
         } else {
-          const selected = this.selectFirstSubtitleOptionForLanguage(language.key, { focusOptions: true });
+          const selected = this.selectFirstSubtitleOptionForLanguage(language.key, {
+            focusOptions: true
+          });
           if (!selected) {
             const nextOptions = this.getSubtitleOptionsForLanguage(language.key);
             if (nextOptions.length) {
@@ -10133,7 +11173,10 @@ export const PlayerScreen = {
         return true;
       }
       if (styleItem) {
-        this.adjustSubtitleStyleControl(styleItem.id, this.getSubtitleStyleControlDelta(this.subtitleStyleControlSide));
+        this.adjustSubtitleStyleControl(
+          styleItem.id,
+          this.getSubtitleStyleControlDelta(this.subtitleStyleControlSide)
+        );
       }
       return true;
     }
@@ -10151,7 +11194,8 @@ export const PlayerScreen = {
     const representedEmbeddedIndexes = new Set();
 
     audioTracks.forEach((track, index) => {
-      const embeddedTrack = this.getEmbeddedAudioTrackByNativeIndex(index) || this.getEmbeddedAudioTrack(index);
+      const embeddedTrack =
+        this.getEmbeddedAudioTrackByNativeIndex(index) || this.getEmbeddedAudioTrack(index);
       const embeddedTrackIndex = Number(embeddedTrack?.embeddedTrackIndex);
       if (Number.isFinite(embeddedTrackIndex) && embeddedTrackIndex >= 0) {
         representedEmbeddedIndexes.add(embeddedTrackIndex);
@@ -10163,9 +11207,10 @@ export const PlayerScreen = {
         id: `audio-track-${index}`,
         label: display.label,
         secondary: display.secondary,
-        selected: Number.isFinite(embeddedTrackIndex) && this.selectedEmbeddedAudioTrackIndex >= 0
-          ? embeddedTrackIndex === this.selectedEmbeddedAudioTrackIndex
-          : index === this.selectedAudioTrackIndex,
+        selected:
+          Number.isFinite(embeddedTrackIndex) && this.selectedEmbeddedAudioTrackIndex >= 0
+            ? embeddedTrackIndex === this.selectedEmbeddedAudioTrackIndex
+            : index === this.selectedAudioTrackIndex,
         audioTrackIndex: index,
         track: mergedTrack
       });
@@ -10173,19 +11218,19 @@ export const PlayerScreen = {
 
     this.embeddedAudioTracks.forEach((track, index) => {
       const embeddedTrackIndex = Number(track?.embeddedTrackIndex);
-      const normalizedEmbeddedIndex = Number.isFinite(embeddedTrackIndex) && embeddedTrackIndex >= 0
-        ? embeddedTrackIndex
-        : index;
+      const normalizedEmbeddedIndex =
+        Number.isFinite(embeddedTrackIndex) && embeddedTrackIndex >= 0 ? embeddedTrackIndex : index;
       const nativeTrackIndex = Number(track?.nativeTrackIndex);
-      const representedByNativeIndex = Number.isFinite(nativeTrackIndex)
-        && nativeTrackIndex >= 0
-        && nativeTrackIndex < audioTracks.length;
+      const representedByNativeIndex =
+        Number.isFinite(nativeTrackIndex) &&
+        nativeTrackIndex >= 0 &&
+        nativeTrackIndex < audioTracks.length;
       const representedByOrder = index < audioTracks.length;
 
       if (
-        representedEmbeddedIndexes.has(normalizedEmbeddedIndex)
-        || representedByNativeIndex
-        || representedByOrder
+        representedEmbeddedIndexes.has(normalizedEmbeddedIndex) ||
+        representedByNativeIndex ||
+        representedByOrder
       ) {
         return;
       }
@@ -10209,14 +11254,16 @@ export const PlayerScreen = {
     if (cachedEntries) {
       return cachedEntries;
     }
-    const avplayAudioTracks = typeof PlayerController.getAvPlayAudioTracks === "function"
-      ? PlayerController.getAvPlayAudioTracks()
-      : [];
+    const avplayAudioTracks =
+      typeof PlayerController.getAvPlayAudioTracks === "function"
+        ? PlayerController.getAvPlayAudioTracks()
+        : [];
     let entries = [];
-	    if (avplayAudioTracks.length) {
-      const selectedAvPlayAudioTrack = typeof PlayerController.getSelectedAvPlayAudioTrackIndex === "function"
-        ? PlayerController.getSelectedAvPlayAudioTrackIndex()
-        : -1;
+    if (avplayAudioTracks.length) {
+      const selectedAvPlayAudioTrack =
+        typeof PlayerController.getSelectedAvPlayAudioTrackIndex === "function"
+          ? PlayerController.getSelectedAvPlayAudioTrackIndex()
+          : -1;
       entries = avplayAudioTracks.map((track, index) => {
         const mergedTrack = this.mergeAvPlayAudioTrackMetadata(track, index);
         const avplayTrackIndex = Number(track?.avplayTrackIndex);
@@ -10226,51 +11273,60 @@ export const PlayerScreen = {
           id: `audio-avplay-${normalizedTrackIndex}`,
           label: display.label,
           secondary: display.secondary,
-          selected: normalizedTrackIndex === selectedAvPlayAudioTrack
-            || (selectedAvPlayAudioTrack < 0 && normalizedTrackIndex === this.selectedAudioTrackIndex),
+          selected:
+            normalizedTrackIndex === selectedAvPlayAudioTrack ||
+            (selectedAvPlayAudioTrack < 0 && normalizedTrackIndex === this.selectedAudioTrackIndex),
           avplayAudioTrackIndex: normalizedTrackIndex,
           track: mergedTrack
         };
       });
     } else {
-      const dashAudioTracks = typeof PlayerController.getDashAudioTracks === "function"
-        ? PlayerController.getDashAudioTracks()
-        : [];
-      if (dashAudioTracks.length) {
-      const selectedDashAudioTrack = typeof PlayerController.getSelectedDashAudioTrackIndex === "function"
-        ? PlayerController.getSelectedDashAudioTrackIndex()
-        : -1;
-      entries = dashAudioTracks.map((track, index) => {
-        const display = formatAudioTrackDisplay(track, index);
-        return {
-          id: `audio-dash-${index}-${track?.id ?? ""}`,
-          label: display.label,
-          secondary: display.secondary,
-          selected: index === selectedDashAudioTrack || (selectedDashAudioTrack < 0 && index === this.selectedAudioTrackIndex),
-          dashAudioTrackIndex: index,
-          track
-        };
-      });
-      } else {
-        const hlsAudioTracks = typeof PlayerController.getHlsAudioTracks === "function"
-          ? PlayerController.getHlsAudioTracks()
+      const dashAudioTracks =
+        typeof PlayerController.getDashAudioTracks === "function"
+          ? PlayerController.getDashAudioTracks()
           : [];
+      if (dashAudioTracks.length) {
+        const selectedDashAudioTrack =
+          typeof PlayerController.getSelectedDashAudioTrackIndex === "function"
+            ? PlayerController.getSelectedDashAudioTrackIndex()
+            : -1;
+        entries = dashAudioTracks.map((track, index) => {
+          const display = formatAudioTrackDisplay(track, index);
+          return {
+            id: `audio-dash-${index}-${track?.id ?? ""}`,
+            label: display.label,
+            secondary: display.secondary,
+            selected:
+              index === selectedDashAudioTrack ||
+              (selectedDashAudioTrack < 0 && index === this.selectedAudioTrackIndex),
+            dashAudioTrackIndex: index,
+            track
+          };
+        });
+      } else {
+        const hlsAudioTracks =
+          typeof PlayerController.getHlsAudioTracks === "function"
+            ? PlayerController.getHlsAudioTracks()
+            : [];
         if (hlsAudioTracks.length) {
-      const selectedHlsAudioTrack = typeof PlayerController.getSelectedHlsAudioTrackIndex === "function"
-        ? PlayerController.getSelectedHlsAudioTrackIndex()
-        : -1;
-      entries = hlsAudioTracks.map((track, index) => {
-        const mergedTrack = this.mergeHlsAudioTrackMetadata(track, index);
-        const display = formatAudioTrackDisplay(mergedTrack, index);
-        return {
-          id: `audio-hls-${index}-${mergedTrack?.id ?? mergedTrack?.name ?? mergedTrack?.lang ?? ""}`,
-          label: display.label,
-          secondary: display.secondary,
-          selected: index === selectedHlsAudioTrack || (selectedHlsAudioTrack < 0 && index === this.selectedAudioTrackIndex),
-          hlsAudioTrackIndex: index,
-          track: mergedTrack
-        };
-      });
+          const selectedHlsAudioTrack =
+            typeof PlayerController.getSelectedHlsAudioTrackIndex === "function"
+              ? PlayerController.getSelectedHlsAudioTrackIndex()
+              : -1;
+          entries = hlsAudioTracks.map((track, index) => {
+            const mergedTrack = this.mergeHlsAudioTrackMetadata(track, index);
+            const display = formatAudioTrackDisplay(mergedTrack, index);
+            return {
+              id: `audio-hls-${index}-${mergedTrack?.id ?? mergedTrack?.name ?? mergedTrack?.lang ?? ""}`,
+              label: display.label,
+              secondary: display.secondary,
+              selected:
+                index === selectedHlsAudioTrack ||
+                (selectedHlsAudioTrack < 0 && index === this.selectedAudioTrackIndex),
+              hlsAudioTrackIndex: index,
+              track: mergedTrack
+            };
+          });
         } else {
           const audioTracks = this.getAudioTracks();
           if (audioTracks.length || this.embeddedAudioTracks.length) {
@@ -10300,21 +11356,62 @@ export const PlayerScreen = {
   },
 
   getImplicitAudioEntry() {
-    const currentStream = this.getCurrentStreamCandidate()?.raw || this.getCurrentStreamCandidate() || {};
-    const hasPlaybackContext = Boolean(this.activePlaybackUrl || currentStream?.url || currentStream?.externalUrl || currentStream?.ytId);
+    const currentStream =
+      this.getCurrentStreamCandidate()?.raw || this.getCurrentStreamCandidate() || {};
+    const hasPlaybackContext = Boolean(
+      this.activePlaybackUrl ||
+      currentStream?.url ||
+      currentStream?.externalUrl ||
+      currentStream?.ytId
+    );
     if (!hasPlaybackContext) {
       return null;
     }
 
     const track = {
-      language: currentStream?.language || currentStream?.lang || currentStream?.track_lang || currentStream?.extraInfo?.language || currentStream?.extraInfo?.track_lang || "",
-      sampleMimeType: currentStream?.sampleMimeType || currentStream?.mimeType || currentStream?.sourceType || currentStream?.type || "",
-      codec: currentStream?.codec || currentStream?.codecs || currentStream?.audioCodec || currentStream?.extraInfo?.audioCodec || "",
-      codecs: currentStream?.codecs || currentStream?.codec || currentStream?.audioCodec || currentStream?.extraInfo?.codecs || "",
+      language:
+        currentStream?.language ||
+        currentStream?.lang ||
+        currentStream?.track_lang ||
+        currentStream?.extraInfo?.language ||
+        currentStream?.extraInfo?.track_lang ||
+        "",
+      sampleMimeType:
+        currentStream?.sampleMimeType ||
+        currentStream?.mimeType ||
+        currentStream?.sourceType ||
+        currentStream?.type ||
+        "",
+      codec:
+        currentStream?.codec ||
+        currentStream?.codecs ||
+        currentStream?.audioCodec ||
+        currentStream?.extraInfo?.audioCodec ||
+        "",
+      codecs:
+        currentStream?.codecs ||
+        currentStream?.codec ||
+        currentStream?.audioCodec ||
+        currentStream?.extraInfo?.codecs ||
+        "",
       audioCodec: currentStream?.audioCodec || currentStream?.extraInfo?.audioCodec || "",
-      channelCount: currentStream?.channelCount || currentStream?.audioChannels || currentStream?.channels || currentStream?.extraInfo?.audioChannels || "",
-      channels: currentStream?.channels || currentStream?.audioChannels || currentStream?.channelCount || currentStream?.extraInfo?.audioChannels || "",
-      sampleRate: currentStream?.sampleRate || currentStream?.audioSampleRate || currentStream?.extraInfo?.audioSampleRate || 0
+      channelCount:
+        currentStream?.channelCount ||
+        currentStream?.audioChannels ||
+        currentStream?.channels ||
+        currentStream?.extraInfo?.audioChannels ||
+        "",
+      channels:
+        currentStream?.channels ||
+        currentStream?.audioChannels ||
+        currentStream?.channelCount ||
+        currentStream?.extraInfo?.audioChannels ||
+        "",
+      sampleRate:
+        currentStream?.sampleRate ||
+        currentStream?.audioSampleRate ||
+        currentStream?.extraInfo?.audioSampleRate ||
+        0
     };
     const display = formatAudioTrackDisplay(track, 0);
     return {
@@ -10329,7 +11426,11 @@ export const PlayerScreen = {
   },
 
   adjustAudioAmplification(delta = 0) {
-    const nextDb = clamp(Number(this.audioAmplificationDb || 0) + Number(delta || 0), AUDIO_AMPLIFICATION_MIN_DB, AUDIO_AMPLIFICATION_MAX_DB);
+    const nextDb = clamp(
+      Number(this.audioAmplificationDb || 0) + Number(delta || 0),
+      AUDIO_AMPLIFICATION_MIN_DB,
+      AUDIO_AMPLIFICATION_MAX_DB
+    );
     this.audioAmplificationDb = nextDb;
     this.persistPlayerPresentationSettings();
     this.applyAudioAmplification();
@@ -10380,9 +11481,10 @@ export const PlayerScreen = {
     }
 
     if (Number.isFinite(selectedEntry.avplayAudioTrackIndex)) {
-      const applied = typeof PlayerController.setAvPlayAudioTrack === "function"
-        ? PlayerController.setAvPlayAudioTrack(selectedEntry.avplayAudioTrackIndex)
-        : false;
+      const applied =
+        typeof PlayerController.setAvPlayAudioTrack === "function"
+          ? PlayerController.setAvPlayAudioTrack(selectedEntry.avplayAudioTrackIndex)
+          : false;
       if (applied) {
         this.selectedAudioTrackIndex = selectedEntry.avplayAudioTrackIndex;
         this.invalidateTrackDialogCaches();
@@ -10392,9 +11494,10 @@ export const PlayerScreen = {
     }
 
     if (Number.isFinite(selectedEntry.dashAudioTrackIndex)) {
-      const applied = typeof PlayerController.setDashAudioTrack === "function"
-        ? PlayerController.setDashAudioTrack(selectedEntry.dashAudioTrackIndex)
-        : false;
+      const applied =
+        typeof PlayerController.setDashAudioTrack === "function"
+          ? PlayerController.setDashAudioTrack(selectedEntry.dashAudioTrackIndex)
+          : false;
       if (applied) {
         this.selectedAudioTrackIndex = selectedEntry.dashAudioTrackIndex;
         this.invalidateTrackDialogCaches();
@@ -10404,9 +11507,10 @@ export const PlayerScreen = {
     }
 
     if (Number.isFinite(selectedEntry.hlsAudioTrackIndex)) {
-      const applied = typeof PlayerController.setHlsAudioTrack === "function"
-        ? PlayerController.setHlsAudioTrack(selectedEntry.hlsAudioTrackIndex)
-        : false;
+      const applied =
+        typeof PlayerController.setHlsAudioTrack === "function"
+          ? PlayerController.setHlsAudioTrack(selectedEntry.hlsAudioTrackIndex)
+          : false;
       if (applied) {
         this.selectedAudioTrackIndex = selectedEntry.hlsAudioTrackIndex;
         this.invalidateTrackDialogCaches();
@@ -10432,42 +11536,61 @@ export const PlayerScreen = {
       return;
     }
 
-	    if (Number.isFinite(selectedEntry.embeddedAudioTrackIndex)) {
-	      const embeddedTrack = this.getEmbeddedAudioTrackByEmbeddedIndex(selectedEntry.embeddedAudioTrackIndex);
-	      let applied = false;
-	      if (Environment.isTizen() && typeof PlayerController.isUsingAvPlay === "function" && PlayerController.isUsingAvPlay()) {
-	        const nativeTrackIndex = Number(embeddedTrack?.nativeTrackIndex);
-	        applied = typeof PlayerController.setAvPlayAudioTrack === "function" && Number.isFinite(nativeTrackIndex)
-	          ? PlayerController.setAvPlayAudioTrack(nativeTrackIndex)
-	          : false;
+    if (Number.isFinite(selectedEntry.embeddedAudioTrackIndex)) {
+      const embeddedTrack = this.getEmbeddedAudioTrackByEmbeddedIndex(
+        selectedEntry.embeddedAudioTrackIndex
+      );
+      let applied = false;
+      if (
+        Environment.isTizen() &&
+        typeof PlayerController.isUsingAvPlay === "function" &&
+        PlayerController.isUsingAvPlay()
+      ) {
+        const nativeTrackIndex = Number(embeddedTrack?.nativeTrackIndex);
+        applied =
+          typeof PlayerController.setAvPlayAudioTrack === "function" &&
+          Number.isFinite(nativeTrackIndex)
+            ? PlayerController.setAvPlayAudioTrack(nativeTrackIndex)
+            : false;
       } else {
         const nativeTrackIndex = Number(embeddedTrack?.nativeTrackIndex);
-        const targetTrackIndex = Number.isFinite(nativeTrackIndex) && nativeTrackIndex >= 0
-          ? nativeTrackIndex
-          : selectedEntry.embeddedAudioTrackIndex;
-	        applied = typeof PlayerController.setWebOsEmbeddedAudioTrack === "function"
-	          ? PlayerController.setWebOsEmbeddedAudioTrack(targetTrackIndex, selectedEntry.embeddedAudioTrackIndex)
-	          : false;
+        const targetTrackIndex =
+          Number.isFinite(nativeTrackIndex) && nativeTrackIndex >= 0
+            ? nativeTrackIndex
+            : selectedEntry.embeddedAudioTrackIndex;
+        applied =
+          typeof PlayerController.setWebOsEmbeddedAudioTrack === "function"
+            ? PlayerController.setWebOsEmbeddedAudioTrack(
+                targetTrackIndex,
+                selectedEntry.embeddedAudioTrackIndex
+              )
+            : false;
       }
-		      if (applied) {
-		        this.selectedEmbeddedAudioTrackIndex = selectedEntry.embeddedAudioTrackIndex;
-		        this.selectedAudioTrackIndex = selectedEntry.embeddedAudioTrackIndex;
-	        this.invalidateTrackDialogCaches();
-	        this.renderControlButtons();
-	        this.renderAudioDialog();
-	      }
+      if (applied) {
+        this.selectedEmbeddedAudioTrackIndex = selectedEntry.embeddedAudioTrackIndex;
+        this.selectedAudioTrackIndex = selectedEntry.embeddedAudioTrackIndex;
+        this.invalidateTrackDialogCaches();
+        this.renderControlButtons();
+        this.renderAudioDialog();
+      }
       return;
     }
 
     const audioTracks = this.getAudioTracks();
     const nativeTrackIndex = Number(selectedEntry.audioTrackIndex);
-    if (!audioTracks.length || !Number.isFinite(nativeTrackIndex) || nativeTrackIndex < 0 || nativeTrackIndex >= audioTracks.length) {
+    if (
+      !audioTracks.length ||
+      !Number.isFinite(nativeTrackIndex) ||
+      nativeTrackIndex < 0 ||
+      nativeTrackIndex >= audioTracks.length
+    ) {
       return;
     }
 
-    const appliedByController = typeof PlayerController.setNativeAudioTrack === "function"
-      ? PlayerController.setNativeAudioTrack(nativeTrackIndex)
-      : false;
+    const appliedByController =
+      typeof PlayerController.setNativeAudioTrack === "function"
+        ? PlayerController.setNativeAudioTrack(nativeTrackIndex)
+        : false;
     if (appliedByController) {
       this.selectedAudioTrackIndex = nativeTrackIndex;
       this.selectedEmbeddedAudioTrackIndex = -1;
@@ -10520,11 +11643,19 @@ export const PlayerScreen = {
         title: t("audio_mix_label", {}, "Audio boost"),
         value: `${Math.round(Number(this.audioAmplificationDb || 0))} dB`,
         helper: this.audioAmplificationAvailable
-          ? t("audio_mix_range", { min: AUDIO_AMPLIFICATION_MIN_DB, max: AUDIO_AMPLIFICATION_MAX_DB }, `Range ${AUDIO_AMPLIFICATION_MIN_DB}-${AUDIO_AMPLIFICATION_MAX_DB} dB`)
+          ? t(
+              "audio_mix_range",
+              { min: AUDIO_AMPLIFICATION_MIN_DB, max: AUDIO_AMPLIFICATION_MAX_DB },
+              `Range ${AUDIO_AMPLIFICATION_MIN_DB}-${AUDIO_AMPLIFICATION_MAX_DB} dB`
+            )
           : t("audio_mix_unavailable", {}, "Unavailable on this device"),
         enabled: Boolean(this.audioAmplificationAvailable),
-        canDecrease: this.audioAmplificationAvailable && Number(this.audioAmplificationDb || 0) > AUDIO_AMPLIFICATION_MIN_DB,
-        canIncrease: this.audioAmplificationAvailable && Number(this.audioAmplificationDb || 0) < AUDIO_AMPLIFICATION_MAX_DB
+        canDecrease:
+          this.audioAmplificationAvailable &&
+          Number(this.audioAmplificationDb || 0) > AUDIO_AMPLIFICATION_MIN_DB,
+        canIncrease:
+          this.audioAmplificationAvailable &&
+          Number(this.audioAmplificationDb || 0) < AUDIO_AMPLIFICATION_MAX_DB
       },
       {
         id: "persist",
@@ -10540,9 +11671,13 @@ export const PlayerScreen = {
     this.audioMixFocusIndex = clamp(this.audioMixFocusIndex, 0, audioControls.length - 1);
     if (!entries.length) {
       this.audioFocusedColumn = "controls";
-      const loading = this.embeddedAudioLoading
-        || (this.isCurrentSourceAdaptiveManifest() && (this.manifestLoading || this.trackDiscoveryInProgress));
-      const emptyMessage = loading ? "Loading audio tracks..." : this.getUnavailableTrackMessage("audio");
+      const loading =
+        this.embeddedAudioLoading ||
+        (this.isCurrentSourceAdaptiveManifest() &&
+          (this.manifestLoading || this.trackDiscoveryInProgress));
+      const emptyMessage = loading
+        ? "Loading audio tracks..."
+        : this.getUnavailableTrackMessage("audio");
       dialog.innerHTML = `
         <div class="player-dialog-title">${escapeHtml(t("audio_dialog_title", {}, "Audio"))}</div>
         <div class="player-dialog-empty">${emptyMessage}</div>
@@ -10558,17 +11693,20 @@ export const PlayerScreen = {
       <div class="player-dialog-title">${escapeHtml(t("audio_dialog_title", {}, "Audio"))}</div>
       <div class="player-audio-overlay-grid">
         <div class="player-dialog-list player-audio-track-list">
-          ${entries.map((entry, index) => {
-            const selected = entry.selected;
-            const focused = this.audioFocusedColumn === "tracks" && index === this.audioDialogIndex;
-            return `
+          ${entries
+            .map((entry, index) => {
+              const selected = entry.selected;
+              const focused =
+                this.audioFocusedColumn === "tracks" && index === this.audioDialogIndex;
+              return `
               <div class="player-dialog-item focusable${selected ? " selected" : ""}${focused ? " focused" : ""}" data-audio-column="tracks" data-audio-index="${index}">
                 <div class="player-dialog-item-main">${escapeHtml(entry.label || "")}</div>
                 <div class="player-dialog-item-sub">${escapeHtml(entry.secondary || "")}</div>
                 <div class="player-dialog-item-check">${selected ? "&#10003;" : ""}</div>
               </div>
             `;
-          }).join("")}
+            })
+            .join("")}
         </div>
         <div class="player-audio-controls-list">
           ${audioControls.map((control, index) => this.renderAudioControlItem(control, index)).join("")}
@@ -10624,7 +11762,8 @@ export const PlayerScreen = {
   handleAudioDialogKey(event) {
     const keyCode = Number(event?.keyCode || 0);
     const entries = this.getAudioEntries();
-    const isNavigationKey = keyCode === 37 || keyCode === 38 || keyCode === 39 || keyCode === 40 || keyCode === 13;
+    const isNavigationKey =
+      keyCode === 37 || keyCode === 38 || keyCode === 39 || keyCode === 40 || keyCode === 13;
 
     if (keyCode === 37) {
       if (this.audioFocusedColumn === "controls") {
@@ -10691,7 +11830,10 @@ export const PlayerScreen = {
     this.subtitleDialogVisible = false;
     this.audioDialogVisible = false;
     this.sourcesPanelVisible = false;
-    this.speedDialogIndex = Math.max(0, PLAYER_SPEEDS.findIndex((value) => value === currentSpeed));
+    this.speedDialogIndex = Math.max(
+      0,
+      PLAYER_SPEEDS.findIndex((value) => value === currentSpeed)
+    );
     this.renderSubtitleDialog();
     this.renderAudioDialog();
     this.renderSourcesPanel();
@@ -10731,13 +11873,15 @@ export const PlayerScreen = {
     dialog.innerHTML = `
       <div class="player-dialog-title">${escapeHtml(t("player_playback_speed", {}, "Playback speed"))}</div>
       <div class="player-dialog-list">
-        ${PLAYER_SPEEDS.map((speed, index) => `
+        ${PLAYER_SPEEDS.map(
+          (speed, index) => `
           <div class="player-dialog-item focusable${speed === currentSpeed ? " selected" : ""}${index === this.speedDialogIndex ? " focused" : ""}" data-speed-index="${index}">
             <div class="player-dialog-item-main">${escapeHtml(`${speed}x`)}</div>
             <div class="player-dialog-item-sub">${escapeHtml(speed === 1 ? t("common.normal", {}, "Normal") : t("player_playback_speed", {}, "Playback speed"))}</div>
             <div class="player-dialog-item-check">${speed === currentSpeed ? "&#10003;" : ""}</div>
           </div>
-        `).join("")}
+        `
+        ).join("")}
       </div>
     `;
   },
@@ -10824,7 +11968,10 @@ export const PlayerScreen = {
       return;
     }
     this.sourceFilter = filter;
-    this.sourcesFocus = { zone: "filter", index: clamp(available.indexOf(filter), 0, available.length - 1) };
+    this.sourcesFocus = {
+      zone: "filter",
+      index: clamp(available.indexOf(filter), 0, available.length - 1)
+    };
   },
 
   openSourcesPanel({ forceReload = false } = {}) {
@@ -10836,7 +11983,10 @@ export const PlayerScreen = {
     this.moreActionsVisible = false;
 
     const filters = this.getSourceFilters();
-    this.sourcesFocus = { zone: "filter", index: clamp(filters.indexOf(this.sourceFilter), 0, Math.max(0, filters.length - 1)) };
+    this.sourcesFocus = {
+      zone: "filter",
+      index: clamp(filters.indexOf(this.sourceFilter), 0, Math.max(0, filters.length - 1))
+    };
 
     this.renderControlButtons();
     this.renderSubtitleDialog();
@@ -10941,36 +12091,45 @@ export const PlayerScreen = {
       </div>
 
       <div class="player-source-current-meta">
-        ${escapeHtml(this.params?.season != null && this.params?.episode != null
-          ? `S${this.params.season} E${this.params.episode}${this.params.playerSubtitle ? ` • ${this.params.playerSubtitle}` : ""}`
-          : (this.params?.playerTitle || this.params?.itemId || ""))}
+        ${escapeHtml(
+          this.params?.season != null && this.params?.episode != null
+            ? `S${this.params.season} E${this.params.episode}${this.params.playerSubtitle ? ` • ${this.params.playerSubtitle}` : ""}`
+            : this.params?.playerTitle || this.params?.itemId || ""
+        )}
       </div>
 
       <div class="player-sources-filters">
-        ${filters.map((filter, index) => {
-          const selected = this.sourceFilter === filter;
-          const focused = this.sourcesFocus.zone === "filter" && this.sourcesFocus.index === index;
-          return `
+        ${filters
+          .map((filter, index) => {
+            const selected = this.sourceFilter === filter;
+            const focused =
+              this.sourcesFocus.zone === "filter" && this.sourcesFocus.index === index;
+            return `
             <div class="player-sources-filter focusable${selected ? " selected" : ""}${focused ? " focused" : ""}" data-sources-zone="filter" data-sources-index="${index}">
               ${escapeHtml(filter === "all" ? t("subtitle_all", {}, "All") : filter)}
             </div>
           `;
-        }).join("")}
+          })
+          .join("")}
       </div>
 
       <div class="player-sources-list">
         ${this.sourcesLoading ? `<div class="player-sources-empty">${escapeHtml(t("stream_finding_source", {}, "Finding stream source"))}</div>` : ""}
         ${this.sourcesError ? `<div class="player-sources-empty">${escapeHtml(this.sourcesError)}</div>` : ""}
-        ${!this.sourcesLoading && !filtered.length
-          ? `<div class="player-sources-empty">${escapeHtml(t("sources_no_streams", {}, "No streams found"))}</div>`
-          : filtered.map((stream, index) => {
-            const focused = this.sourcesFocus.zone === "list" && this.sourcesFocus.index === index;
-            const isCurrent = this.streamCandidates[this.currentStreamIndex]?.url === stream.url;
-            const badges = renderPlayerSourceBadges(stream, badgeSettings);
-            const topBadges = badgePlacement === "TOP" ? badges : "";
-            const bottomBadges = badgePlacement === "BOTTOM" ? badges : "";
-            const addonLogoUrl = normalizeImageUrl(stream.addonLogo);
-            return `
+        ${
+          !this.sourcesLoading && !filtered.length
+            ? `<div class="player-sources-empty">${escapeHtml(t("sources_no_streams", {}, "No streams found"))}</div>`
+            : filtered
+                .map((stream, index) => {
+                  const focused =
+                    this.sourcesFocus.zone === "list" && this.sourcesFocus.index === index;
+                  const isCurrent =
+                    this.streamCandidates[this.currentStreamIndex]?.url === stream.url;
+                  const badges = renderPlayerSourceBadges(stream, badgeSettings);
+                  const topBadges = badgePlacement === "TOP" ? badges : "";
+                  const bottomBadges = badgePlacement === "BOTTOM" ? badges : "";
+                  const addonLogoUrl = normalizeImageUrl(stream.addonLogo);
+                  return `
               <article class="player-source-card focusable${focused ? " focused" : ""}${isCurrent ? " selected" : ""}" data-sources-zone="list" data-sources-index="${index}">
                 <div class="player-source-main">
                   ${topBadges}
@@ -10989,7 +12148,9 @@ export const PlayerScreen = {
                 </div>
               </article>
             `;
-          }).join("")}
+                })
+                .join("")
+        }
       </div>
     `;
 
@@ -11016,7 +12177,10 @@ export const PlayerScreen = {
       }
       if (direction === "down") {
         if (filters.length) {
-          this.sourcesFocus = { zone: "filter", index: clamp(filters.indexOf(this.sourceFilter), 0, filters.length - 1) };
+          this.sourcesFocus = {
+            zone: "filter",
+            index: clamp(filters.indexOf(this.sourceFilter), 0, filters.length - 1)
+          };
         } else if (list.length) {
           this.sourcesFocus = { zone: "list", index: 0 };
         }
@@ -11027,11 +12191,17 @@ export const PlayerScreen = {
 
     if (zone === "filter") {
       if (direction === "left") {
-        this.sourcesFocus = { zone: "filter", index: clamp(index - 1, 0, Math.max(0, filters.length - 1)) };
+        this.sourcesFocus = {
+          zone: "filter",
+          index: clamp(index - 1, 0, Math.max(0, filters.length - 1))
+        };
         return;
       }
       if (direction === "right") {
-        this.sourcesFocus = { zone: "filter", index: clamp(index + 1, 0, Math.max(0, filters.length - 1)) };
+        this.sourcesFocus = {
+          zone: "filter",
+          index: clamp(index + 1, 0, Math.max(0, filters.length - 1))
+        };
         return;
       }
       if (direction === "up") {
@@ -11049,14 +12219,20 @@ export const PlayerScreen = {
         if (index > 0) {
           this.sourcesFocus = { zone: "list", index: index - 1 };
         } else if (filters.length) {
-          this.sourcesFocus = { zone: "filter", index: clamp(filters.indexOf(this.sourceFilter), 0, filters.length - 1) };
+          this.sourcesFocus = {
+            zone: "filter",
+            index: clamp(filters.indexOf(this.sourceFilter), 0, filters.length - 1)
+          };
         } else {
           this.sourcesFocus = { zone: "top", index: 0 };
         }
         return;
       }
       if (direction === "down") {
-        this.sourcesFocus = { zone: "list", index: clamp(index + 1, 0, Math.max(0, list.length - 1)) };
+        this.sourcesFocus = {
+          zone: "list",
+          index: clamp(index + 1, 0, Math.max(0, list.length - 1))
+        };
       }
     }
   },
@@ -11166,12 +12342,29 @@ export const PlayerScreen = {
   },
 
   calculateAspectRect(objectFit = "contain", video = PlayerController.video) {
-    const viewport = typeof PlayerController.getPlayerViewportSize === "function"
-      ? PlayerController.getPlayerViewportSize()
-      : {
-        width: Math.max(1, Number(window.innerWidth || document.documentElement?.clientWidth || globalThis.screen?.width || 1920)),
-        height: Math.max(1, Number(window.innerHeight || document.documentElement?.clientHeight || globalThis.screen?.height || 1080))
-      };
+    const viewport =
+      typeof PlayerController.getPlayerViewportSize === "function"
+        ? PlayerController.getPlayerViewportSize()
+        : {
+            width: Math.max(
+              1,
+              Number(
+                window.innerWidth ||
+                  document.documentElement?.clientWidth ||
+                  globalThis.screen?.width ||
+                  1920
+              )
+            ),
+            height: Math.max(
+              1,
+              Number(
+                window.innerHeight ||
+                  document.documentElement?.clientHeight ||
+                  globalThis.screen?.height ||
+                  1080
+              )
+            )
+          };
     const viewportWidth = viewport.width;
     const viewportHeight = viewport.height;
     if (objectFit === "fill") {
@@ -11184,19 +12377,16 @@ export const PlayerScreen = {
       };
     }
 
-    const avplayDimensions = typeof PlayerController.getAvPlayVideoDimensions === "function"
-      ? PlayerController.getAvPlayVideoDimensions()
-      : null;
+    const avplayDimensions =
+      typeof PlayerController.getAvPlayVideoDimensions === "function"
+        ? PlayerController.getAvPlayVideoDimensions()
+        : null;
     const videoWidth = Number(video?.videoWidth || avplayDimensions?.width || 0);
     const videoHeight = Number(video?.videoHeight || avplayDimensions?.height || 0);
-    const mediaRatio = videoWidth > 0 && videoHeight > 0
-      ? videoWidth / videoHeight
-      : 16 / 9;
+    const mediaRatio = videoWidth > 0 && videoHeight > 0 ? videoWidth / videoHeight : 16 / 9;
     const viewportRatio = viewportWidth / viewportHeight;
     const shouldCover = objectFit === "cover";
-    const widthLimited = shouldCover
-      ? viewportRatio > mediaRatio
-      : viewportRatio < mediaRatio;
+    const widthLimited = shouldCover ? viewportRatio > mediaRatio : viewportRatio < mediaRatio;
     const width = widthLimited ? viewportWidth : viewportHeight * mediaRatio;
     const height = widthLimited ? viewportWidth / mediaRatio : viewportHeight;
 
@@ -11205,7 +12395,9 @@ export const PlayerScreen = {
       y: (viewportHeight - height) / 2,
       width,
       height,
-      displayMethod: shouldCover ? "PLAYER_DISPLAY_MODE_FULL_SCREEN" : "PLAYER_DISPLAY_MODE_LETTER_BOX"
+      displayMethod: shouldCover
+        ? "PLAYER_DISPLAY_MODE_FULL_SCREEN"
+        : "PLAYER_DISPLAY_MODE_LETTER_BOX"
     };
   },
 
@@ -11219,7 +12411,8 @@ export const PlayerScreen = {
       return;
     }
 
-    const shouldRender = (this.parentalGuideVisible || this.parentalGuideExiting) && this.parentalWarnings.length;
+    const shouldRender =
+      (this.parentalGuideVisible || this.parentalGuideExiting) && this.parentalWarnings.length;
     overlay.classList.toggle("hidden", !shouldRender);
     overlay.classList.toggle("is-exiting", Boolean(this.parentalGuideExiting));
     if (!shouldRender) {
@@ -11234,12 +12427,16 @@ export const PlayerScreen = {
     }
 
     const total = this.parentalWarnings.length;
-    const firstItemDelay = PARENTAL_GUIDE_CONTAINER_IN_MS + PARENTAL_GUIDE_LINE_IN_MS + PARENTAL_GUIDE_ITEM_STAGGER_MS;
-    const lineExitDelay = Math.max(0, total * (PARENTAL_GUIDE_ITEM_EXIT_STAGGER_MS + PARENTAL_GUIDE_ITEM_EXIT_MS)) + PARENTAL_GUIDE_LINE_OUT_DELAY_MS;
-    const containerExitDelay = lineExitDelay + PARENTAL_GUIDE_LINE_OUT_MS + PARENTAL_GUIDE_CONTAINER_OUT_DELAY_MS;
+    const firstItemDelay =
+      PARENTAL_GUIDE_CONTAINER_IN_MS + PARENTAL_GUIDE_LINE_IN_MS + PARENTAL_GUIDE_ITEM_STAGGER_MS;
+    const lineExitDelay =
+      Math.max(0, total * (PARENTAL_GUIDE_ITEM_EXIT_STAGGER_MS + PARENTAL_GUIDE_ITEM_EXIT_MS)) +
+      PARENTAL_GUIDE_LINE_OUT_DELAY_MS;
+    const containerExitDelay =
+      lineExitDelay + PARENTAL_GUIDE_LINE_OUT_MS + PARENTAL_GUIDE_CONTAINER_OUT_DELAY_MS;
     const rowHeight = PARENTAL_GUIDE_ROW_HEIGHT;
     const rowGap = PARENTAL_GUIDE_ROW_GAP;
-    const lineHeight = (rowHeight * total) + (rowGap * Math.max(0, total - 1));
+    const lineHeight = rowHeight * total + rowGap * Math.max(0, total - 1);
     const currentLineHeight = clamp(Number(this.parentalGuideLineProgress || 0), 0, lineHeight);
     const rootStyle = getComputedStyle(document.documentElement);
     const parentalAccent = rootStyle.getPropertyValue("--secondary-color").trim() || "#f5f5f5";
@@ -11256,18 +12453,24 @@ export const PlayerScreen = {
         <div class="player-parental-line-fill"></div>
       </div>
       <div class="player-parental-list">
-        ${this.parentalWarnings.map((warning, index) => {
-          const enterDelay = firstItemDelay + (index * (PARENTAL_GUIDE_ITEM_STAGGER_MS + PARENTAL_GUIDE_ITEM_IN_MS));
-          const exitDelay = PARENTAL_GUIDE_ITEM_EXIT_STAGGER_MS + ((total - index - 1) * (PARENTAL_GUIDE_ITEM_EXIT_STAGGER_MS + PARENTAL_GUIDE_ITEM_EXIT_MS));
-          const activeDelay = this.parentalGuideExiting ? exitDelay : enterDelay;
-          return `
+        ${this.parentalWarnings
+          .map((warning, index) => {
+            const enterDelay =
+              firstItemDelay + index * (PARENTAL_GUIDE_ITEM_STAGGER_MS + PARENTAL_GUIDE_ITEM_IN_MS);
+            const exitDelay =
+              PARENTAL_GUIDE_ITEM_EXIT_STAGGER_MS +
+              (total - index - 1) *
+                (PARENTAL_GUIDE_ITEM_EXIT_STAGGER_MS + PARENTAL_GUIDE_ITEM_EXIT_MS);
+            const activeDelay = this.parentalGuideExiting ? exitDelay : enterDelay;
+            return `
           <div class="player-parental-item" style="animation-delay:${activeDelay}ms;--parental-enter-delay:${enterDelay}ms;--parental-exit-delay:${exitDelay}ms">
             <span class="player-parental-label">${escapeHtml(warning.label)}</span>
             <span class="player-parental-separator"> · </span>
             <span class="player-parental-severity">${escapeHtml(warning.severity)}</span>
           </div>
         `;
-        }).join("")}
+          })
+          .join("")}
       </div>
     `;
 
@@ -11290,7 +12493,10 @@ export const PlayerScreen = {
       clearTimeout(this.parentalGuideLineExitTimer);
       this.parentalGuideLineExitTimer = null;
     }
-    if (this.parentalGuideLineAnimationFrame != null && typeof cancelAnimationFrame === "function") {
+    if (
+      this.parentalGuideLineAnimationFrame != null &&
+      typeof cancelAnimationFrame === "function"
+    ) {
       cancelAnimationFrame(this.parentalGuideLineAnimationFrame);
     }
     this.parentalGuideLineAnimationFrame = null;
@@ -11326,7 +12532,7 @@ export const PlayerScreen = {
     const tick = (timestamp) => {
       const elapsed = Math.max(0, Number(timestamp || Date.now()) - startedAt);
       const progress = clamp(elapsed / Math.max(1, Number(durationMs || 1)), 0, 1);
-      this.parentalGuideLineProgress = from + ((target - from) * progress);
+      this.parentalGuideLineProgress = from + (target - from) * progress;
       line.style.height = `${Math.max(0, this.parentalGuideLineProgress).toFixed(2)}px`;
       if (progress < 1) {
         this.parentalGuideLineAnimationFrame = requestAnimationFrame(tick);
@@ -11360,9 +12566,14 @@ export const PlayerScreen = {
     this.parentalGuideShown = true;
     this.renderParentalGuideOverlay();
     this.stopParentalGuideLineAnimation({ reset: true });
-    const lineHeight = (PARENTAL_GUIDE_ROW_HEIGHT * this.parentalWarnings.length)
-      + (PARENTAL_GUIDE_ROW_GAP * Math.max(0, this.parentalWarnings.length - 1));
-    this.scheduleParentalGuideLineAnimation(lineHeight, PARENTAL_GUIDE_CONTAINER_IN_MS, PARENTAL_GUIDE_LINE_IN_MS);
+    const lineHeight =
+      PARENTAL_GUIDE_ROW_HEIGHT * this.parentalWarnings.length +
+      PARENTAL_GUIDE_ROW_GAP * Math.max(0, this.parentalWarnings.length - 1);
+    this.scheduleParentalGuideLineAnimation(
+      lineHeight,
+      PARENTAL_GUIDE_CONTAINER_IN_MS,
+      PARENTAL_GUIDE_LINE_IN_MS
+    );
 
     if (this.parentalGuideTimer) {
       clearTimeout(this.parentalGuideTimer);
@@ -11372,9 +12583,10 @@ export const PlayerScreen = {
       this.parentalGuideExitTimer = null;
     }
 
-    const enterDuration = PARENTAL_GUIDE_CONTAINER_IN_MS
-      + PARENTAL_GUIDE_LINE_IN_MS
-      + (this.parentalWarnings.length * (PARENTAL_GUIDE_ITEM_STAGGER_MS + PARENTAL_GUIDE_ITEM_IN_MS));
+    const enterDuration =
+      PARENTAL_GUIDE_CONTAINER_IN_MS +
+      PARENTAL_GUIDE_LINE_IN_MS +
+      this.parentalWarnings.length * (PARENTAL_GUIDE_ITEM_STAGGER_MS + PARENTAL_GUIDE_ITEM_IN_MS);
     this.parentalGuideTimer = setTimeout(() => {
       this.hideParentalGuideOverlay();
     }, enterDuration + PARENTAL_GUIDE_HOLD_MS);
@@ -11401,8 +12613,11 @@ export const PlayerScreen = {
       clearTimeout(this.parentalGuideExitTimer);
     }
     const total = this.parentalWarnings.length;
-    const lineExitDelay = Math.max(0, total * (PARENTAL_GUIDE_ITEM_EXIT_STAGGER_MS + PARENTAL_GUIDE_ITEM_EXIT_MS)) + PARENTAL_GUIDE_LINE_OUT_DELAY_MS;
-    const containerExitDelay = lineExitDelay + PARENTAL_GUIDE_LINE_OUT_MS + PARENTAL_GUIDE_CONTAINER_OUT_DELAY_MS;
+    const lineExitDelay =
+      Math.max(0, total * (PARENTAL_GUIDE_ITEM_EXIT_STAGGER_MS + PARENTAL_GUIDE_ITEM_EXIT_MS)) +
+      PARENTAL_GUIDE_LINE_OUT_DELAY_MS;
+    const containerExitDelay =
+      lineExitDelay + PARENTAL_GUIDE_LINE_OUT_MS + PARENTAL_GUIDE_CONTAINER_OUT_DELAY_MS;
     this.parentalGuideLineExitTimer = setTimeout(() => {
       this.parentalGuideLineExitTimer = null;
       this.animateParentalGuideLine(0, PARENTAL_GUIDE_LINE_OUT_MS);
@@ -11455,13 +12670,17 @@ export const PlayerScreen = {
     panel.id = "episodeSidePanel";
     panel.className = "player-episode-panel";
 
-    const cards = this.episodes.slice(0, 80).map((episode, index) => {
-      const selected = index === this.episodePanelIndex;
-      const selectedClass = selected ? " selected" : "";
-      const current = Number(episode?.season) === Number(this.params?.season) && Number(episode?.episode) === Number(this.params?.episode);
-      const code = episodeDisplayCode(episode);
-      const thumbnail = episodeThumbnailUrl(episode);
-      return `
+    const cards = this.episodes
+      .slice(0, 80)
+      .map((episode, index) => {
+        const selected = index === this.episodePanelIndex;
+        const selectedClass = selected ? " selected" : "";
+        const current =
+          Number(episode?.season) === Number(this.params?.season) &&
+          Number(episode?.episode) === Number(this.params?.episode);
+        const code = episodeDisplayCode(episode);
+        const thumbnail = episodeThumbnailUrl(episode);
+        return `
         <div class="player-episode-item focusable${selectedClass}" data-episode-index="${index}">
           <div class="player-episode-thumb-wrap">
             ${thumbnail ? `<img class="player-episode-thumb" src="${escapeAttribute(thumbnail)}" alt="" />` : `<div class="player-episode-thumb-fallback"></div>`}
@@ -11475,7 +12694,8 @@ export const PlayerScreen = {
           </div>
         </div>
       `;
-    }).join("");
+      })
+      .join("");
 
     panel.innerHTML = `
       <div class="player-episode-panel-title">${escapeHtml(t("episodes_panel_title", {}, "Episodes"))}</div>
@@ -11512,30 +12732,35 @@ export const PlayerScreen = {
       const nextEpisode = this.episodes[this.episodePanelIndex + 1] || null;
       await PlayerController.flushCurrentProgress({ forceCloudSync: true });
       await this.releaseCurrentEngineFsStream("episode-change", { removeTorrent: true });
-      Router.navigate("player", {
-        streamUrl: bestStream,
-        itemId: this.params?.itemId,
-        itemType,
-        imdbId: this.params?.imdbId || null,
-        videoId: selected.id,
-        season: selected.season ?? null,
-        episode: selected.episode ?? null,
-        episodeLabel: `S${selected.season}E${selected.episode}`,
-        playerTitle: this.params?.playerTitle || this.params?.itemId,
-        playerSubtitle: `${selected.title || ""}`.trim() || `S${selected.season}E${selected.episode}`,
-        playerBackdropUrl: this.params?.playerBackdropUrl || null,
-        playerLogoUrl: this.params?.playerLogoUrl || null,
-        episodes: this.episodes,
-        streamCandidates: streamItems,
-        nextEpisodeVideoId: nextEpisode?.id || null,
-        nextEpisodeLabel: nextEpisode ? `S${nextEpisode.season}E${nextEpisode.episode}` : null,
-        nextEpisodeSeason: nextEpisode?.season ?? null,
-        nextEpisodeEpisode: nextEpisode?.episode ?? null,
-        nextEpisodeTitle: nextEpisode?.title || "",
-        nextEpisodeReleased: nextEpisode?.released || ""
-      }, {
-        replaceHistory: true
-      });
+      Router.navigate(
+        "player",
+        {
+          streamUrl: bestStream,
+          itemId: this.params?.itemId,
+          itemType,
+          imdbId: this.params?.imdbId || null,
+          videoId: selected.id,
+          season: selected.season ?? null,
+          episode: selected.episode ?? null,
+          episodeLabel: `S${selected.season}E${selected.episode}`,
+          playerTitle: this.params?.playerTitle || this.params?.itemId,
+          playerSubtitle:
+            `${selected.title || ""}`.trim() || `S${selected.season}E${selected.episode}`,
+          playerBackdropUrl: this.params?.playerBackdropUrl || null,
+          playerLogoUrl: this.params?.playerLogoUrl || null,
+          episodes: this.episodes,
+          streamCandidates: streamItems,
+          nextEpisodeVideoId: nextEpisode?.id || null,
+          nextEpisodeLabel: nextEpisode ? `S${nextEpisode.season}E${nextEpisode.episode}` : null,
+          nextEpisodeSeason: nextEpisode?.season ?? null,
+          nextEpisodeEpisode: nextEpisode?.episode ?? null,
+          nextEpisodeTitle: nextEpisode?.title || "",
+          nextEpisodeReleased: nextEpisode?.released || ""
+        },
+        {
+          replaceHistory: true
+        }
+      );
     } finally {
       this.switchingEpisode = false;
     }
@@ -11605,9 +12830,10 @@ export const PlayerScreen = {
     this.clearMountedExternalSubtitleTracks();
 
     this.builtInSubtitleCount = this.getTextTracks().length;
-    const usingAvPlay = typeof PlayerController.isUsingAvPlay === "function"
-      ? PlayerController.isUsingAvPlay()
-      : false;
+    const usingAvPlay =
+      typeof PlayerController.isUsingAvPlay === "function"
+        ? PlayerController.isUsingAvPlay()
+        : false;
     if (usingAvPlay) {
       return;
     }
@@ -11715,7 +12941,10 @@ export const PlayerScreen = {
       this.stickyProgressFocus = false;
       this.moreActionsVisible = true;
       this.controlFocusZone = "buttons";
-      this.controlFocusIndex = Math.max(0, this.getControlDefinitions().findIndex((entry) => entry.action === "speed"));
+      this.controlFocusIndex = Math.max(
+        0,
+        this.getControlDefinitions().findIndex((entry) => entry.action === "speed")
+      );
       this.renderControlButtons();
       return;
     }
@@ -11724,7 +12953,10 @@ export const PlayerScreen = {
       this.stickyProgressFocus = false;
       this.moreActionsVisible = false;
       this.controlFocusZone = "buttons";
-      this.controlFocusIndex = Math.max(0, this.getControlDefinitions().findIndex((entry) => entry.action === "more"));
+      this.controlFocusIndex = Math.max(
+        0,
+        this.getControlDefinitions().findIndex((entry) => entry.action === "more")
+      );
       this.renderControlButtons();
       return;
     }
@@ -11754,7 +12986,9 @@ export const PlayerScreen = {
 
     const controlButton = target?.closest?.(".player-control-btn[data-action]");
     if (controlButton) {
-      const buttons = Array.from(this.uiRefs?.controlButtons?.querySelectorAll?.(".player-control-btn[data-action]") || []);
+      const buttons = Array.from(
+        this.uiRefs?.controlButtons?.querySelectorAll?.(".player-control-btn[data-action]") || []
+      );
       const index = buttons.indexOf(controlButton);
       if (index >= 0) {
         this.stickyProgressFocus = false;
@@ -11793,7 +13027,10 @@ export const PlayerScreen = {
         this.subtitleOptionRailIndex = index;
       } else {
         this.subtitleStyleRailIndex = index;
-        this.subtitleStyleControlSide = String(subtitleNode.dataset.subtitleStyleAction || "").toLowerCase() === "increase" ? "plus" : "minus";
+        this.subtitleStyleControlSide =
+          String(subtitleNode.dataset.subtitleStyleAction || "").toLowerCase() === "increase"
+            ? "plus"
+            : "minus";
       }
       return;
     }
@@ -11887,7 +13124,10 @@ export const PlayerScreen = {
       const styleItems = this.getSubtitleStyleControls();
       const styleItem = styleItems[this.subtitleStyleRailIndex];
       if (styleItem) {
-        const side = String(subtitleStep.dataset.subtitleStyleAction || "").toLowerCase() === "increase" ? "plus" : "minus";
+        const side =
+          String(subtitleStep.dataset.subtitleStyleAction || "").toLowerCase() === "increase"
+            ? "plus"
+            : "minus";
         this.subtitleStyleControlSide = side;
         this.adjustSubtitleStyleControl(styleItem.id, this.getSubtitleStyleControlDelta(side));
       }
@@ -11931,9 +13171,10 @@ export const PlayerScreen = {
   },
 
   switchPlaybackEngine() {
-    const targetEngine = typeof PlayerController.getAlternativePlaybackEngine === "function"
-      ? PlayerController.getAlternativePlaybackEngine(this.activePlaybackUrl)
-      : null;
+    const targetEngine =
+      typeof PlayerController.getAlternativePlaybackEngine === "function"
+        ? PlayerController.getAlternativePlaybackEngine(this.activePlaybackUrl)
+        : null;
     if (!targetEngine || !this.activePlaybackUrl) {
       this.showAspectToast(t("player_engine_switch_unavailable", {}, "No alternate player engine"));
       return;
@@ -12151,7 +13392,13 @@ export const PlayerScreen = {
       }
     }
 
-    if (!this.paused && this.controlsVisible && !this.isDialogOpen() && Boolean(event?.repeat) && (keyCode === 37 || keyCode === 39)) {
+    if (
+      !this.paused &&
+      this.controlsVisible &&
+      !this.isDialogOpen() &&
+      Boolean(event?.repeat) &&
+      (keyCode === 37 || keyCode === 39)
+    ) {
       this.focusProgressBar();
       this.beginSeekPreview(keyCode === 37 ? -1 : 1, true);
       return;
@@ -12269,9 +13516,10 @@ export const PlayerScreen = {
 
     const hasCapabilityProbe = Boolean(PlayerController?.video);
     const isWebOsRuntime = Environment.isWebOS();
-    const capabilities = hasCapabilityProbe && typeof PlayerController.getPlaybackCapabilities === "function"
-      ? PlayerController.getPlaybackCapabilities()
-      : null;
+    const capabilities =
+      hasCapabilityProbe && typeof PlayerController.getPlaybackCapabilities === "function"
+        ? PlayerController.getPlaybackCapabilities()
+        : null;
     const supports = (key, fallback = true) => {
       if (!capabilities) {
         return fallback;
@@ -12285,13 +13533,15 @@ export const PlayerScreen = {
     };
 
     const scored = streams
-      .filter((stream) => Boolean(
-        stream?.url
-          || stream?.externalUrl
-          || DirectDebridResolver.canResolveStream(stream, resolveContext)
-          || WebOsEngineFsResolver.canResolveStream(stream)
-          || TizenStreamingServerResolver.canResolveStream(stream)
-      ))
+      .filter((stream) =>
+        Boolean(
+          stream?.url ||
+          stream?.externalUrl ||
+          DirectDebridResolver.canResolveStream(stream, resolveContext) ||
+          WebOsEngineFsResolver.canResolveStream(stream) ||
+          TizenStreamingServerResolver.canResolveStream(stream)
+        )
+      )
       .map((stream) => {
         const presentation = stream.streamPresentation || stream.raw?.streamPresentation || {};
         const text = [
@@ -12311,7 +13561,10 @@ export const PlayerScreen = {
           stream.url,
           stream.externalUrl,
           stream.infoHash
-        ].filter(Boolean).join(" ").toLowerCase();
+        ]
+          .filter(Boolean)
+          .join(" ")
+          .toLowerCase();
         let score = 0;
 
         if (text.includes("2160") || text.includes("4k")) score += 60;
@@ -12366,10 +13619,19 @@ export const PlayerScreen = {
           score += isWebOsRuntime ? 10 : 4;
         }
 
-        if (!stream.url && !stream.externalUrl && (WebOsEngineFsResolver.canResolveStream(stream) || TizenStreamingServerResolver.canResolveStream(stream))) {
+        if (
+          !stream.url &&
+          !stream.externalUrl &&
+          (WebOsEngineFsResolver.canResolveStream(stream) ||
+            TizenStreamingServerResolver.canResolveStream(stream))
+        ) {
           score += 4;
         }
-        if (!stream.url && !stream.externalUrl && DirectDebridResolver.canResolveStream(stream, resolveContext)) {
+        if (
+          !stream.url &&
+          !stream.externalUrl &&
+          DirectDebridResolver.canResolveStream(stream, resolveContext)
+        ) {
           score += 2;
         }
 
@@ -12391,7 +13653,9 @@ export const PlayerScreen = {
       return null;
     }
 
-    const addonStreams = streams.filter((stream) => String(stream?.addonName || "").trim() === normalizedAddonName);
+    const addonStreams = streams.filter(
+      (stream) => String(stream?.addonName || "").trim() === normalizedAddonName
+    );
     if (!addonStreams.length) {
       return null;
     }
@@ -12535,5 +13799,4 @@ export const PlayerScreen = {
       this.endedHandler = null;
     }
   }
-
 };

--- a/js/ui/screens/plugin/pluginScreen.js
+++ b/js/ui/screens/plugin/pluginScreen.js
@@ -3,6 +3,8 @@ import { Router } from "../../navigation/router.js";
 import { addonRepository } from "../../../data/repository/addonRepository.js";
 import { LayoutPreferences } from "../../../data/local/layoutPreferences.js";
 import { Platform } from "../../../platform/index.js";
+import { AuthManager } from "../../../core/auth/authManager.js";
+import { LibrarySyncService } from "../../../core/profile/librarySyncService.js";
 import { QrCodeGenerator } from "../../../core/qr/qrCodeGenerator.js";
 import {
   activateLegacySidebarAction,
@@ -40,7 +42,6 @@ async function getPhoneManagerUrl() {
 }
 
 export const PluginScreen = {
-
   async mount() {
     this.container = document.getElementById("plugin");
     ScreenUtils.show(this.container);
@@ -53,6 +54,7 @@ export const PluginScreen = {
     this.contentRow = Number.isFinite(this.contentRow) ? this.contentRow : 0;
     this.contentCol = Number.isFinite(this.contentCol) ? this.contentCol : 0;
     this.qrOverlayOpen = false;
+    this.syncing = false;
     const [sidebarProfile, model] = await Promise.all([
       getSidebarProfileState(),
       this.collectModel()
@@ -60,14 +62,57 @@ export const PluginScreen = {
     this.sidebarProfile = sidebarProfile;
     this.model = model;
     await this.render({ refreshModel: false });
+    // Self-heal: re-pull linked addons from the account on open. Web-enabled
+    // addons sometimes never appeared on the TV (issue #230); re-syncing here
+    // makes them show up without a restart, and surfaces a status the user can
+    // read since TVs have no console access.
+    if (AuthManager.isAuthenticated) {
+      void this.refreshAddons();
+    }
   },
 
   async collectModel() {
     const addonUrls = addonRepository.getInstalledAddonUrls();
     return {
       addonCount: addonUrls.length,
+      authenticated: AuthManager.isAuthenticated,
+      syncStatus: LibrarySyncService.getLastPullStatus(),
       phoneManagerUrl: await getPhoneManagerUrl()
     };
+  },
+
+  buildSyncStatusText() {
+    if (this.syncing) {
+      return "Syncing addons…";
+    }
+    if (!this.model?.authenticated) {
+      return "Sign in on your phone to link addons.";
+    }
+    const status = this.model?.syncStatus || {};
+    if (status.state === "error") {
+      return "Couldn't reach the addon service — check the TV's internet connection and try Refresh.";
+    }
+    if (this.model?.addonCount > 0) {
+      return "Addons are up to date.";
+    }
+    return "No addons linked yet. Add them on your phone, then press Refresh.";
+  },
+
+  async refreshAddons() {
+    if (this.syncing) {
+      return;
+    }
+    this.syncing = true;
+    await this.render({ refreshModel: true });
+    try {
+      await LibrarySyncService.pull();
+    } catch (error) {
+      console.warn("Addon refresh failed", error);
+    }
+    this.syncing = false;
+    if (Router.getCurrent() === "plugin") {
+      await this.render({ refreshModel: true });
+    }
   },
 
   setRowColumns(row, cols) {
@@ -84,10 +129,12 @@ export const PluginScreen = {
 
   normalizeFocus() {
     const rows = this.getAvailableRows();
-    this.contentRow = rows.includes(this.contentRow) ? this.contentRow : (rows[0] || 0);
+    this.contentRow = rows.includes(this.contentRow) ? this.contentRow : rows[0] || 0;
     const cols = this.getAvailableCols(this.contentRow);
     this.contentCol = cols.includes(this.contentCol) ? this.contentCol : cols[0];
-    const sidebarNodes = this.layoutPrefs?.modernSidebar ? getModernSidebarNodes(this.container) : getLegacySidebarNodes(this.container);
+    const sidebarNodes = this.layoutPrefs?.modernSidebar
+      ? getModernSidebarNodes(this.container)
+      : getLegacySidebarNodes(this.container);
     this.sidebarFocusIndex = clamp(this.sidebarFocusIndex, 0, Math.max(0, sidebarNodes.length - 1));
   },
 
@@ -96,7 +143,8 @@ export const PluginScreen = {
     if (!container || !target) {
       return;
     }
-    const anchor = target.closest(".addons-installed-card, .addons-large-row, .addons-install-card") || target;
+    const anchor =
+      target.closest(".addons-installed-card, .addons-large-row, .addons-install-card") || target;
     const pad = 56;
     const containerRect = container.getBoundingClientRect();
     const anchorRect = anchor.getBoundingClientRect();
@@ -167,12 +215,16 @@ export const PluginScreen = {
     this.actionMap = new Map();
     this.setRowColumns(0, [0]);
     this.setRowColumns(1, [0]);
+    this.setRowColumns(2, [0]);
 
     this.actionMap.set("manage_from_phone", async () => {
       await this.openQrOverlay();
     });
     this.actionMap.set("reorder_home_catalogs", async () => {
       Router.navigate("catalogOrder");
+    });
+    this.actionMap.set("refresh_addons", async () => {
+      await this.refreshAddons();
     });
     this.actionMap.set("close_qr_overlay", async () => {
       await this.closeQrOverlay();
@@ -195,6 +247,7 @@ export const PluginScreen = {
                 Manage addons and home catalogs from your phone.
               </p>
               <p class="addons-meta">${escapeHtml(`${this.model.addonCount} addon${this.model.addonCount === 1 ? "" : "s"} currently linked`)}</p>
+              <p class="addons-sync-status">${escapeHtml(this.buildSyncStatusText())}</p>
               <div role="button"
                    class="addons-large-row addons-large-row-centered addons-focusable"
                    data-zone="content"
@@ -227,10 +280,29 @@ export const PluginScreen = {
                   <span class="addons-large-row-tail material-icons" aria-hidden="true">chevron_right</span>
                 </span>
               </div>
+              <div role="button"
+                   class="addons-large-row addons-large-row-centered addons-focusable"
+                   data-zone="content"
+                   data-row="2"
+                   data-col="0"
+                   data-action-id="refresh_addons"
+                   tabindex="-1"
+                   aria-disabled="${this.syncing ? "true" : "false"}">
+                <span class="addons-large-row-icon material-icons" aria-hidden="true">${this.syncing ? "hourglass_top" : "sync"}</span>
+                <span class="addons-large-row-copy">
+                  <strong>${this.syncing ? "Refreshing…" : "Refresh addons"}</strong>
+                  <small>Re-check your account for addons you enabled on your phone</small>
+                </span>
+                <span class="addons-large-row-tail-group">
+                  <span class="addons-large-row-tail material-icons" aria-hidden="true">refresh</span>
+                </span>
+              </div>
             </section>
           </div>
         </main>
-        ${this.qrOverlayOpen ? `
+        ${
+          this.qrOverlayOpen
+            ? `
           <div class="addons-qr-overlay">
             <div class="addons-qr-dialog">
               <p class="addons-qr-instruction">Scan with your phone to manage addons, catalogs, and collections</p>
@@ -242,7 +314,9 @@ export const PluginScreen = {
               </div>
             </div>
           </div>
-        ` : ""}
+        `
+            : ""
+        }
       </div>
     `;
     this.pluginRouteEnterPending = false;
@@ -259,7 +333,9 @@ export const PluginScreen = {
   },
 
   applyFocus() {
-    this.container.querySelectorAll(".addons-focusable.focused, .focusable.focused").forEach((node) => node.classList.remove("focused"));
+    this.container
+      .querySelectorAll(".addons-focusable.focused, .focusable.focused")
+      .forEach((node) => node.classList.remove("focused"));
 
     if (this.qrOverlayOpen) {
       const closeButton = this.container.querySelector(".addons-qr-close");
@@ -271,9 +347,14 @@ export const PluginScreen = {
     }
 
     if (this.focusZone === "sidebar") {
-      const sidebarNodes = this.layoutPrefs?.modernSidebar ? getModernSidebarNodes(this.container) : getLegacySidebarNodes(this.container);
-      const node = sidebarNodes[this.sidebarFocusIndex]
-        || (this.layoutPrefs?.modernSidebar ? getModernSidebarSelectedNode(this.container) : getLegacySidebarSelectedNode(this.container));
+      const sidebarNodes = this.layoutPrefs?.modernSidebar
+        ? getModernSidebarNodes(this.container)
+        : getLegacySidebarNodes(this.container);
+      const node =
+        sidebarNodes[this.sidebarFocusIndex] ||
+        (this.layoutPrefs?.modernSidebar
+          ? getModernSidebarSelectedNode(this.container)
+          : getLegacySidebarSelectedNode(this.container));
       if (node) {
         node.classList.add("focused");
         node.focus();
@@ -288,11 +369,14 @@ export const PluginScreen = {
     if (!this.layoutPrefs?.modernSidebar) {
       setLegacySidebarExpanded(this.container, false);
     }
-    const target = this.container.querySelector(
-      `.addons-focusable[data-zone="content"][data-row="${this.contentRow}"][data-col="${this.contentCol}"]`
-    ) || this.container.querySelector(
-      `.addons-focusable[data-zone="content"][data-row="${this.contentRow}"][data-col="0"]`
-    ) || this.container.querySelector(".addons-focusable[data-zone='content']");
+    const target =
+      this.container.querySelector(
+        `.addons-focusable[data-zone="content"][data-row="${this.contentRow}"][data-col="${this.contentCol}"]`
+      ) ||
+      this.container.querySelector(
+        `.addons-focusable[data-zone="content"][data-row="${this.contentRow}"][data-col="0"]`
+      ) ||
+      this.container.querySelector(".addons-focusable[data-zone='content']");
 
     if (target) {
       target.classList.add("focused");
@@ -319,14 +403,24 @@ export const PluginScreen = {
   },
 
   moveSidebar(delta) {
-    const sidebarNodes = this.layoutPrefs?.modernSidebar ? getModernSidebarNodes(this.container) : getLegacySidebarNodes(this.container);
-    this.sidebarFocusIndex = clamp(this.sidebarFocusIndex + delta, 0, Math.max(0, sidebarNodes.length - 1));
+    const sidebarNodes = this.layoutPrefs?.modernSidebar
+      ? getModernSidebarNodes(this.container)
+      : getLegacySidebarNodes(this.container);
+    this.sidebarFocusIndex = clamp(
+      this.sidebarFocusIndex + delta,
+      0,
+      Math.max(0, sidebarNodes.length - 1)
+    );
     this.applyFocus();
   },
 
   async openSidebar() {
-    const sidebarNodes = this.layoutPrefs?.modernSidebar ? getModernSidebarNodes(this.container) : getLegacySidebarNodes(this.container);
-    const selected = this.layoutPrefs?.modernSidebar ? getModernSidebarSelectedNode(this.container) : getLegacySidebarSelectedNode(this.container);
+    const sidebarNodes = this.layoutPrefs?.modernSidebar
+      ? getModernSidebarNodes(this.container)
+      : getLegacySidebarNodes(this.container);
+    const selected = this.layoutPrefs?.modernSidebar
+      ? getModernSidebarSelectedNode(this.container)
+      : getLegacySidebarSelectedNode(this.container);
     this.sidebarFocusIndex = Math.max(0, sidebarNodes.indexOf(selected));
     if (this.layoutPrefs?.modernSidebar && !this.sidebarExpanded) {
       this.sidebarExpanded = true;
@@ -448,8 +542,12 @@ export const PluginScreen = {
         if (this.contentCol > 0) {
           this.moveContent(0, -1);
         } else {
-          const nodes = this.layoutPrefs?.modernSidebar ? getModernSidebarNodes(this.container) : getLegacySidebarNodes(this.container);
-          const selected = this.layoutPrefs?.modernSidebar ? getModernSidebarSelectedNode(this.container) : getLegacySidebarSelectedNode(this.container);
+          const nodes = this.layoutPrefs?.modernSidebar
+            ? getModernSidebarNodes(this.container)
+            : getLegacySidebarNodes(this.container);
+          const selected = this.layoutPrefs?.modernSidebar
+            ? getModernSidebarSelectedNode(this.container)
+            : getLegacySidebarSelectedNode(this.container);
           this.focusZone = "sidebar";
           this.sidebarFocusIndex = Math.max(0, nodes.indexOf(selected));
           if (this.layoutPrefs?.modernSidebar && !this.sidebarExpanded) {
@@ -474,5 +572,4 @@ export const PluginScreen = {
   cleanup() {
     ScreenUtils.hide(this.container);
   }
-
 };

--- a/js/ui/screens/stream/streamScreen.js
+++ b/js/ui/screens/stream/streamScreen.js
@@ -45,7 +45,7 @@ function escapeHtml(value = "") {
     .replaceAll("&", "&amp;")
     .replaceAll("<", "&lt;")
     .replaceAll(">", "&gt;")
-    .replaceAll("\"", "&quot;")
+    .replaceAll('"', "&quot;")
     .replaceAll("'", "&#39;");
 }
 
@@ -78,23 +78,27 @@ function detectQuality(text = "") {
 }
 
 function isMagnetUrl(value = "") {
-  return String(value || "").trim().toLowerCase().startsWith("magnet:");
+  return String(value || "")
+    .trim()
+    .toLowerCase()
+    .startsWith("magnet:");
 }
 
 function streamDebridIdentity(item = {}) {
   const resolve = item.clientResolve || item.raw?.clientResolve || {};
   const behaviorHints = item.behaviorHints || item.raw?.behaviorHints || {};
   const infoHash = item.infoHash || item.raw?.infoHash || resolve.infoHash || "";
-  const magnetUri = resolve.magnetUri
-    || (isMagnetUrl(item.url) ? item.url : "")
-    || (isMagnetUrl(item.externalUrl) ? item.externalUrl : "");
+  const magnetUri =
+    resolve.magnetUri ||
+    (isMagnetUrl(item.url) ? item.url : "") ||
+    (isMagnetUrl(item.externalUrl) ? item.externalUrl : "");
   const hasDebridMarker = Boolean(
-    item.clientResolve
-      || item.raw?.clientResolve
-      || item.debridCacheStatus
-      || item.raw?.debridCacheStatus
-      || infoHash
-      || magnetUri
+    item.clientResolve ||
+    item.raw?.clientResolve ||
+    item.debridCacheStatus ||
+    item.raw?.debridCacheStatus ||
+    infoHash ||
+    magnetUri
   );
   if (!hasDebridMarker) {
     return "";
@@ -105,7 +109,12 @@ function streamDebridIdentity(item = {}) {
   }
   return [
     String(item.addonName || "Addon"),
-    String(resolve.service || item.debridCacheStatus?.providerId || item.raw?.debridCacheStatus?.providerId || ""),
+    String(
+      resolve.service ||
+        item.debridCacheStatus?.providerId ||
+        item.raw?.debridCacheStatus?.providerId ||
+        ""
+    ),
     String(locator),
     String(resolve.fileIdx ?? item.fileIdx ?? item.raw?.fileIdx ?? ""),
     String(behaviorHints.filename || resolve.filename || ""),
@@ -144,7 +153,8 @@ function mergeStreamItem(previous = {}, next = {}) {
     externalUrl: next.externalUrl || previous.externalUrl || null,
     ytId: next.ytId || previous.ytId || null,
     behaviorHints: Object.keys(behaviorHints).length ? behaviorHints : null,
-    subtitles: Array.isArray(next.subtitles) && next.subtitles.length ? next.subtitles : previous.subtitles,
+    subtitles:
+      Array.isArray(next.subtitles) && next.subtitles.length ? next.subtitles : previous.subtitles,
     sources: Array.isArray(next.sources) && next.sources.length ? next.sources : previous.sources,
     streamPresentation: next.streamPresentation || previous.streamPresentation || null
   };
@@ -162,7 +172,7 @@ function formatBytes(value) {
     amount /= 1024;
     unitIndex += 1;
   }
-  const precision = unitIndex >= 3 ? 2 : (unitIndex >= 2 ? 1 : 0);
+  const precision = unitIndex >= 3 ? 2 : unitIndex >= 2 ? 1 : 0;
   return `${amount.toFixed(precision)} ${units[unitIndex]}`;
 }
 
@@ -184,7 +194,9 @@ function flattenStreams(streamResult) {
     const groupName = group.addonName || "Addon";
     (group.streams || []).forEach((stream, index) => {
       const entry = {
-        id: stream.id || `${groupName}-${index}-${stream.url || stream.externalUrl || stream.ytId || ""}`,
+        id:
+          stream.id ||
+          `${groupName}-${index}-${stream.url || stream.externalUrl || stream.ytId || ""}`,
         name: stream.name || null,
         title: stream.title || null,
         description: stream.description || null,
@@ -197,7 +209,9 @@ function flattenStreams(streamResult) {
         behaviorHints: stream.behaviorHints || null,
         sources: Array.isArray(stream.sources) ? stream.sources : [],
         quality: stream.quality || null,
-        qualityValue: Number.isFinite(Number(stream.qualityValue)) ? Number(stream.qualityValue) : -1,
+        qualityValue: Number.isFinite(Number(stream.qualityValue))
+          ? Number(stream.qualityValue)
+          : -1,
         clientResolve: stream.clientResolve || null,
         debridCacheStatus: stream.debridCacheStatus || null,
         streamPresentation: stream.streamPresentation || null,
@@ -212,9 +226,9 @@ function flattenStreams(streamResult) {
         raw: stream
       };
       if (
-        DirectDebridResolver.shouldListStream(entry)
-        || WebOsEngineFsResolver.canResolveStream(entry)
-        || TizenStreamingServerResolver.canResolveStream(entry)
+        DirectDebridResolver.shouldListStream(entry) ||
+        WebOsEngineFsResolver.canResolveStream(entry) ||
+        TizenStreamingServerResolver.canResolveStream(entry)
       ) {
         flattened.push(entry);
       }
@@ -270,12 +284,14 @@ function renderMetaItem(kind, value) {
 }
 
 function extractPeerCount(stream = {}) {
-  const text = String([
-    stream.name || "",
-    stream.title || "",
-    stream.description || "",
-    stream.behaviorHints?.filename || ""
-  ].join(" "));
+  const text = String(
+    [
+      stream.name || "",
+      stream.title || "",
+      stream.description || "",
+      stream.behaviorHints?.filename || ""
+    ].join(" ")
+  );
   const patterns = [
     /\bseed(?:ers?)?\s*[:\-]?\s*(\d{1,5})\b/i,
     /\bpeers?\s*[:\-]?\s*(\d{1,5})\b/i,
@@ -299,23 +315,20 @@ function extractIndexerName(stream = {}) {
       return value;
     }
   }
-  const searchText = String([
-    stream.name || "",
-    stream.title || "",
-    stream.description || "",
-    stream.behaviorHints?.filename || ""
-  ].join(" "));
-  const known = [
-    "ThePirateBay",
-    "1337x",
-    "RARBG",
-    "YTS",
-    "EZTV",
-    "TorBox",
-    "Torrentio",
-    "Orion"
-  ];
-  return known.find((entry) => new RegExp(entry.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "i").test(searchText)) || "";
+  const searchText = String(
+    [
+      stream.name || "",
+      stream.title || "",
+      stream.description || "",
+      stream.behaviorHints?.filename || ""
+    ].join(" ")
+  );
+  const known = ["ThePirateBay", "1337x", "RARBG", "YTS", "EZTV", "TorBox", "Torrentio", "Orion"];
+  return (
+    known.find((entry) =>
+      new RegExp(entry.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "i").test(searchText)
+    ) || ""
+  );
 }
 
 function getAddonBadgeLabel(name = "") {
@@ -385,8 +398,7 @@ async function warmAddonLogoPreview(url = "") {
       directImage.decoding = "async";
       try {
         directImage.referrerPolicy = "no-referrer";
-      } catch (_) {
-      }
+      } catch (_) {}
       directImage.onload = () => {
         (async () => {
           await awaitImageDecoded(directImage);
@@ -414,8 +426,7 @@ async function warmAddonLogoPreview(url = "") {
               settle(true);
               return;
             }
-          } catch (_) {
-          }
+          } catch (_) {}
           finishDirect();
         })();
         return;
@@ -426,12 +437,10 @@ async function warmAddonLogoPreview(url = "") {
     image.decoding = "async";
     try {
       image.crossOrigin = "anonymous";
-    } catch (_) {
-    }
+    } catch (_) {}
     try {
       image.referrerPolicy = "no-referrer";
-    } catch (_) {
-    }
+    } catch (_) {}
     image.onload = () => finish(image);
     image.onerror = loadDirect;
     image.src = normalized;
@@ -465,7 +474,10 @@ export async function preloadStreamBadgeImages(settings = StreamBadgeSettingsSto
   await Promise.all(Array.from(urls).map((url) => requestAddonLogo(url)));
 }
 
-async function preloadMatchedStreamBadgeImages(streams = [], settings = StreamBadgeSettingsStore.snapshot()) {
+async function preloadMatchedStreamBadgeImages(
+  streams = [],
+  settings = StreamBadgeSettingsStore.snapshot()
+) {
   const urls = new Set();
   (streams || []).forEach((stream) => {
     matchStreamBadges(stream, settings?.rules)
@@ -484,9 +496,7 @@ async function preloadAddonLogoImages(streams = [], lookup = {}) {
   const urls = new Set();
   (streams || []).forEach((stream) => {
     const url = normalizeAddonLogoUrl(
-      stream?.addonLogo
-      || stream?.raw?.addonLogo
-      || resolveAddonLogo(stream?.addonName, lookup)
+      stream?.addonLogo || stream?.raw?.addonLogo || resolveAddonLogo(stream?.addonName, lookup)
     );
     if (url) {
       urls.add(url);
@@ -501,9 +511,7 @@ function hydrateAddonLogoCache() {
   }
   addonLogoCacheHydrated = true;
   const cached = LocalStore.get(ADDON_LOGO_CACHE_KEY, {});
-  const entries = cached && typeof cached === "object" && !Array.isArray(cached)
-    ? cached
-    : {};
+  const entries = cached && typeof cached === "object" && !Array.isArray(cached) ? cached : {};
   Object.keys(entries).forEach((url) => {
     const entry = entries[url];
     const dataUrl = String(entry?.dataUrl || "").trim();
@@ -521,11 +529,12 @@ function hydrateAddonLogoCache() {
 function persistAddonLogoCache() {
   addonLogoCachePersistTimer = null;
   const entries = Array.from(addonLogoCache.entries())
-    .filter(([, entry]) => (
-      entry?.status === "ready"
-      && String(entry.displayUrl || "").startsWith("data:image/")
-      && String(entry.displayUrl || "").length <= ADDON_LOGO_CACHE_MAX_LENGTH
-    ))
+    .filter(
+      ([, entry]) =>
+        entry?.status === "ready" &&
+        String(entry.displayUrl || "").startsWith("data:image/") &&
+        String(entry.displayUrl || "").length <= ADDON_LOGO_CACHE_MAX_LENGTH
+    )
     .sort((left, right) => Number(right[1].updatedAt || 0) - Number(left[1].updatedAt || 0))
     .slice(0, ADDON_LOGO_CACHE_LIMIT);
   const payload = {};
@@ -688,7 +697,9 @@ function getCachedAddonLogoDisplayUrl(url = "") {
 }
 
 function normalizeAddonLookupKey(value = "") {
-  return String(value || "").trim().toLowerCase();
+  return String(value || "")
+    .trim()
+    .toLowerCase();
 }
 
 function rememberAddonLogoLookup(lookup = {}, addonName = "", addonLogo = "") {
@@ -715,12 +726,7 @@ function buildAddonLogoLookup(addons = []) {
     if (!logo) {
       return;
     }
-    [
-      addon?.displayName,
-      addon?.name,
-      addon?.id,
-      addon?.baseUrl
-    ].forEach((key) => {
+    [addon?.displayName, addon?.name, addon?.id, addon?.baseUrl].forEach((key) => {
       rememberAddonLogoLookup(lookup, key, lookup[normalizeAddonLookupKey(key)] || logo);
     });
   });
@@ -740,39 +746,43 @@ function rememberFailedAddonLogo(url = "") {
 }
 
 function getStreamHeadline(stream = {}) {
-  const primary = [
-    stream.name,
-    stream.title,
-    stream.description
-  ].find((value) => String(value || "").trim());
+  const primary = [stream.name, stream.title, stream.description].find((value) =>
+    String(value || "").trim()
+  );
   if (!primary) {
     return stream.addonName || "Unknown source";
   }
   const firstLine = String(primary).split(/\r?\n/)[0].trim();
-  return firstLine || (stream.addonName || "Unknown source");
+  return firstLine || stream.addonName || "Unknown source";
 }
 
 function getStreamQuality(stream = {}) {
   const qualityLines = [];
   [stream.name, stream.title, stream.description].forEach((value) => {
-    String(value || "").split(/\r?\n/).forEach((line) => {
-      const normalized = String(line || "").trim();
-      if (normalized) {
-        qualityLines.push(normalized);
-      }
-    });
+    String(value || "")
+      .split(/\r?\n/)
+      .forEach((line) => {
+        const normalized = String(line || "").trim();
+        if (normalized) {
+          qualityLines.push(normalized);
+        }
+      });
   });
-  const qualityCandidate = qualityLines.find((line, index) => index > 0 && /(2160|4k|1080|720|480)/i.test(line));
+  const qualityCandidate = qualityLines.find(
+    (line, index) => index > 0 && /(2160|4k|1080|720|480)/i.test(line)
+  );
   if (qualityCandidate) {
     return qualityCandidate;
   }
-  return detectQuality([
-    stream.name || "",
-    stream.title || "",
-    stream.description || "",
-    stream.behaviorHints?.filename || "",
-    stream.sourceType || ""
-  ].join(" "));
+  return detectQuality(
+    [
+      stream.name || "",
+      stream.title || "",
+      stream.description || "",
+      stream.behaviorHints?.filename || "",
+      stream.sourceType || ""
+    ].join(" ")
+  );
 }
 
 function isMetaNoiseLine(line = "") {
@@ -783,10 +793,16 @@ function isMetaNoiseLine(line = "") {
   if (/[👤💾⚙🧲]/u.test(value)) {
     return true;
   }
-  if (/(?:thepiratebay|torrentio|torbox|1337x|rarbg|yts|eztv|orion)/i.test(value) && /\b\d+(?:\.\d+)?\s*(?:mb|gb|tb)\b/i.test(value)) {
+  if (
+    /(?:thepiratebay|torrentio|torbox|1337x|rarbg|yts|eztv|orion)/i.test(value) &&
+    /\b\d+(?:\.\d+)?\s*(?:mb|gb|tb)\b/i.test(value)
+  ) {
     return true;
   }
-  if (/\b(?:seed(?:ers?)?|peers?)\b/i.test(value) && /\b\d+(?:\.\d+)?\s*(?:mb|gb|tb)\b/i.test(value)) {
+  if (
+    /\b(?:seed(?:ers?)?|peers?)\b/i.test(value) &&
+    /\b\d+(?:\.\d+)?\s*(?:mb|gb|tb)\b/i.test(value)
+  ) {
     return true;
   }
   return false;
@@ -799,12 +815,14 @@ function getStreamDescriptionLines(stream = {}) {
     stream.title,
     stream.behaviorHints?.filename
   ].reduce((items, value) => {
-    String(value || "").split(/\r?\n/).forEach((line) => {
-      const normalized = String(line || "").trim();
-      if (normalized) {
-        items.push(normalized);
-      }
-    });
+    String(value || "")
+      .split(/\r?\n/)
+      .forEach((line) => {
+        const normalized = String(line || "").trim();
+        if (normalized) {
+          items.push(normalized);
+        }
+      });
     return items;
   }, []);
   const unique = [];
@@ -855,7 +873,9 @@ function parsedStreamDetails(stream = {}) {
 }
 
 function normalizeCodecBadge(value = "") {
-  const normalized = normalizeBadgeText(value).toLowerCase().replace(/[^a-z0-9]/g, "");
+  const normalized = normalizeBadgeText(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, "");
   if (!normalized) return "";
   if (normalized === "av1") return "AV1";
   if (["hevc", "h265", "x265"].includes(normalized)) return "HEVC";
@@ -924,14 +944,17 @@ function fallbackLanguagesFromText(text = "") {
       matches.push(label);
     }
   };
-  if (/(^|[^a-z0-9])(pt[\s._-]?br|brazilian[\s._-]?portuguese)([^a-z0-9]|$)/i.test(value)) pushMatch("pt-br");
+  if (/(^|[^a-z0-9])(pt[\s._-]?br|brazilian[\s._-]?portuguese)([^a-z0-9]|$)/i.test(value))
+    pushMatch("pt-br");
   if (/(^|[^a-z0-9])(en|eng|english)([^a-z0-9]|$)/i.test(value)) pushMatch("en");
-  if (/(^|[^a-z0-9])(pt|por|portuguese)([^a-z0-9]|$)/i.test(value) && !matches.includes("pt-br")) pushMatch("pt");
+  if (/(^|[^a-z0-9])(pt|por|portuguese)([^a-z0-9]|$)/i.test(value) && !matches.includes("pt-br"))
+    pushMatch("pt");
   if (/(^|[^a-z0-9])(it|ita|italian)([^a-z0-9]|$)/i.test(value)) pushMatch("it");
   if (/(^|[^a-z0-9])(es|spa|spanish)([^a-z0-9]|$)/i.test(value)) pushMatch("es");
   if (/(^|[^a-z0-9])(fr|fra|fre|french)([^a-z0-9]|$)/i.test(value)) pushMatch("fr");
   if (/(^|[^a-z0-9])(de|deu|ger|german)([^a-z0-9]|$)/i.test(value)) pushMatch("de");
-  if (/(^|[^a-z0-9])(multi|multilang|multi[\s._-]?audio)([^a-z0-9]|$)/i.test(value)) pushMatch("multi");
+  if (/(^|[^a-z0-9])(multi|multilang|multi[\s._-]?audio)([^a-z0-9]|$)/i.test(value))
+    pushMatch("multi");
   return matches;
 }
 
@@ -944,7 +967,9 @@ function fallbackPresentationFromText(stream = {}) {
     stream.behaviorHints?.filename,
     stream.sourceType,
     ...(Array.isArray(parsed.languages) ? parsed.languages : [])
-  ].filter(Boolean).join(" ");
+  ]
+    .filter(Boolean)
+    .join(" ");
   const visualTags = [];
   if (/\b(dolby[ ._-]?vision|dovi|dv)\b/i.test(text)) visualTags.push("DV");
   if (/\bhdr10\+|hdr10plus\b/i.test(text)) visualTags.push("HDR10+");
@@ -980,11 +1005,21 @@ function getStreamPresentation(stream = {}) {
   const parsed = parsedStreamDetails(stream);
   const presentation = stream.streamPresentation || stream.raw?.streamPresentation || {};
   const fallback = fallbackPresentationFromText(stream);
-  const visualTags = toBadgeArray(presentation.visualTags?.length ? presentation.visualTags : parsed.hdr);
-  const audioTags = toBadgeArray(presentation.audioTags?.length ? presentation.audioTags : parsed.audio);
-  const audioChannels = toBadgeArray(presentation.audioChannels?.length ? presentation.audioChannels : parsed.channels);
-  const languages = toBadgeArray(presentation.languages?.length ? presentation.languages : parsed.languages);
-  const languageEmojis = toBadgeArray(presentation.languageEmojis?.length ? presentation.languageEmojis : []);
+  const visualTags = toBadgeArray(
+    presentation.visualTags?.length ? presentation.visualTags : parsed.hdr
+  );
+  const audioTags = toBadgeArray(
+    presentation.audioTags?.length ? presentation.audioTags : parsed.audio
+  );
+  const audioChannels = toBadgeArray(
+    presentation.audioChannels?.length ? presentation.audioChannels : parsed.channels
+  );
+  const languages = toBadgeArray(
+    presentation.languages?.length ? presentation.languages : parsed.languages
+  );
+  const languageEmojis = toBadgeArray(
+    presentation.languageEmojis?.length ? presentation.languageEmojis : []
+  );
   const resolvedLanguages = languages.length ? languages : fallback.languages;
   return {
     resolution: presentation.resolution || parsed.resolution || fallback.resolution,
@@ -994,7 +1029,9 @@ function getStreamPresentation(stream = {}) {
     audioTags: audioTags.length ? audioTags : fallback.audioTags,
     audioChannels: audioChannels.length ? audioChannels : fallback.audioChannels,
     languages: resolvedLanguages,
-    languageEmojis: languageEmojis.length ? languageEmojis : resolvedLanguages.map(languageBadge).filter(Boolean),
+    languageEmojis: languageEmojis.length
+      ? languageEmojis
+      : resolvedLanguages.map(languageBadge).filter(Boolean),
     size: presentation.size || stream.behaviorHints?.videoSize || fallback.size,
     cached: presentation.cached,
     serviceShortName: presentation.serviceShortName || ""
@@ -1008,14 +1045,26 @@ function buildLegacyStreamBadges(stream = {}, enabled = true, includeSizeBadge =
   const presentation = getStreamPresentation(stream);
   const badges = [];
   const seen = new Set();
-  const quality = normalizeBadgeText(presentation.resolution && presentation.resolution !== "Auto" ? presentation.resolution : getStreamQuality(stream));
+  const quality = normalizeBadgeText(
+    presentation.resolution && presentation.resolution !== "Auto"
+      ? presentation.resolution
+      : getStreamQuality(stream)
+  );
   uniquePushBadge(badges, seen, quality, "quality");
   uniquePushBadge(badges, seen, presentation.quality, "quality");
-  toBadgeArray(presentation.visualTags).slice(0, 3).forEach((tag) => uniquePushBadge(badges, seen, tag, "visual"));
+  toBadgeArray(presentation.visualTags)
+    .slice(0, 3)
+    .forEach((tag) => uniquePushBadge(badges, seen, tag, "visual"));
   uniquePushBadge(badges, seen, presentation.encode, "codec");
-  toBadgeArray(presentation.languageEmojis).slice(0, 4).forEach((tag) => uniquePushBadge(badges, seen, tag, "language"));
-  toBadgeArray(presentation.audioTags).slice(0, 3).forEach((tag) => uniquePushBadge(badges, seen, tag, "audio"));
-  toBadgeArray(presentation.audioChannels).slice(0, 1).forEach((tag) => uniquePushBadge(badges, seen, tag, "audio"));
+  toBadgeArray(presentation.languageEmojis)
+    .slice(0, 4)
+    .forEach((tag) => uniquePushBadge(badges, seen, tag, "language"));
+  toBadgeArray(presentation.audioTags)
+    .slice(0, 3)
+    .forEach((tag) => uniquePushBadge(badges, seen, tag, "audio"));
+  toBadgeArray(presentation.audioChannels)
+    .slice(0, 1)
+    .forEach((tag) => uniquePushBadge(badges, seen, tag, "audio"));
   if (includeSizeBadge) {
     uniquePushBadge(badges, seen, formatBytes(presentation.size), "size");
   }
@@ -1037,7 +1086,10 @@ function renderImageBadgeChip(badge = {}) {
   const backgroundColor = normalizeStreamBadgeChipColor(badge.tagColor);
   const outlineColor = normalizeStreamBadgeChipColor(badge.borderColor);
   const textColor = normalizeStreamBadgeChipColor(badge.textColor);
-  const filled = String(badge.tagStyle || "").trim().toLowerCase() === "filled";
+  const filled =
+    String(badge.tagStyle || "")
+      .trim()
+      .toLowerCase() === "filled";
   const fallbackImageUrl = Environment.isWebOS() ? "" : imageUrl;
   const safeImageUrl = displayImageUrl || fallbackImageUrl;
   const style = [
@@ -1047,9 +1099,11 @@ function renderImageBadgeChip(badge = {}) {
   ].join("");
   return `
     <span class="stream-route-stream-badge image${filled ? " filled" : ""}"${style ? ` style="${escapeHtml(style)}"` : ""}>
-      ${safeImageUrl
-        ? `<img src="${escapeHtml(safeImageUrl)}" alt="${escapeHtml(badge.name || "")}" loading="lazy" decoding="async" referrerpolicy="no-referrer" />`
-        : ""}
+      ${
+        safeImageUrl
+          ? `<img src="${escapeHtml(safeImageUrl)}" alt="${escapeHtml(badge.name || "")}" loading="lazy" decoding="async" referrerpolicy="no-referrer" />`
+          : ""
+      }
     </span>
   `;
 }
@@ -1058,7 +1112,9 @@ function renderImportedStreamBadgeChips(stream = {}, badges = [], showFileSizeBa
   const sizeBytes = stream.behaviorHints?.videoSize;
   const chips = [];
   if (showFileSizeBadges && sizeBytes != null) {
-    chips.push(`<span class="stream-route-stream-badge size">${escapeHtml(t("streams_size", [formatBytes(sizeBytes)], `SIZE ${formatBytes(sizeBytes)}`))}</span>`);
+    chips.push(
+      `<span class="stream-route-stream-badge size">${escapeHtml(t("streams_size", [formatBytes(sizeBytes)], `SIZE ${formatBytes(sizeBytes)}`))}</span>`
+    );
   }
   badges.slice(0, STREAM_BADGE_LIMIT).forEach((badge) => {
     chips.push(renderImageBadgeChip(badge));
@@ -1072,10 +1128,18 @@ function renderStreamBadges(stream = {}, enabled = true, badgeSettings = null) {
   const currentBadgeSettings = badgeSettings || StreamBadgeSettingsStore.snapshot();
   const importedBadges = matchStreamBadges(stream, currentBadgeSettings.rules);
   if (importedBadges.length) {
-    return renderImportedStreamBadgeChips(stream, importedBadges, currentBadgeSettings.showFileSizeBadges !== false);
+    return renderImportedStreamBadgeChips(
+      stream,
+      importedBadges,
+      currentBadgeSettings.showFileSizeBadges !== false
+    );
   }
 
-  const badges = buildLegacyStreamBadges(stream, enabled, currentBadgeSettings.showFileSizeBadges !== false);
+  const badges = buildLegacyStreamBadges(
+    stream,
+    enabled,
+    currentBadgeSettings.showFileSizeBadges !== false
+  );
   if (!badges.length) {
     return "";
   }
@@ -1087,7 +1151,11 @@ function renderStreamBadges(stream = {}, enabled = true, badgeSettings = null) {
 }
 
 function resolveStreamBadgePlacement(badgeSettings = null) {
-  const placement = String((badgeSettings || StreamBadgeSettingsStore.snapshot()).badgePlacement || "BOTTOM").trim().toUpperCase();
+  const placement = String(
+    (badgeSettings || StreamBadgeSettingsStore.snapshot()).badgePlacement || "BOTTOM"
+  )
+    .trim()
+    .toUpperCase();
   return placement === "TOP" ? "TOP" : "BOTTOM";
 }
 
@@ -1095,7 +1163,11 @@ function getOrderedFilterNames(sourceChips = [], streams = []) {
   const ordered = [];
   const sortedChips = (sourceChips || [])
     .slice()
-    .sort((left, right) => Number(left?.orderIndex ?? Number.MAX_SAFE_INTEGER) - Number(right?.orderIndex ?? Number.MAX_SAFE_INTEGER));
+    .sort(
+      (left, right) =>
+        Number(left?.orderIndex ?? Number.MAX_SAFE_INTEGER) -
+        Number(right?.orderIndex ?? Number.MAX_SAFE_INTEGER)
+    );
   sortedChips.forEach((chip) => {
     if (chip?.name && !ordered.includes(chip.name)) {
       ordered.push(chip.name);
@@ -1147,7 +1219,6 @@ function sortStreamsByAddonOrder(streams = [], sourceChips = []) {
 }
 
 export const StreamScreen = {
-
   cancelScheduledRender() {
     if (this.renderDelayTimer) {
       clearTimeout(this.renderDelayTimer);
@@ -1200,8 +1271,9 @@ export const StreamScreen = {
 
   areAddonLogosReady(streams = []) {
     return (streams || []).every((stream) => {
-      const addonLogoUrl = normalizeAddonLogoUrl(stream?.addonLogo)
-        || resolveAddonLogo(stream?.addonName, this.addonLogoLookup);
+      const addonLogoUrl =
+        normalizeAddonLogoUrl(stream?.addonLogo) ||
+        resolveAddonLogo(stream?.addonName, this.addonLogoLookup);
       if (!addonLogoUrl || failedAddonLogoUrls.has(addonLogoUrl)) {
         return true;
       }
@@ -1210,9 +1282,19 @@ export const StreamScreen = {
   },
 
   requestAddonLogoPrerender(streams = []) {
-    const urls = Array.from(new Set((streams || [])
-      .map((stream) => normalizeAddonLogoUrl(stream?.addonLogo) || resolveAddonLogo(stream?.addonName, this.addonLogoLookup))
-      .filter((url) => url && !failedAddonLogoUrls.has(url) && !getCachedAddonLogoDisplayUrl(url))));
+    const urls = Array.from(
+      new Set(
+        (streams || [])
+          .map(
+            (stream) =>
+              normalizeAddonLogoUrl(stream?.addonLogo) ||
+              resolveAddonLogo(stream?.addonName, this.addonLogoLookup)
+          )
+          .filter(
+            (url) => url && !failedAddonLogoUrls.has(url) && !getCachedAddonLogoDisplayUrl(url)
+          )
+      )
+    );
     if (!urls.length) {
       return;
     }
@@ -1222,15 +1304,14 @@ export const StreamScreen = {
     }
     const token = this.loadToken || 0;
     this.pendingAddonLogoPrerenderKey = key;
-    void preloadAddonLogoImages(streams, this.addonLogoLookup)
-      .finally(() => {
-        if (this.pendingAddonLogoPrerenderKey === key) {
-          this.pendingAddonLogoPrerenderKey = "";
-        }
-        if (this.container && Router.getCurrent() === "stream" && token === this.loadToken) {
-          this.requestRender();
-        }
-      });
+    void preloadAddonLogoImages(streams, this.addonLogoLookup).finally(() => {
+      if (this.pendingAddonLogoPrerenderKey === key) {
+        this.pendingAddonLogoPrerenderKey = "";
+      }
+      if (this.container && Router.getCurrent() === "stream" && token === this.loadToken) {
+        this.requestRender();
+      }
+    });
   },
 
   scheduleDebridPreparation() {
@@ -1253,18 +1334,19 @@ export const StreamScreen = {
           if (!this.container || Router.getCurrent() !== "stream" || token !== this.loadToken) {
             return;
           }
-          const keyFor = (stream) => [
-            stream.clientResolve?.service || "",
-            stream.clientResolve?.infoHash || stream.infoHash || "",
-            stream.clientResolve?.fileIdx ?? stream.fileIdx ?? "",
-            stream.clientResolve?.filename || stream.behaviorHints?.filename || "",
-            stream.name || "",
-            stream.title || ""
-          ].join("|");
+          const keyFor = (stream) =>
+            [
+              stream.clientResolve?.service || "",
+              stream.clientResolve?.infoHash || stream.infoHash || "",
+              stream.clientResolve?.fileIdx ?? stream.fileIdx ?? "",
+              stream.clientResolve?.filename || stream.behaviorHints?.filename || "",
+              stream.name || "",
+              stream.title || ""
+            ].join("|");
           const originalKey = keyFor(original);
-          this.streams = this.streams.map((stream) => (
+          this.streams = this.streams.map((stream) =>
             keyFor(stream) === originalKey ? { ...stream, ...prepared } : stream
-          ));
+          );
           this.requestRender();
         }
       });
@@ -1290,20 +1372,24 @@ export const StreamScreen = {
     if (!itemId) {
       return false;
     }
-    void Router.navigate("detail", {
-      itemId,
-      itemType: normalizeType(this.params?.itemType),
-      fallbackTitle: this.params?.itemTitle || this.params?.playerTitle || "Untitled",
-      returnHomeOnBack: Boolean(
-        this.params?.continueWatchingBackHome
-        || this.params?.returnHomeOnBack
-        || this.params?.returnToDetail
-        || this.params?.fromDetailRoute
-      )
-    }, {
-      skipStackPush: true,
-      replaceHistory: true
-    });
+    void Router.navigate(
+      "detail",
+      {
+        itemId,
+        itemType: normalizeType(this.params?.itemType),
+        fallbackTitle: this.params?.itemTitle || this.params?.playerTitle || "Untitled",
+        returnHomeOnBack: Boolean(
+          this.params?.continueWatchingBackHome ||
+          this.params?.returnHomeOnBack ||
+          this.params?.returnToDetail ||
+          this.params?.fromDetailRoute
+        )
+      },
+      {
+        skipStackPush: true,
+        replaceHistory: true
+      }
+    );
     return true;
   },
 
@@ -1320,7 +1406,9 @@ export const StreamScreen = {
       streams: Array.isArray(this.streams) ? this.streams.map((stream) => ({ ...stream })) : [],
       addonFilter: String(this.addonFilter || "all"),
       focusState: this.focusState ? { ...this.focusState } : { zone: "filter", index: 0 },
-      sourceChips: Array.isArray(this.sourceChips) ? this.sourceChips.map((chip) => ({ ...chip })) : [],
+      sourceChips: Array.isArray(this.sourceChips)
+        ? this.sourceChips.map((chip) => ({ ...chip }))
+        : [],
       addonLogoLookup: this.addonLogoLookup ? { ...this.addonLogoLookup } : {},
       listScrollTop: Number(list?.scrollTop || 0)
     };
@@ -1341,6 +1429,7 @@ export const StreamScreen = {
     this.addonLogoLookup = {};
     this.addonFilter = "all";
     this.hasRenderedStreamRouteShell = false;
+    this.autoResumeAttempted = false;
     if (this.releaseImageProxyReadyListener) {
       this.releaseImageProxyReadyListener();
       this.releaseImageProxyReadyListener = null;
@@ -1353,19 +1442,27 @@ export const StreamScreen = {
       void ensureWebOsImageProxyReady();
     }
 
-    const restored = navigationContext?.restoredState && typeof navigationContext.restoredState === "object"
-      ? navigationContext.restoredState
-      : null;
+    const restored =
+      navigationContext?.restoredState && typeof navigationContext.restoredState === "object"
+        ? navigationContext.restoredState
+        : null;
     if (restored) {
       this.loading = Boolean(restored.loading);
       this.error = String(restored.error || "");
-      this.streams = Array.isArray(restored.streams) ? restored.streams.map((stream) => ({ ...stream })) : [];
+      this.streams = Array.isArray(restored.streams)
+        ? restored.streams.map((stream) => ({ ...stream }))
+        : [];
       this.addonFilter = String(restored.addonFilter || "all");
-      this.focusState = restored.focusState ? { ...restored.focusState } : { zone: "filter", index: 0 };
-      this.sourceChips = Array.isArray(restored.sourceChips) ? restored.sourceChips.map((chip) => ({ ...chip })) : [];
-      this.addonLogoLookup = restored.addonLogoLookup && typeof restored.addonLogoLookup === "object"
-        ? normalizeAddonLogoLookup(restored.addonLogoLookup)
-        : {};
+      this.focusState = restored.focusState
+        ? { ...restored.focusState }
+        : { zone: "filter", index: 0 };
+      this.sourceChips = Array.isArray(restored.sourceChips)
+        ? restored.sourceChips.map((chip) => ({ ...chip }))
+        : [];
+      this.addonLogoLookup =
+        restored.addonLogoLookup && typeof restored.addonLogoLookup === "object"
+          ? normalizeAddonLogoLookup(restored.addonLogoLookup)
+          : {};
       this.listScrollTop = Number(restored.listScrollTop || 0);
     }
 
@@ -1464,12 +1561,14 @@ export const StreamScreen = {
         .filter((entry) => entry.name);
       const successSet = new Set(entries.map((entry) => entry.name));
       const known = new Set(this.sourceChips.map((chip) => chip.name));
-      this.sourceChips = this.sourceChips.map((chip) => (
+      this.sourceChips = this.sourceChips.map((chip) =>
         successSet.has(chip.name) ? { ...chip, status: "success" } : chip
-      ));
+      );
       entries.forEach((entry) => {
         if (!known.has(entry.name)) {
-          const orderIndex = Number.isFinite(entry.orderIndex) ? entry.orderIndex : Number.MAX_SAFE_INTEGER;
+          const orderIndex = Number.isFinite(entry.orderIndex)
+            ? entry.orderIndex
+            : Number.MAX_SAFE_INTEGER;
           this.sourceChips.push({
             name: entry.name,
             logo: entry.logo || resolveAddonLogo(entry.name, this.addonLogoLookup),
@@ -1480,7 +1579,11 @@ export const StreamScreen = {
       });
       this.sourceChips = this.sourceChips
         .slice()
-        .sort((left, right) => Number(left.orderIndex ?? Number.MAX_SAFE_INTEGER) - Number(right.orderIndex ?? Number.MAX_SAFE_INTEGER));
+        .sort(
+          (left, right) =>
+            Number(left.orderIndex ?? Number.MAX_SAFE_INTEGER) -
+            Number(right.orderIndex ?? Number.MAX_SAFE_INTEGER)
+        );
     };
 
     const displayChunkGroups = async (groups = []) => {
@@ -1503,11 +1606,13 @@ export const StreamScreen = {
       }
       this.streams = mergeStreamItems(this.streams, chunkStreams);
       this.scheduleDebridPreparation();
-      markSuccessfulSources(groups.map((group) => ({
-        name: group?.addonName || "",
-        logo: group?.addonLogo || "",
-        orderIndex: group?.addonOrderIndex
-      })));
+      markSuccessfulSources(
+        groups.map((group) => ({
+          name: group?.addonName || "",
+          logo: group?.addonLogo || "",
+          orderIndex: group?.addonOrderIndex
+        }))
+      );
       if (this.streams.length && this.focusState?.zone !== "card") {
         this.focusState = { zone: "card", index: 0 };
       }
@@ -1547,16 +1652,25 @@ export const StreamScreen = {
     };
 
     try {
-      const streamResult = await streamRepository.getStreamsFromAllAddons(itemType, videoId, options);
+      const streamResult = await streamRepository.getStreamsFromAllAddons(
+        itemType,
+        videoId,
+        options
+      );
       if (token !== this.loadToken) {
         return;
       }
-      const loadedStreams = mergeStreamItems([], this.applyAddonLogos(flattenStreams(streamResult)));
+      const loadedStreams = mergeStreamItems(
+        [],
+        this.applyAddonLogos(flattenStreams(streamResult))
+      );
       await Promise.allSettled(Array.from(pendingChunkTasks));
       if (token !== this.loadToken) {
         return;
       }
-      const existingKeys = new Set(this.streams.map((stream) => streamMergeKey(stream)).filter(Boolean));
+      const existingKeys = new Set(
+        this.streams.map((stream) => streamMergeKey(stream)).filter(Boolean)
+      );
       const missingStreams = loadedStreams.filter((stream) => {
         const key = streamMergeKey(stream);
         return key && !existingKeys.has(key);
@@ -1576,26 +1690,30 @@ export const StreamScreen = {
       if (this.streams.length) {
         await preloadAddonLogoImages(this.streams, this.addonLogoLookup);
       }
-      this.sourceChips = this.sourceChips.map((chip) => (
+      this.sourceChips = this.sourceChips.map((chip) =>
         chip.status === "loading" ? { ...chip, status: "error" } : chip
-      ));
+      );
       this.loading = false;
       if (this.streams.length) {
-        this.focusState = { zone: "card", index: clamp(Number(this.focusState?.index || 0), 0, this.streams.length - 1) };
+        this.focusState = {
+          zone: "card",
+          index: clamp(Number(this.focusState?.index || 0), 0, this.streams.length - 1)
+        };
       } else {
         this.focusState = { zone: "filter", index: 0 };
       }
       this.requestRender();
       this.scheduleErrorChipCleanup();
+      this.maybeAutoResumeStream();
     } catch (error) {
       if (token !== this.loadToken) {
         return;
       }
       this.loading = false;
       this.error = error?.message || "Failed to load streams.";
-      this.sourceChips = this.sourceChips.map((chip) => (
+      this.sourceChips = this.sourceChips.map((chip) =>
         chip.status === "loading" ? { ...chip, status: "error" } : chip
-      ));
+      );
       this.requestRender();
       this.scheduleErrorChipCleanup();
     }
@@ -1645,7 +1763,10 @@ export const StreamScreen = {
       this.focusState = { zone: "card", index: clamp(preferredIndex, 0, filtered.length - 1) };
     } else {
       const ordered = ["all", ...this.getOrderedFilterNames()];
-      this.focusState = { zone: "filter", index: clamp(ordered.indexOf(targetFilter), 0, Math.max(0, ordered.length - 1)) };
+      this.focusState = {
+        zone: "filter",
+        index: clamp(ordered.indexOf(targetFilter), 0, Math.max(0, ordered.length - 1))
+      };
     }
     this.listScrollTop = 0;
     this.render();
@@ -1660,7 +1781,9 @@ export const StreamScreen = {
     if (!target) {
       return false;
     }
-    this.container.querySelectorAll(".focusable").forEach((node) => node.classList.remove("focused"));
+    this.container
+      .querySelectorAll(".focusable")
+      .forEach((node) => node.classList.remove("focused"));
     target.classList.add("focused");
     try {
       target.focus({ preventScroll: true });
@@ -1695,7 +1818,10 @@ export const StreamScreen = {
     if (!listNode) {
       return;
     }
-    const maxScrollTop = Math.max(0, Number(listNode.scrollHeight || 0) - Number(listNode.clientHeight || 0));
+    const maxScrollTop = Math.max(
+      0,
+      Number(listNode.scrollHeight || 0) - Number(listNode.clientHeight || 0)
+    );
     const normalized = clamp(Number(nextScrollTop || 0), 0, maxScrollTop);
     listNode.scrollTop = normalized;
     if (typeof listNode.scrollTo === "function") {
@@ -1715,10 +1841,18 @@ export const StreamScreen = {
     const viewTop = Number(listNode.scrollTop || 0);
     let itemTop = Number(target.offsetTop || 0);
     let itemBottom = itemTop + Number(target.offsetHeight || 0);
-    if (typeof listNode.getBoundingClientRect === "function" && typeof target.getBoundingClientRect === "function") {
+    if (
+      typeof listNode.getBoundingClientRect === "function" &&
+      typeof target.getBoundingClientRect === "function"
+    ) {
       const listRect = listNode.getBoundingClientRect();
       const targetRect = target.getBoundingClientRect();
-      if (listRect && targetRect && Number.isFinite(targetRect.top) && Number.isFinite(listRect.top)) {
+      if (
+        listRect &&
+        targetRect &&
+        Number.isFinite(targetRect.top) &&
+        Number.isFinite(listRect.top)
+      ) {
         itemTop = viewTop + (targetRect.top - listRect.top);
         itemBottom = viewTop + (targetRect.bottom - listRect.top);
       }
@@ -1793,7 +1927,9 @@ export const StreamScreen = {
     const episodeLabel = normalizeEpisodeCode(this.params?.season, this.params?.episode);
     const detailLine = isSeries
       ? ""
-      : [String(this.params?.genres || "").trim(), String(this.params?.year || "").trim()].filter(Boolean).join(" • ");
+      : [String(this.params?.genres || "").trim(), String(this.params?.year || "").trim()]
+          .filter(Boolean)
+          .join(" • ");
     return { isSeries, title, subtitle, episodeLabel, detailLine };
   },
 
@@ -1804,8 +1940,13 @@ export const StreamScreen = {
       "focusable",
       selected ? "selected" : "",
       chipStatus !== "success" ? chipStatus : ""
-    ].filter(Boolean).join(" ");
-    const spinner = chipStatus === "loading" ? '<span class="stream-route-chip-spinner" aria-hidden="true"></span>' : "";
+    ]
+      .filter(Boolean)
+      .join(" ");
+    const spinner =
+      chipStatus === "loading"
+        ? '<span class="stream-route-chip-spinner" aria-hidden="true"></span>'
+        : "";
     return `
       <button class="${classes}" data-action="setFilter" data-addon="${escapeHtml(name)}">
         ${spinner}
@@ -1822,7 +1963,9 @@ export const StreamScreen = {
     const topBadges = badgePlacement === "TOP" ? badges : "";
     const bottomBadges = badgePlacement === "BOTTOM" ? badges : "";
     const descriptionLines = getStreamDescriptionLines(stream);
-    const addonLogoUrl = normalizeAddonLogoUrl(stream.addonLogo) || resolveAddonLogo(stream.addonName, this.addonLogoLookup);
+    const addonLogoUrl =
+      normalizeAddonLogoUrl(stream.addonLogo) ||
+      resolveAddonLogo(stream.addonName, this.addonLogoLookup);
     const cachedAddonLogoUrl = getCachedAddonLogoDisplayUrl(addonLogoUrl);
     let displayAddonLogoUrl = cachedAddonLogoUrl || "";
     if (addonLogoUrl && !displayAddonLogoUrl && !failedAddonLogoUrls.has(addonLogoUrl)) {
@@ -1836,9 +1979,11 @@ export const StreamScreen = {
       renderMetaItem("peers", extractPeerCount(stream)),
       renderMetaItem("size", formatBytes(stream.behaviorHints?.videoSize)),
       renderMetaItem("source", extractIndexerName(stream))
-    ].filter(Boolean).join("");
-    const addonLogoLoading = (Environment.isWebOS() || Environment.isTizen()) ? "eager" : "lazy";
-    const addonLogoDecoding = (Environment.isWebOS() || Environment.isTizen()) ? "sync" : "async";
+    ]
+      .filter(Boolean)
+      .join("");
+    const addonLogoLoading = Environment.isWebOS() || Environment.isTizen() ? "eager" : "lazy";
+    const addonLogoDecoding = Environment.isWebOS() || Environment.isTizen() ? "sync" : "async";
     const addonBadge = displayAddonLogoUrl
       ? `<img src="${escapeHtml(displayAddonLogoUrl)}" alt="${escapeHtml(stream.addonName || "Addon")}" data-addon-logo="${escapeHtml(addonLogoUrl)}" decoding="${addonLogoDecoding}" loading="${addonLogoLoading}" referrerpolicy="no-referrer" /><span hidden>${addonBadgeLabel}</span>`
       : `<span>${addonBadgeLabel}</span>`;
@@ -1865,14 +2010,18 @@ export const StreamScreen = {
 
   renderLoadingCards(count = 3) {
     const safeCount = Math.max(1, Number(count || 0));
-    return Array.from({ length: safeCount }).map(() => `
+    return Array.from({ length: safeCount })
+      .map(
+        () => `
       <div class="stream-route-card skeleton">
         <div class="stream-route-skeleton-line wide"></div>
         <div class="stream-route-skeleton-line short"></div>
         <div class="stream-route-skeleton-line"></div>
         <div class="stream-route-skeleton-line"></div>
       </div>
-    `).join("");
+    `
+      )
+      .join("");
   },
 
   render() {
@@ -1885,7 +2034,10 @@ export const StreamScreen = {
     const chips = [
       this.renderChip("all", this.addonFilter === "all", "success"),
       ...orderedFilters.map((name) => {
-        const chip = this.sourceChips.find((entry) => entry.name === name) || { name, status: "success" };
+        const chip = this.sourceChips.find((entry) => entry.name === name) || {
+          name,
+          status: "success"
+        };
         return this.renderChip(name, this.addonFilter === name, chip.status);
       })
     ].join("");
@@ -1898,7 +2050,11 @@ export const StreamScreen = {
 
     let body = "";
     if (filtered.length && addonLogosReady) {
-      body = filtered.map((stream, index) => this.renderStreamCard(stream, index, streamBadgesEnabled, badgeSettings)).join("");
+      body = filtered
+        .map((stream, index) =>
+          this.renderStreamCard(stream, index, streamBadgesEnabled, badgeSettings)
+        )
+        .join("");
       if (hasPendingForFilter) {
         body += this.renderLoadingCards(1);
       }
@@ -1925,7 +2081,7 @@ export const StreamScreen = {
               ${logo ? `<img src="${logo}" class="stream-route-logo" alt="${escapeHtml(title)}" />` : `<h1 class="stream-route-title">${escapeHtml(title)}</h1>`}
               ${episodeLabel ? `<div class="stream-route-episode-code">${escapeHtml(episodeLabel)}</div>` : ""}
               ${subtitle ? `<div class="stream-route-subtitle">${escapeHtml(subtitle)}</div>` : ""}
-              ${detailLine ? `<div class="stream-route-detail-line">${escapeHtml(detailLine)}</div>` : (!isSeries && subtitle ? `<div class="stream-route-detail-line">${escapeHtml(subtitle)}</div>` : "")}
+              ${detailLine ? `<div class="stream-route-detail-line">${escapeHtml(detailLine)}</div>` : !isSeries && subtitle ? `<div class="stream-route-detail-line">${escapeHtml(subtitle)}</div>` : ""}
             </div>
           </section>
           <section class="stream-route-right">
@@ -1955,27 +2111,53 @@ export const StreamScreen = {
     if (!list) {
       return;
     }
-    list.addEventListener("scroll", () => {
-      this.listScrollTop = Number(list.scrollTop || 0);
-    }, { passive: true });
+    list.addEventListener(
+      "scroll",
+      () => {
+        this.listScrollTop = Number(list.scrollTop || 0);
+      },
+      { passive: true }
+    );
   },
 
   bindAddonLogoFallbacks() {
-    this.container?.querySelectorAll(".stream-route-addon-badge img[data-addon-logo]").forEach((node) => {
-      if (!(node instanceof HTMLImageElement) || node.dataset.fallbackBound === "true") {
-        return;
-      }
-      node.dataset.fallbackBound = "true";
-      const fallback = node.nextElementSibling;
-      const applyFallback = () => {
-        rememberFailedAddonLogo(node.dataset.addonLogo || node.getAttribute("src") || "");
-        node.hidden = true;
-        if (fallback instanceof HTMLElement) {
-          fallback.hidden = false;
+    this.container
+      ?.querySelectorAll(".stream-route-addon-badge img[data-addon-logo]")
+      .forEach((node) => {
+        if (!(node instanceof HTMLImageElement) || node.dataset.fallbackBound === "true") {
+          return;
         }
-      };
-      node.addEventListener("error", applyFallback, { once: true });
-    });
+        node.dataset.fallbackBound = "true";
+        const fallback = node.nextElementSibling;
+        const applyFallback = () => {
+          rememberFailedAddonLogo(node.dataset.addonLogo || node.getAttribute("src") || "");
+          node.hidden = true;
+          if (fallback instanceof HTMLElement) {
+            fallback.hidden = false;
+          }
+        };
+        node.addEventListener("error", applyFallback, { once: true });
+      });
+  },
+
+  // Continue Watching passes the identity of the stream that was playing. If a
+  // matching source reappears in the freshly-loaded list, resume it directly
+  // instead of forcing the user to re-pick a link (issue #232). Identities are
+  // debrid/infoHash-stable; ephemeral direct URLs simply won't match and fall
+  // back to the normal picker.
+  maybeAutoResumeStream() {
+    if (this.autoResumeAttempted) {
+      return;
+    }
+    const identity = String(this.params?.resumeStreamIdentity || "").trim();
+    if (!identity || !this.streams.length) {
+      return;
+    }
+    this.autoResumeAttempted = true;
+    const match = this.streams.find((stream) => streamMergeKey(stream) === identity);
+    if (match?.id) {
+      void this.playStream(match.id);
+    }
   },
 
   async playStream(streamId) {
@@ -1993,9 +2175,10 @@ export const StreamScreen = {
       imdbId: this.params?.imdbId || null,
       videoId: this.params?.videoId || null,
       resumePositionMs: Number(this.params?.resumePositionMs || 0) || 0,
-      episodeLabel: this.params?.season && this.params?.episode
-        ? `S${this.params.season}E${this.params.episode}`
-        : null,
+      episodeLabel:
+        this.params?.season && this.params?.episode
+          ? `S${this.params.season}E${this.params.episode}`
+          : null,
       playerTitle: this.params?.itemTitle || this.params?.playerTitle || "Untitled",
       playerSubtitle: this.params?.episodeTitle || this.params?.playerSubtitle || "",
       playerEpisodeTitle: this.params?.episodeTitle || "",
@@ -2082,7 +2265,11 @@ export const StreamScreen = {
             const currentFilter = ordered[clamp(index, 0, ordered.length - 1)] || "all";
             const currentPosition = ordered.indexOf(currentFilter);
             const nextFilter = ordered[clamp(currentPosition - 1, 0, ordered.length - 1)];
-            this.setAddonFilter(nextFilter, "filter", clamp(index - 1, 0, Math.max(0, chips.length - 1)));
+            this.setAddonFilter(
+              nextFilter,
+              "filter",
+              clamp(index - 1, 0, Math.max(0, chips.length - 1))
+            );
           }
           return;
         }
@@ -2092,7 +2279,11 @@ export const StreamScreen = {
             const currentFilter = ordered[clamp(index, 0, ordered.length - 1)] || "all";
             const currentPosition = ordered.indexOf(currentFilter);
             const nextFilter = ordered[clamp(currentPosition + 1, 0, ordered.length - 1)];
-            this.setAddonFilter(nextFilter, "filter", clamp(index + 1, 0, Math.max(0, chips.length - 1)));
+            this.setAddonFilter(
+              nextFilter,
+              "filter",
+              clamp(index + 1, 0, Math.max(0, chips.length - 1))
+            );
           }
           return;
         }
@@ -2112,13 +2303,20 @@ export const StreamScreen = {
           }
           this.focusState = {
             zone: "filter",
-            index: clamp(["all", ...this.getOrderedFilterNames()].indexOf(this.addonFilter), 0, Math.max(0, chips.length - 1))
+            index: clamp(
+              ["all", ...this.getOrderedFilterNames()].indexOf(this.addonFilter),
+              0,
+              Math.max(0, chips.length - 1)
+            )
           };
           this.applyFocus();
           return;
         }
         if (direction === "down") {
-          this.focusState = { zone: "card", index: clamp(index + 1, 0, Math.max(0, cards.length - 1)) };
+          this.focusState = {
+            zone: "card",
+            index: clamp(index + 1, 0, Math.max(0, cards.length - 1))
+          };
           this.applyFocus();
           return;
         }
@@ -2145,7 +2343,11 @@ export const StreamScreen = {
     const action = String(current.dataset.action || "");
     if (action === "setFilter") {
       const addon = String(current.dataset.addon || "all");
-      this.setAddonFilter(addon, "filter", Array.from(this.container.querySelectorAll(".stream-route-chip.focusable")).indexOf(current));
+      this.setAddonFilter(
+        addon,
+        "filter",
+        Array.from(this.container.querySelectorAll(".stream-route-chip.focusable")).indexOf(current)
+      );
       return;
     }
     if (action === "playStream") {
@@ -2155,7 +2357,7 @@ export const StreamScreen = {
 
   cleanup() {
     this.loadToken = (this.loadToken || 0) + 1;
-    this.playResolveToken = (Number(this.playResolveToken || 0) + 1);
+    this.playResolveToken = Number(this.playResolveToken || 0) + 1;
     this.cancelScheduledRender();
     if (this.errorChipTimer) {
       clearTimeout(this.errorChipTimer);
@@ -2167,5 +2369,4 @@ export const StreamScreen = {
     }
     ScreenUtils.hide(this.container);
   }
-
 };


### PR DESCRIPTION
Resolves four open issues across webOS/Tizen.

And now it contains a bunch of code styling fixes that got automatically done after saving files so they can be ignored.

## #231 — Tizen subtitles not showing / menu reverts to another language
`setAvPlaySubtitleTrack` now selects the AVPlay track **before** `setSilentSubtitle(false)`. The previous order left the chosen track unapplied on several Tizen firmware versions, so subtitles never rendered and the menu reverted to whatever track was actually active.

## #232 — laggy modern scroll, sidebar pops up on Back, lost resume
- Modern home track pagination is coalesced to one run per animation frame (it read `offsetWidth` on every scroll event, forcing reflow → jank on slow TVs).
- The sidebar no longer auto-expands and steals focus when returning home via Back — it only locks to the sidebar when the restored focus actually belonged to it.
- **Resume:** the playing stream's identity (`streamMergeKey`, debrid/infoHash-stable) is persisted with watch progress. Continue Watching auto-selects the matching source and resumes it, falling back to the picker if no match (e.g. an expired direct URL).

## #233 — webOS app won't reopen until a TV reboot
Added a `webOSRelaunch` handler that re-mounts the active route, so a backgrounded/resident instance re-renders and regains remote focus on reopen instead of staying stuck.

## #230 — Tizen addons show "0 addons currently linked"
`LibrarySyncService.pull()` now records a real status (ok / signed-out / error + reason) instead of swallowing failures into `[]`. The Addons screen auto re-pulls on open (self-heal), shows an on-screen sync status, and has a **Refresh addons** action — so retail-TV users who can't access console logs can recover and report what they see.

## Verification
`npm run build` succeeds; `node --check` passes on all changed files; prettier clean. (ESLint dep not installed in the dev environment.)

⚠️ #233, #230, and the #232 resume path target device-specific behavior and should be validated on real webOS/Tizen hardware before release.

Closes #230
Closes #231
Closes #232
Closes #233