### PR TITLE
fix(tv): resolve issues #230-#233 without eslint churn

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -12513,6 +12513,21 @@ button:focus-visible {
   scrollbar-width: none;
 }
 
+.series-episode-track.is-virtualized {
+  gap: 0 !important;
+}
+
+.series-episode-track-window {
+  display: flex;
+  flex: 0 0 auto;
+  gap: var(--episode-track-gap, 14px);
+}
+
+.series-episode-track-spacer {
+  flex: 0 0 auto;
+  height: 1px;
+}
+
 .series-episode-track::-webkit-scrollbar {
   display: none;
 }

--- a/css/components.css
+++ b/css/components.css
@@ -9101,6 +9101,15 @@ button:focus-visible {
   color: var(--addons-text-tertiary);
 }
 
+.addons-sync-status {
+  margin: 8px 0 0;
+  font-size: 18px;
+  line-height: 26px;
+  letter-spacing: 0.2px;
+  color: var(--addons-text-tertiary);
+  opacity: 0.85;
+}
+
 .addons-install-card {
   border-radius: 24px;
   background: var(--addons-card);

--- a/js/app.js
+++ b/js/app.js
@@ -181,6 +181,49 @@ function setupWebOsAppLifecycle() {
   if (!Platform.isWebOS()) {
     return;
   }
+
+  const appSystems = Array.from(new Set([
+    globalThis.webOSSystem || null,
+    globalThis.PalmSystem || null,
+  ].filter(Boolean)));
+
+  function activateWebOsApp() {
+    const system = appSystems.find((entry) => typeof entry?.activate === "function") || null;
+    if (!system) {
+      return;
+    }
+    try {
+      system.activate();
+    } catch (error) {
+      console.warn("webOS activate failed", error);
+    }
+  }
+
+  function installNativeCallback(system, systemName, callbackName, { recoverOnCall = false } = {}) {
+    if (!system) {
+      return;
+    }
+    const previous = typeof system[callbackName] === "function"
+      ? system[callbackName].bind(system)
+      : null;
+    try {
+      system[callbackName] = (...args) => {
+        if (previous) {
+          try {
+            previous(...args);
+          } catch (error) {
+            console.warn(`webOS callback ${systemName}.${callbackName} failed`, error);
+          }
+        }
+        if (recoverOnCall) {
+          void recover(`${systemName}.${callbackName}`);
+        }
+      };
+    } catch (error) {
+      console.warn(`webOS callback hook ${systemName}.${callbackName} failed`, error);
+    }
+  }
+
   // webOS keeps the app resident when it is backgrounded. Re-opening can fire
   // a launch event on the existing JS context instead of reloading the page.
   let recovering = false;
@@ -204,6 +247,9 @@ function setupWebOsAppLifecycle() {
         replaceHistory: true,
         skipStackPush: true,
       });
+      // With handlesRelaunch=true, webOS expects the app to explicitly request
+      // foreground activation after processing the relaunch callback.
+      activateWebOsApp();
     } catch (error) {
       console.warn("webOS relaunch recovery failed", error);
     } finally {
@@ -213,12 +259,12 @@ function setupWebOsAppLifecycle() {
 
   document.addEventListener("webOSRelaunch", () => {
     void recover();
-  });
+  }, true);
 
   // webOS 4.x may fire webOSLaunch instead of webOSRelaunch when resuming.
   document.addEventListener("webOSLaunch", () => {
     void recover();
-  });
+  }, true);
 
   // Some builds only expose visibilitychange when the WebView is resumed.
   document.addEventListener("visibilitychange", () => {
@@ -226,6 +272,26 @@ function setupWebOsAppLifecycle() {
       void recover();
     }
   });
+
+  // Older webOS WebKit builds may emit only the prefixed visibility signal.
+  document.addEventListener("webkitvisibilitychange", () => {
+    if (document.webkitHidden !== true) {
+      void recover();
+    }
+  });
+
+  installNativeCallback(globalThis.webOSSystem, "webOSSystem", "onshow", { recoverOnCall: true });
+  installNativeCallback(globalThis.webOSSystem, "webOSSystem", "onhide");
+  installNativeCallback(globalThis.webOSSystem, "webOSSystem", "onfocus", { recoverOnCall: true });
+  installNativeCallback(globalThis.webOSSystem, "webOSSystem", "onblur");
+  installNativeCallback(globalThis.webOSSystem, "webOSSystem", "onactivate", { recoverOnCall: true });
+  installNativeCallback(globalThis.webOSSystem, "webOSSystem", "ondeactivate");
+  installNativeCallback(globalThis.PalmSystem, "PalmSystem", "onshow", { recoverOnCall: true });
+  installNativeCallback(globalThis.PalmSystem, "PalmSystem", "onhide");
+  installNativeCallback(globalThis.PalmSystem, "PalmSystem", "onfocus", { recoverOnCall: true });
+  installNativeCallback(globalThis.PalmSystem, "PalmSystem", "onblur");
+  installNativeCallback(globalThis.PalmSystem, "PalmSystem", "onactivate", { recoverOnCall: true });
+  installNativeCallback(globalThis.PalmSystem, "PalmSystem", "ondeactivate");
 }
 
 async function bootstrapApp() {

--- a/js/app.js
+++ b/js/app.js
@@ -177,6 +177,57 @@ async function routeAfterAuthentication() {
   Router.navigate("home");
 }
 
+function setupWebOsAppLifecycle() {
+  if (!Platform.isWebOS()) {
+    return;
+  }
+  // webOS keeps the app resident when it is backgrounded. Re-opening can fire
+  // a launch event on the existing JS context instead of reloading the page.
+  let recovering = false;
+  const recover = async () => {
+    if (recovering || !appShellRendered) {
+      return;
+    }
+    const current = Router.getCurrent();
+    if (!current) {
+      return;
+    }
+    recovering = true;
+    try {
+      if (document.body) {
+        document.body.style.removeProperty("display");
+      }
+      const isTransientRoute = current === "player" || current === "stream";
+      const target = isTransientRoute ? "home" : current;
+      const params = target === current ? Router.currentParams || {} : {};
+      await Router.navigate(target, params, {
+        replaceHistory: true,
+        skipStackPush: true,
+      });
+    } catch (error) {
+      console.warn("webOS relaunch recovery failed", error);
+    } finally {
+      recovering = false;
+    }
+  };
+
+  document.addEventListener("webOSRelaunch", () => {
+    void recover();
+  });
+
+  // webOS 4.x may fire webOSLaunch instead of webOSRelaunch when resuming.
+  document.addEventListener("webOSLaunch", () => {
+    void recover();
+  });
+
+  // Some builds only expose visibilitychange when the WebView is resumed.
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "visible") {
+      void recover();
+    }
+  });
+}
+
 async function bootstrapApp() {
   renderAppShell();
   appShellRendered = true;
@@ -188,6 +239,7 @@ async function bootstrapApp() {
   PlayerController.init();
 
   FocusEngine.init();
+  setupWebOsAppLifecycle();
 
   ThemeManager.apply();
   I18n.apply();

--- a/js/core/player/playerController.js
+++ b/js/core/player/playerController.js
@@ -1109,12 +1109,8 @@ export const PlayerController = {
       return false;
     }
 
-    try {
-      avplay.setSilentSubtitle?.(false);
-    } catch (_) {
-      // Ignore subtitle unmute failures.
-    }
-
+    // Tizen AVPlay applies the chosen subtitle track reliably only when the
+    // track is selected before subtitles are unmuted.
     try {
       avplay.setSelectTrack?.("TEXT", targetIndex);
     } catch (_) {
@@ -1123,6 +1119,12 @@ export const PlayerController = {
       } catch (_) {
         return false;
       }
+    }
+
+    try {
+      avplay.setSilentSubtitle?.(false);
+    } catch (_) {
+      // Ignore subtitle unmute failures.
     }
 
     this.selectedAvPlaySubtitleTrackIndex = targetIndex;
@@ -2860,7 +2862,7 @@ export const PlayerController = {
     }
   },
 
-  async play(url, { itemId = null, itemType = "movie", videoId = null, season = null, episode = null, title = null, poster = null, background = null, episodeTitle = null, requestHeaders = {}, mediaSourceType = null, forceEngine = null } = {}) {
+  async play(url, { itemId = null, itemType = "movie", videoId = null, season = null, episode = null, title = null, poster = null, background = null, episodeTitle = null, requestHeaders = {}, mediaSourceType = null, forceEngine = null, streamIdentity = null } = {}) {
     if (!this.video) return;
 
     await this.flushCurrentProgress({ allowCloudSync: false });
@@ -2876,6 +2878,7 @@ export const PlayerController = {
     this.currentItemPoster = poster || null;
     this.currentItemBackground = background || null;
     this.currentEpisodeTitle = episodeTitle || null;
+    this.currentStreamIdentity = streamIdentity || null;
     this.currentPlaybackUrl = String(url || "").trim();
     this.currentPlaybackHeaders = { ...(requestHeaders || {}) };
     this.currentPlaybackMediaSourceType = this.resolveRuntimeSourceType(mediaSourceType);
@@ -3134,6 +3137,7 @@ export const PlayerController = {
     this.currentItemPoster = null;
     this.currentItemBackground = null;
     this.currentEpisodeTitle = null;
+    this.currentStreamIdentity = null;
     this.currentPlaybackUrl = "";
     this.currentPlaybackHeaders = {};
     this.currentPlaybackMediaSourceType = null;
@@ -3160,7 +3164,8 @@ export const PlayerController = {
       title: this.currentItemTitle || null,
       poster: this.currentItemPoster || null,
       background: this.currentItemBackground || null,
-      episodeTitle: this.currentEpisodeTitle || null
+      episodeTitle: this.currentEpisodeTitle || null,
+      streamIdentity: this.currentStreamIdentity || null
     };
   },
 
@@ -3306,6 +3311,9 @@ export const PlayerController = {
       poster: active.poster || null,
       background: active.background || null,
       episodeTitle: active.episodeTitle || null,
+      // Persist the stream identity so Continue Watching can resume the same
+      // source instead of reopening the stream picker.
+      streamIdentity: active.streamIdentity || null,
       positionMs: Math.max(0, Math.trunc(safePosition)),
       durationMs: hasFiniteDuration ? Math.max(0, Math.trunc(safeDuration)) : 0
     });

--- a/js/core/profile/librarySyncService.js
+++ b/js/core/profile/librarySyncService.js
@@ -6,6 +6,19 @@ import { ProfileManager } from "./profileManager.js";
 const ADDONS_TABLE = "addons";
 const TABLE = "tv_addons";
 
+// Records the outcome of the latest pull so the Addons screen can show a
+// visible sync state on TV.
+let lastPullStatus = { state: "idle", count: 0, error: null, at: 0 };
+
+function recordPullStatus(state, { count = 0, error = null } = {}) {
+  lastPullStatus = {
+    state,
+    count: Number(count) || 0,
+    error: error ? String(error.message || error) : null,
+    at: Date.now()
+  };
+}
+
 function isMissingResourceError(error) {
   if (!error) {
     return false;
@@ -104,9 +117,15 @@ function applyPulledAddons(rows = []) {
 
 export const LibrarySyncService = {
 
+  getLastPullStatus() {
+    return lastPullStatus;
+  },
+
   async pull() {
+    let readError = null;
     try {
       if (!AuthManager.isAuthenticated) {
+        recordPullStatus("signed-out");
         return [];
       }
       const localUrls = addonRepository.getInstalledAddonUrls();
@@ -122,9 +141,13 @@ export const LibrarySyncService = {
         );
         const addonUrls = applyPulledAddons(addonRows);
         await addonRepository.setAddonOrder(addonUrls, { silent: true });
+        recordPullStatus("ok", { count: addonUrls.length });
         return addonUrls;
       } catch (addonsTableError) {
         addonTableMissing = isMissingResourceError(addonsTableError);
+        if (!addonTableMissing) {
+          readError = addonsTableError;
+        }
         console.warn("Addon sync pull addons-table read failed", addonsTableError);
       }
 
@@ -137,9 +160,13 @@ export const LibrarySyncService = {
         );
         const urls = applyPulledAddons(rows);
         await addonRepository.setAddonOrder(urls, { silent: true });
+        recordPullStatus("ok", { count: urls.length });
         return urls;
       } catch (tvTableError) {
         tvTableMissing = isMissingResourceError(tvTableError);
+        if (!tvTableMissing) {
+          readError = tvTableError;
+        }
         console.warn("Addon sync pull tv-table read failed", tvTableError);
       }
 
@@ -152,17 +179,25 @@ export const LibrarySyncService = {
           );
           const urls = applyPulledAddons(rpcRows);
           await addonRepository.setAddonOrder(urls, { silent: true });
+          recordPullStatus("ok", { count: urls.length });
           return urls;
         } catch (rpcError) {
+          readError = rpcError;
           console.warn("Addon sync pull RPC failed", rpcError);
         }
       }
 
+      if (readError) {
+        recordPullStatus("error", { count: localUrls.length, error: readError });
+      } else {
+        recordPullStatus("ok", { count: localUrls.length });
+      }
       if (localUrls.length) {
         return localUrls;
       }
       return [];
     } catch (error) {
+      recordPullStatus("error", { error });
       console.warn("Library sync pull failed", error);
       return [];
     }

--- a/js/ui/screens/detail/metaDetailsScreen.js
+++ b/js/ui/screens/detail/metaDetailsScreen.js
@@ -43,6 +43,11 @@ const DETAIL_SCROLL_DAMPING_RATIO = 0.95;
 const DETAIL_TAB_FOCUS_TARGET = 0.40;
 const DETAIL_ROW_FOCUS_TARGET = 0.33;
 const DETAIL_SCROLL_MAX_FRAME_SECONDS = 0.016;
+const EPISODE_VIRTUALIZATION_THRESHOLD = 72;
+const EPISODE_VIRTUALIZATION_MIN_WINDOW = 20;
+const EPISODE_VIRTUALIZATION_OVERSCAN = 8;
+const EPISODE_VIRTUALIZATION_DEFAULT_CARD_WIDTH = 540;
+const EPISODE_VIRTUALIZATION_DEFAULT_GAP = 34;
 const LOCAL_YOUTUBE_PROXY_URL = "youtube-proxy.html";
 
 function t(key, params = {}, fallback = key) {
@@ -1231,6 +1236,11 @@ export const MetaDetailsScreen = {
     this.resumeProgress = null;
     this.resumeContentIds = [];
     this.episodeFocusIndexBySeason = {};
+    this.episodeVirtualWindow = null;
+    this.episodeVirtualState = null;
+    this.episodeTrackScrollHandler = null;
+    this.episodeTrackScrollNode = null;
+    this.episodeVirtualSyncRaf = null;
     this.railFocusIndexByKey = {};
     this.watchedEpisodeKeys = new Set();
     this.autoOpenedContinueWatchingStream = false;
@@ -2273,6 +2283,7 @@ export const MetaDetailsScreen = {
       ScreenUtils.setInitialFocus(this.container);
     }
     this.bindDetailChrome();
+    this.scheduleEpisodeVirtualizationSync(this.getRememberedEpisodeIndex());
   },
   renderHeroSection({ meta, playLabel, creditLine = "", creditPrefix = "", showWatchedButton = false }) {
     const logoOrTitle = meta.logo
@@ -2633,6 +2644,7 @@ export const MetaDetailsScreen = {
     ScreenUtils.indexFocusables(this.container);
     this.pendingFocusRestore = focusRestore;
     this.bindDetailChrome();
+    this.scheduleEpisodeVirtualizationSync(this.getRememberedEpisodeIndex());
   },
   renderMovieInsightSection(meta) {
     const trailerItems = resolveTrailerItems(meta);
@@ -2798,53 +2810,270 @@ export const MetaDetailsScreen = {
               data-season="${season}">
         ${escapeHtml(t("detail.seasonLabel", { season }, "Season {{season}}"))}
       </button>
-    `).join("");
+      `).join("");
   },
 
-  renderEpisodeCards() {
-    if (!this.episodes?.length) {
-      return `<p>${escapeHtml(t("detail.noEpisodesFound", {}, "No episodes found."))}</p>`;
+  getSelectedSeasonEpisodes() {
+    if (!Array.isArray(this.episodes) || !this.episodes.length) {
+      return [];
     }
-    const selectedSeasonEpisodes = this.episodes.filter((episode) => episode.season === this.selectedSeason);
-    if (!selectedSeasonEpisodes.length) {
+    return this.episodes.filter((episode) => Number(episode?.season || 0) === Number(this.selectedSeason || 0));
+  },
+
+  getEpisodeIndexByVideoId(videoId) {
+    const wanted = String(videoId || "").trim();
+    if (!wanted) {
+      return -1;
+    }
+    return this.getSelectedSeasonEpisodes().findIndex((episode) => String(episode?.id || "") === wanted);
+  },
+
+  getEpisodeTrackElement() {
+    return this.container?.querySelector(".series-episode-track") || null;
+  },
+
+  measureEpisodeTrackMetrics(track = null) {
+    const target = track instanceof HTMLElement ? track : this.getEpisodeTrackElement();
+    const sampleCard = target?.querySelector?.(".series-episode-card") || null;
+    const sampleWindow = target?.querySelector?.(".series-episode-track-window") || target;
+    const trackStyle = target && typeof getComputedStyle === "function" ? getComputedStyle(target) : null;
+    const windowStyle = sampleWindow && typeof getComputedStyle === "function" ? getComputedStyle(sampleWindow) : null;
+    const rawGap = Number.parseFloat(windowStyle?.gap || windowStyle?.columnGap || trackStyle?.gap || trackStyle?.columnGap || "0");
+    const gap = Number.isFinite(rawGap) && rawGap >= 0 ? rawGap : EPISODE_VIRTUALIZATION_DEFAULT_GAP;
+    const measuredWidth = Number(sampleCard?.getBoundingClientRect?.().width || 0);
+    const cardWidth = measuredWidth > 0 ? measuredWidth : (this.episodeVirtualState?.cardWidth || EPISODE_VIRTUALIZATION_DEFAULT_CARD_WIDTH);
+    const stride = Math.max(1, cardWidth + gap);
+    const viewportWidth = Number(target?.clientWidth || 0);
+    this.episodeVirtualState = {
+      season: Number(this.selectedSeason || 0),
+      cardWidth,
+      gap,
+      stride,
+      viewportWidth,
+      measuredAt: Date.now()
+    };
+    return this.episodeVirtualState;
+  },
+
+  getEpisodeVirtualWindowState(episodes = this.getSelectedSeasonEpisodes(), preferredIndex = null) {
+    const list = Array.isArray(episodes) ? episodes : [];
+    const total = list.length;
+    if (!total) {
+      return null;
+    }
+    const virtualized = total > EPISODE_VIRTUALIZATION_THRESHOLD;
+    if (!virtualized) {
+      const metrics = this.measureEpisodeTrackMetrics();
+      return {
+        season: Number(this.selectedSeason || 0),
+        virtualized: false,
+        start: 0,
+        end: total - 1,
+        cardWidth: metrics.cardWidth,
+        gap: metrics.gap,
+        stride: metrics.stride,
+        leftSpacer: 0,
+        rightSpacer: 0,
+        preferredIndex: Number.isFinite(preferredIndex) ? preferredIndex : null
+      };
+    }
+
+    const metrics = this.measureEpisodeTrackMetrics();
+    const visibleEstimate = Math.ceil(Math.max(1, metrics.viewportWidth || 0) / Math.max(1, metrics.stride || 1));
+    const windowSize = Math.min(
+      total,
+      Math.max(
+        EPISODE_VIRTUALIZATION_MIN_WINDOW,
+        visibleEstimate + (EPISODE_VIRTUALIZATION_OVERSCAN * 2)
+      )
+    );
+    const maxStart = Math.max(0, total - windowSize);
+    const currentTrack = this.getEpisodeTrackElement();
+    const currentScrollLeft = Number(currentTrack?.scrollLeft || 0);
+    const baseIndex = Number.isFinite(preferredIndex)
+      ? preferredIndex
+      : Math.floor(currentScrollLeft / Math.max(1, metrics.stride || 1));
+    const start = Math.max(0, Math.min(maxStart, baseIndex - EPISODE_VIRTUALIZATION_OVERSCAN));
+    const end = Math.min(total - 1, start + windowSize - 1);
+    return {
+      season: Number(this.selectedSeason || 0),
+      virtualized: true,
+      start,
+      end,
+      cardWidth: metrics.cardWidth,
+      gap: metrics.gap,
+      stride: metrics.stride,
+      leftSpacer: start * metrics.stride,
+      rightSpacer: Math.max(0, (total - end - 1) * metrics.stride),
+      preferredIndex: Number.isFinite(preferredIndex) ? preferredIndex : null
+    };
+  },
+
+  renderEpisodeCard(episode, absoluteIndex) {
+    const progress = this.episodeProgressMap.get(`${episode.season}:${episode.episode}`) || null;
+    const position = Number(progress?.positionMs || 0);
+    const duration = Number(progress?.durationMs || 0);
+    const progressRatio = duration > 0 ? Math.min(1, Math.max(0, position / duration)) : 0;
+    const episodeKey = `${episode.season}:${episode.episode}`;
+    const isWatched = this.enrichedWatchedState?.has(episodeKey)
+      ? Boolean(this.enrichedWatchedState.get(episodeKey)?.isWatched)
+      : this.watchedEpisodeKeys.has(episodeKey);
+    const rating = resolveEpisodeImdbRating(episode, this.seriesRatingsBySeason);
+    const dateLabel = formatEpisodeCardDate(episode.released || "");
+    const isUnavailable = episode.available === false;
+    const metaParts = [
+      episode.runtimeMinutes > 0 ? renderEpisodeRuntimeLabel(episode.runtimeMinutes) : "",
+      rating != null ? `<span class="series-episode-rating-inline">${renderImdbBadge(String(Number(rating).toFixed(1)))}</span>` : "",
+      dateLabel ? `<span class="series-episode-date">${escapeHtml(dateLabel)}</span>` : ""
+    ].filter(Boolean).join("");
+    return `
+      <article class="series-episode-card focusable${isWatched ? " watched" : ""}"
+            data-action="openEpisodeStreams"
+            data-video-id="${escapeHtml(episode.id)}"
+            data-episode-index="${absoluteIndex}">
+        <div class="series-episode-thumb"${episode.thumbnail ? ` style="background-image:url('${episode.thumbnail.replace(/'/g, "%27")}')"` : ""}>
+          <div class="series-episode-overlay"></div>
+          ${isWatched ? `<div class="series-episode-status complete">${renderWatchedBadgeGlyph()}</div>` : progressRatio < 0.02 ? `<div class="series-episode-status idle"></div>` : ""}
+          ${isUnavailable ? `<div class="series-episode-unavailable">${escapeHtml(t("episodes_unavailable", {}, "Unavailable").toUpperCase())}</div>` : ""}
+          <div class="series-episode-copy">
+            <div class="series-episode-badge">${escapeHtml(t("episodes_episode", {}, "Episode").toUpperCase())} ${Number(episode.episode || 0)}</div>
+            <div class="series-episode-title">${escapeHtml(normalizeEpisodeTitle(episode.title, episode.episode))}</div>
+            <div class="series-episode-overview">${escapeHtml(episode.overview || t("episodes_episode", {}, "Episode"))}</div>
+            ${metaParts ? `<div class="series-episode-meta">${metaParts}</div>` : ""}
+            ${progressRatio > 0.02 && progressRatio < 0.98 ? `<div class="series-episode-progress"><span style="width:${Math.round(progressRatio * 100)}%"></span></div>` : ""}
+          </div>
+        </div>
+      </article>
+    `;
+  },
+
+  renderEpisodeCards(preferredIndex = null) {
+    const episodes = this.getSelectedSeasonEpisodes();
+    if (!episodes.length) {
       return `<p>${escapeHtml(t("episodes_panel_no_episodes", {}, "No episodes available"))}</p>`;
     }
-    return selectedSeasonEpisodes.map((episode) => {
-      const progress = this.episodeProgressMap.get(`${episode.season}:${episode.episode}`) || null;
-      const position = Number(progress?.positionMs || 0);
-      const duration = Number(progress?.durationMs || 0);
-      const progressRatio = duration > 0 ? Math.min(1, Math.max(0, position / duration)) : 0;
-      const episodeKey = `${episode.season}:${episode.episode}`;
-      const isWatched = this.enrichedWatchedState?.has(episodeKey)
-        ? Boolean(this.enrichedWatchedState.get(episodeKey)?.isWatched)
-        : this.watchedEpisodeKeys.has(episodeKey);
-      const rating = resolveEpisodeImdbRating(episode, this.seriesRatingsBySeason);
-      const dateLabel = formatEpisodeCardDate(episode.released || "");
-      const isUnavailable = episode.available === false;
-      const metaParts = [
-        episode.runtimeMinutes > 0 ? renderEpisodeRuntimeLabel(episode.runtimeMinutes) : "",
-        rating != null ? `<span class="series-episode-rating-inline">${renderImdbBadge(String(Number(rating).toFixed(1)))}</span>` : "",
-        dateLabel ? `<span class="series-episode-date">${escapeHtml(dateLabel)}</span>` : ""
-      ].filter(Boolean).join("");
-      return `
-        <article class="series-episode-card focusable${isWatched ? " watched" : ""}"
-             data-action="openEpisodeStreams"
-             data-video-id="${episode.id}">
-          <div class="series-episode-thumb"${episode.thumbnail ? ` style="background-image:url('${episode.thumbnail.replace(/'/g, "%27")}')"` : ""}>
-            <div class="series-episode-overlay"></div>
-            ${isWatched ? `<div class="series-episode-status complete">${renderWatchedBadgeGlyph()}</div>` : progressRatio < 0.02 ? `<div class="series-episode-status idle"></div>` : ""}
-            ${isUnavailable ? `<div class="series-episode-unavailable">${escapeHtml(t("episodes_unavailable", {}, "Unavailable").toUpperCase())}</div>` : ""}
-            <div class="series-episode-copy">
-              <div class="series-episode-badge">${escapeHtml(t("episodes_episode", {}, "Episode").toUpperCase())} ${Number(episode.episode || 0)}</div>
-              <div class="series-episode-title">${escapeHtml(normalizeEpisodeTitle(episode.title, episode.episode))}</div>
-             <div class="series-episode-overview">${escapeHtml(episode.overview || t("episodes_episode", {}, "Episode"))}</div>
-              ${metaParts ? `<div class="series-episode-meta">${metaParts}</div>` : ""}
-              ${progressRatio > 0.02 && progressRatio < 0.98 ? `<div class="series-episode-progress"><span style="width:${Math.round(progressRatio * 100)}%"></span></div>` : ""}
-            </div>
-          </div>
-        </article>
-      `;
-    }).join("");
+    const windowState = this.getEpisodeVirtualWindowState(episodes, preferredIndex);
+    if (!windowState) {
+      return `<p>${escapeHtml(t("episodes_panel_no_episodes", {}, "No episodes available"))}</p>`;
+    }
+    this.episodeVirtualWindow = windowState;
+    const visibleEpisodes = windowState.virtualized
+      ? episodes.slice(windowState.start, windowState.end + 1)
+      : episodes;
+    const cards = visibleEpisodes.map((episode, offset) => this.renderEpisodeCard(episode, windowState.virtualized ? windowState.start + offset : offset)).join("");
+    if (!windowState.virtualized) {
+      return cards;
+    }
+    return `
+      <div class="series-episode-track-spacer" aria-hidden="true" style="flex-basis:${Math.max(0, windowState.leftSpacer)}px"></div>
+      <div class="series-episode-track-window" style="--episode-track-gap:${windowState.gap}px">
+        ${cards}
+      </div>
+      <div class="series-episode-track-spacer" aria-hidden="true" style="flex-basis:${Math.max(0, windowState.rightSpacer)}px"></div>
+    `;
+  },
+
+  refreshEpisodeTrack(focusRestoreOverride = null, preferredIndex = null) {
+    if (!this.container || !isSeriesDetailMeta(this.meta, this.episodes)) {
+      return false;
+    }
+    const episodeMount = this.container.querySelector("#detailEpisodeTrackMount");
+    if (!episodeMount) {
+      return false;
+    }
+    const focusRestore = focusRestoreOverride || this.captureDetailFocus();
+    this.captureRenderedChromeState();
+    episodeMount.innerHTML = `<div class="series-episode-track${this.getSelectedSeasonEpisodes().length > EPISODE_VIRTUALIZATION_THRESHOLD ? " is-virtualized" : ""}" data-scroll-key="episodes:${this.selectedSeason || 1}">${this.renderEpisodeCards(preferredIndex)}</div>`;
+    ScreenUtils.indexFocusables(this.container);
+    this.pendingFocusRestore = focusRestore;
+    this.bindDetailChrome();
+    return true;
+  },
+
+  scheduleEpisodeVirtualizationSync(preferredIndex = null) {
+    if (this.episodeVirtualSyncRaf) {
+      cancelAnimationFrame(this.episodeVirtualSyncRaf);
+    }
+    const raf = typeof requestAnimationFrame === "function"
+      ? requestAnimationFrame
+      : (cb) => setTimeout(cb, 16);
+    this.episodeVirtualSyncRaf = raf(() => {
+      this.episodeVirtualSyncRaf = null;
+      this.syncEpisodeVirtualization(preferredIndex);
+    });
+  },
+
+  syncEpisodeVirtualization(preferredIndex = null) {
+    if (!this.container || !isSeriesDetailMeta(this.meta, this.episodes)) {
+      return false;
+    }
+    const episodes = this.getSelectedSeasonEpisodes();
+    if (episodes.length <= EPISODE_VIRTUALIZATION_THRESHOLD) {
+      return false;
+    }
+    const track = this.getEpisodeTrackElement();
+    if (!track) {
+      return false;
+    }
+    const currentFocus = this.container.querySelector(".series-episode-card.focusable.focused") || null;
+    const focusIndex = Number.isFinite(preferredIndex)
+      ? preferredIndex
+      : Number(currentFocus?.dataset?.episodeIndex || this.getRememberedEpisodeIndex(episodes));
+    const nextWindow = this.getEpisodeVirtualWindowState(episodes, focusIndex);
+    if (!nextWindow) {
+      return false;
+    }
+    const currentWindow = this.episodeVirtualWindow;
+    if (
+      currentWindow
+      && currentWindow.season === nextWindow.season
+      && currentWindow.start === nextWindow.start
+      && currentWindow.end === nextWindow.end
+      && currentWindow.virtualized === nextWindow.virtualized
+    ) {
+      this.episodeVirtualState = nextWindow;
+      return false;
+    }
+    this.episodeVirtualWindow = nextWindow;
+    this.episodeVirtualState = nextWindow;
+    this.refreshEpisodeTrack({ episodeIndex: focusIndex, preserveVerticalScroll: true }, focusIndex);
+    return true;
+  },
+
+  focusEpisodeByIndex(index, options = {}) {
+    const episodes = this.getSelectedSeasonEpisodes();
+    if (!episodes.length) {
+      return false;
+    }
+    const targetIndex = Math.max(0, Math.min(episodes.length - 1, Number(index || 0)));
+    const focusRestore = { episodeIndex: targetIndex, preserveVerticalScroll: Boolean(options?.preserveVerticalScroll) };
+    if (this.syncEpisodeVirtualization(targetIndex)) {
+      const target = this.container?.querySelector(`.series-episode-card[data-episode-index="${targetIndex}"]`) || null;
+      if (target instanceof HTMLElement) {
+        return this.focusInList([target], 0, {
+          animated: options?.animated !== false,
+          preserveVerticalScroll: Boolean(options?.preserveVerticalScroll)
+        });
+      }
+      this.pendingFocusRestore = focusRestore;
+      return true;
+    }
+    const target = this.container?.querySelector(`.series-episode-card[data-episode-index="${targetIndex}"]`) || null;
+    if (!(target instanceof HTMLElement)) {
+      return false;
+    }
+    return this.focusInList([target], 0, {
+      animated: options?.animated !== false,
+      preserveVerticalScroll: Boolean(options?.preserveVerticalScroll)
+    });
+  },
+
+  focusEpisodeByVideoId(videoId, options = {}) {
+    const index = this.getEpisodeIndexByVideoId(videoId);
+    if (index < 0) {
+      return false;
+    }
+    return this.focusEpisodeByIndex(index, options);
   },
 
   syncSeriesHeroPlayButtonLabel() {
@@ -2930,7 +3159,15 @@ export const MetaDetailsScreen = {
 
   getEpisodeFocusDescriptor(videoId) {
     const value = String(videoId || "").trim();
-    return value ? { selector: `.series-episode-card[data-video-id="${escapeSelectorValue(value)}"]` } : null;
+    if (!value) {
+      return null;
+    }
+    const episodeIndex = this.getEpisodeIndexByVideoId(value);
+    return {
+      episodeVideoId: value,
+      episodeIndex: episodeIndex >= 0 ? episodeIndex : null,
+      selector: `.series-episode-card[data-video-id="${escapeSelectorValue(value)}"]`
+    };
   },
 
   getEpisodeMenuProgress(episode) {
@@ -3037,7 +3274,22 @@ export const MetaDetailsScreen = {
   },
 
   focusDetailDescriptor(descriptor) {
-    if (!descriptor?.selector || !this.container) {
+    if (!descriptor || !this.container) {
+      return false;
+    }
+    if (Number.isFinite(descriptor.episodeIndex) && descriptor.episodeIndex >= 0) {
+      return this.focusEpisodeByIndex(Number(descriptor.episodeIndex), {
+        animated: false,
+        preserveVerticalScroll: Boolean(descriptor.preserveVerticalScroll)
+      });
+    }
+    if (descriptor.episodeVideoId) {
+      return this.focusEpisodeByVideoId(descriptor.episodeVideoId, {
+        animated: false,
+        preserveVerticalScroll: Boolean(descriptor.preserveVerticalScroll)
+      });
+    }
+    if (!descriptor?.selector) {
       return false;
     }
     const target = this.container.querySelector(descriptor.selector);
@@ -4099,6 +4351,19 @@ export const MetaDetailsScreen = {
       shell.classList.toggle("detail-scrolled", content.scrollTop > 160);
     };
     content.addEventListener("scroll", this.detailScrollHandler, { passive: true });
+    const episodeTrack = this.container?.querySelector(".series-episode-track");
+    if (this.episodeTrackScrollNode && this.episodeTrackScrollHandler) {
+      this.episodeTrackScrollNode.removeEventListener("scroll", this.episodeTrackScrollHandler);
+    }
+    this.episodeTrackScrollNode = episodeTrack instanceof HTMLElement ? episodeTrack : null;
+    if (this.episodeTrackScrollNode) {
+      this.episodeTrackScrollHandler = () => {
+        this.scheduleEpisodeVirtualizationSync();
+      };
+      this.episodeTrackScrollNode.addEventListener("scroll", this.episodeTrackScrollHandler, { passive: true });
+    } else {
+      this.episodeTrackScrollHandler = null;
+    }
     if (this.detailFocusHandler) {
       this.container.removeEventListener("focusin", this.detailFocusHandler, true);
     }
@@ -4280,7 +4545,12 @@ export const MetaDetailsScreen = {
     }
     if (action === "openEpisodeStreams") {
       const videoId = String(target.dataset.videoId || "");
-      return videoId ? { selector: `.series-episode-card[data-video-id="${escapeSelectorValue(videoId)}"]` } : null;
+      const episodeIndex = Number(target.dataset.episodeIndex || -1);
+      return videoId ? {
+        episodeVideoId: videoId,
+        episodeIndex: Number.isFinite(episodeIndex) && episodeIndex >= 0 ? episodeIndex : this.getEpisodeIndexByVideoId(videoId),
+        selector: `.series-episode-card[data-video-id="${escapeSelectorValue(videoId)}"]`
+      } : null;
     }
     if (action === "openCastDetail") {
       const castKey = String(target.dataset.castKey || "");
@@ -5450,13 +5720,15 @@ export const MetaDetailsScreen = {
   },
 
   getRememberedEpisodeIndex(episodes = []) {
-    if (!Array.isArray(episodes) || !episodes.length) {
+    const seasonEpisodes = this.getSelectedSeasonEpisodes();
+    const total = Array.isArray(episodes) && episodes.length ? Math.max(episodes.length, seasonEpisodes.length) : seasonEpisodes.length;
+    if (!total) {
       return 0;
     }
     const seasonKey = String(Number(this.selectedSeason || 0) || 0);
     const remembered = Number(this.episodeFocusIndexBySeason?.[seasonKey]);
     if (Number.isFinite(remembered) && remembered >= 0) {
-      return Math.min(episodes.length - 1, remembered);
+      return Math.min(total - 1, remembered);
     }
     return 0;
   },
@@ -5496,6 +5768,11 @@ export const MetaDetailsScreen = {
       return;
     }
     const seasonKey = String(Number(this.selectedSeason || 0) || 0);
+    const absoluteIndex = Number(target.dataset.episodeIndex || -1);
+    if (Number.isFinite(absoluteIndex) && absoluteIndex >= 0) {
+      this.episodeFocusIndexBySeason[seasonKey] = absoluteIndex;
+      return;
+    }
     const items = Array.isArray(list) && list.length
       ? list
       : Array.from(this.container?.querySelectorAll(".series-episode-track .series-episode-card.focusable") || []);
@@ -5847,7 +6124,7 @@ export const MetaDetailsScreen = {
       }
       if (castCards.length) return this.focusInList(castCards, Math.min(index, castCards.length - 1));
       if (insightTabs.length) return this.focusInList(insightTabs, this.getActiveInsightTabIndex(insightTabs));
-      if (episodes.length) return this.focusInList(episodes, this.getRememberedEpisodeIndex(episodes));
+      if (episodes.length) return this.focusEpisodeByIndex(this.getRememberedEpisodeIndex(episodes), { preserveVerticalScroll: true });
       return false;
     };
     const focusFirstSeriesSectionBelowHero = (index = 0) => {
@@ -5873,7 +6150,7 @@ export const MetaDetailsScreen = {
     };
     const focusSeriesSectionAboveInsights = (index = 0) => {
       if (episodes.length) {
-        return this.focusInList(episodes, this.getRememberedEpisodeIndex(episodes));
+        return this.focusEpisodeByIndex(this.getRememberedEpisodeIndex(episodes), { preserveVerticalScroll: true });
       }
       if (seasons.length) {
         return this.focusInList(seasons, Math.min(index, seasons.length - 1));
@@ -5897,7 +6174,7 @@ export const MetaDetailsScreen = {
           return this.focusInList(seasons, this.getSelectedSeasonIndex(seasons)) || true;
         }
         if (episodes.length) {
-          return this.focusInList(episodes, this.getRememberedEpisodeIndex(episodes)) || true;
+          return this.focusEpisodeByIndex(this.getRememberedEpisodeIndex(episodes), { preserveVerticalScroll: true }) || true;
         }
         if (focusFirstSeriesSectionBelowHero(actionIndex)) {
           return true;
@@ -5917,7 +6194,7 @@ export const MetaDetailsScreen = {
       }
       if (direction === "down") {
         if (episodes.length) {
-          return this.focusInList(episodes, this.getRememberedEpisodeIndex(episodes)) || true;
+          return this.focusEpisodeByIndex(this.getRememberedEpisodeIndex(episodes), { preserveVerticalScroll: true }) || true;
         }
         if (focusFirstSeriesSectionBelowHero(seasonIndex)) {
           return true;
@@ -5928,14 +6205,15 @@ export const MetaDetailsScreen = {
 
     const episodeIndex = episodes.indexOf(current);
     if (episodeIndex >= 0) {
-      if (direction === "left") return this.focusInList(episodes, episodeIndex - 1, { preserveVerticalScroll: true }) || true;
-      if (direction === "right") return this.focusInList(episodes, episodeIndex + 1, { preserveVerticalScroll: true }) || true;
+      const absoluteEpisodeIndex = Number(current.dataset.episodeIndex || episodeIndex);
+      if (direction === "left") return this.focusEpisodeByIndex(absoluteEpisodeIndex - 1, { preserveVerticalScroll: true }) || true;
+      if (direction === "right") return this.focusEpisodeByIndex(absoluteEpisodeIndex + 1, { preserveVerticalScroll: true }) || true;
       if (direction === "up") {
         if (seasons.length) {
           return this.focusInList(seasons, this.getSelectedSeasonIndex(seasons)) || true;
         }
         if (actions.length) {
-          return this.focusInList(actions, Math.min(episodeIndex, actions.length - 1)) || true;
+          return this.focusInList(actions, Math.min(absoluteEpisodeIndex, actions.length - 1)) || true;
         }
       }
       if (direction === "down" && insightTabs.length) {
@@ -5993,7 +6271,7 @@ export const MetaDetailsScreen = {
           return this.focusInList(insightTabs, this.getActiveInsightTabIndex(insightTabs)) || true;
         }
         if (episodes.length) {
-          return this.focusInList(episodes, this.getRememberedEpisodeIndex(episodes)) || true;
+          return this.focusEpisodeByIndex(this.getRememberedEpisodeIndex(episodes), { preserveVerticalScroll: true }) || true;
         }
       }
       if (direction === "down" && focusCommentsEntry(castIndex)) {
@@ -6017,7 +6295,7 @@ export const MetaDetailsScreen = {
           return this.focusInList(insightTabs, this.getActiveInsightTabIndex(insightTabs, 1)) || true;
         }
         if (episodes.length) {
-          return this.focusInList(episodes, this.getRememberedEpisodeIndex(episodes)) || true;
+          return this.focusEpisodeByIndex(this.getRememberedEpisodeIndex(episodes), { preserveVerticalScroll: true }) || true;
         }
       }
       if (direction === "down" && ratingChips.length) {
@@ -6044,7 +6322,7 @@ export const MetaDetailsScreen = {
           return this.focusInList(insightTabs, this.getActiveInsightTabIndex(insightTabs, 1)) || true;
         }
         if (episodes.length) {
-          return this.focusInList(episodes, this.getRememberedEpisodeIndex(episodes)) || true;
+          return this.focusEpisodeByIndex(this.getRememberedEpisodeIndex(episodes), { preserveVerticalScroll: true }) || true;
         }
       }
       if (direction === "down" && focusCommentsEntry(ratingChipIndex)) {
@@ -6090,7 +6368,7 @@ export const MetaDetailsScreen = {
           return this.focusInList(insightTabs, moreLikeTabIndex) || true;
         }
         if (episodes.length) {
-          return this.focusInList(episodes, this.getRememberedEpisodeIndex(episodes)) || true;
+          return this.focusEpisodeByIndex(this.getRememberedEpisodeIndex(episodes), { preserveVerticalScroll: true }) || true;
         }
       }
       if (direction === "down" && focusCommentsEntry(moreLikeIndex)) {
@@ -6130,7 +6408,7 @@ export const MetaDetailsScreen = {
           return this.focusInList(insightTabs, this.getActiveInsightTabIndex(insightTabs)) || true;
         }
         if (episodes.length) {
-          return this.focusInList(episodes, this.getRememberedEpisodeIndex(episodes)) || true;
+          return this.focusEpisodeByIndex(this.getRememberedEpisodeIndex(episodes), { preserveVerticalScroll: true }) || true;
         }
       }
       if (direction === "down" && trackIndex < companyCards.length - 1 && companyCards[trackIndex + 1]?.length) {
@@ -6717,6 +6995,17 @@ export const MetaDetailsScreen = {
     this.seasonHoldMenu = null;
     this.heroPlayMenu = null;
     this.libraryListMenu = null;
+    if (this.episodeVirtualSyncRaf) {
+      cancelAnimationFrame(this.episodeVirtualSyncRaf);
+      this.episodeVirtualSyncRaf = null;
+    }
+    if (this.episodeTrackScrollNode && this.episodeTrackScrollHandler) {
+      this.episodeTrackScrollNode.removeEventListener("scroll", this.episodeTrackScrollHandler);
+    }
+    this.episodeTrackScrollNode = null;
+    this.episodeTrackScrollHandler = null;
+    this.episodeVirtualWindow = null;
+    this.episodeVirtualState = null;
     this.stopTrailerPlayback({ keepDom: false, restartAutoplay: false });
     if (this.detailScrollHandler && this.container) {
       const content = this.container.querySelector(".series-detail-content");

--- a/js/ui/screens/detail/metaDetailsScreen.js
+++ b/js/ui/screens/detail/metaDetailsScreen.js
@@ -51,8 +51,39 @@ const EPISODE_VIRTUALIZATION_DEFAULT_GAP = 34;
 const EPISODE_HOLD_REPEAT_INITIAL_DELAY_MS = 170;
 const EPISODE_HOLD_REPEAT_MIN_INTERVAL_MS = 24;
 const EPISODE_HOLD_REPEAT_MAX_INTERVAL_MS = 140;
-const EPISODE_HOLD_REPEAT_STEP_INTERVAL_MS = 220;
 const EPISODE_HOLD_REPEAT_STEP_MULTIPLIER_MAX = 50;
+const EPISODE_HOLD_REPEAT_PROFILE = [
+  {
+    elapsedMs: 5000,
+    stepCount: 40,
+    intervalMs: EPISODE_HOLD_REPEAT_MIN_INTERVAL_MS,
+    stepSize: EPISODE_HOLD_REPEAT_STEP_MULTIPLIER_MAX
+  },
+  {
+    elapsedMs: 3200,
+    stepCount: 28,
+    intervalMs: 28,
+    stepSize: 24
+  },
+  {
+    elapsedMs: 2000,
+    stepCount: 18,
+    intervalMs: 42,
+    stepSize: 16
+  },
+  {
+    elapsedMs: 1200,
+    stepCount: 10,
+    intervalMs: 60,
+    stepSize: 10
+  },
+  {
+    elapsedMs: 650,
+    stepCount: 5,
+    intervalMs: 86,
+    stepSize: 6
+  }
+];
 const LOCAL_YOUTUBE_PROXY_URL = "youtube-proxy.html";
 
 function t(key, params = {}, fallback = key) {
@@ -404,6 +435,14 @@ function getDpadDirection(event) {
   if (keyCode === 38 || key === "arrowup" || key === "up") return "up";
   if (keyCode === 40 || key === "arrowdown" || key === "down") return "down";
   return null;
+}
+
+function resolveEpisodeHoldRepeatProfile(stepCount = 0, elapsedMs = 0) {
+  return EPISODE_HOLD_REPEAT_PROFILE.find((entry) => elapsedMs >= entry.elapsedMs || stepCount >= entry.stepCount)
+    || {
+      intervalMs: EPISODE_HOLD_REPEAT_MAX_INTERVAL_MS,
+      stepSize: 1
+    };
 }
 
 async function withTimeout(promise, ms, fallbackValue) {
@@ -1242,7 +1281,7 @@ export const MetaDetailsScreen = {
     this.resumeContentIds = [];
     this.episodeFocusIndexBySeason = {};
     this.episodeVirtualWindow = null;
-    this.episodeVirtualState = null;
+    this.episodeVirtualMetrics = null;
     this.episodeTrackScrollHandler = null;
     this.episodeTrackScrollNode = null;
     this.episodeVirtualSyncRaf = null;
@@ -1250,8 +1289,8 @@ export const MetaDetailsScreen = {
     this.episodeHoldRepeatDirection = "";
     this.episodeHoldRepeatStartedAt = 0;
     this.episodeHoldRepeatStepCount = 0;
-    this.episodeHoldRepeatTargetVideoId = "";
     this.episodeThumbnailPrefetchCache = new Set();
+    this.selectedSeasonEpisodeState = null;
     this.railFocusIndexByKey = {};
     this.watchedEpisodeKeys = new Set();
     this.autoOpenedContinueWatchingStream = false;
@@ -2825,10 +2864,36 @@ export const MetaDetailsScreen = {
   },
 
   getSelectedSeasonEpisodes() {
-    if (!Array.isArray(this.episodes) || !this.episodes.length) {
-      return [];
+    return this.getSelectedSeasonEpisodeState().episodes;
+  },
+
+  getSelectedSeasonEpisodeState() {
+    const allEpisodes = Array.isArray(this.episodes) ? this.episodes : [];
+    const season = Number(this.selectedSeason || 0);
+    const cachedState = this.selectedSeasonEpisodeState;
+    if (cachedState?.source === allEpisodes && cachedState.season === season) {
+      return cachedState;
     }
-    return this.episodes.filter((episode) => Number(episode?.season || 0) === Number(this.selectedSeason || 0));
+    const seasonEpisodes = [];
+    const indexByVideoId = new Map();
+    for (const episode of allEpisodes) {
+      if (Number(episode?.season || 0) !== season) {
+        continue;
+      }
+      const absoluteIndex = seasonEpisodes.length;
+      seasonEpisodes.push(episode);
+      const videoId = String(episode?.id || "").trim();
+      if (videoId && !indexByVideoId.has(videoId)) {
+        indexByVideoId.set(videoId, absoluteIndex);
+      }
+    }
+    this.selectedSeasonEpisodeState = {
+      source: allEpisodes,
+      season,
+      episodes: seasonEpisodes,
+      indexByVideoId
+    };
+    return this.selectedSeasonEpisodeState;
   },
 
   getEpisodeIndexByVideoId(videoId) {
@@ -2836,15 +2901,43 @@ export const MetaDetailsScreen = {
     if (!wanted) {
       return -1;
     }
-    return this.getSelectedSeasonEpisodes().findIndex((episode) => String(episode?.id || "") === wanted);
+    return this.getSelectedSeasonEpisodeState().indexByVideoId.get(wanted) ?? -1;
   },
 
   getEpisodeTrackElement() {
     return this.container?.querySelector(".series-episode-track") || null;
   },
 
+  getFocusedEpisodeCard() {
+    const target = this.container?.querySelector(".series-episode-card.focusable.focused") || null;
+    return target instanceof HTMLElement ? target : null;
+  },
+
+  getEpisodeAbsoluteIndex(node) {
+    if (!(node instanceof HTMLElement)) {
+      return -1;
+    }
+    const explicitIndex = Number(node.dataset.episodeIndex || -1);
+    if (Number.isFinite(explicitIndex) && explicitIndex >= 0) {
+      return explicitIndex;
+    }
+    return this.getEpisodeIndexByVideoId(String(node.dataset.videoId || ""));
+  },
+
   measureEpisodeTrackMetrics(track = null) {
     const target = track instanceof HTMLElement ? track : this.getEpisodeTrackElement();
+    const season = Number(this.selectedSeason || 0);
+    const viewportWidth = Number(target?.clientWidth || 0);
+    const cachedMetrics = this.episodeVirtualMetrics;
+    if (
+      cachedMetrics
+      && cachedMetrics.season === season
+      && cachedMetrics.viewportWidth === viewportWidth
+      && cachedMetrics.cardWidth > 0
+      && cachedMetrics.stride > 0
+    ) {
+      return cachedMetrics;
+    }
     const sampleCard = target?.querySelector?.(".series-episode-card") || null;
     const sampleWindow = target?.querySelector?.(".series-episode-track-window") || target;
     const trackStyle = target && typeof getComputedStyle === "function" ? getComputedStyle(target) : null;
@@ -2852,18 +2945,16 @@ export const MetaDetailsScreen = {
     const rawGap = Number.parseFloat(windowStyle?.gap || windowStyle?.columnGap || trackStyle?.gap || trackStyle?.columnGap || "0");
     const gap = Number.isFinite(rawGap) && rawGap >= 0 ? rawGap : EPISODE_VIRTUALIZATION_DEFAULT_GAP;
     const measuredWidth = Number(sampleCard?.getBoundingClientRect?.().width || 0);
-    const cardWidth = measuredWidth > 0 ? measuredWidth : (this.episodeVirtualState?.cardWidth || EPISODE_VIRTUALIZATION_DEFAULT_CARD_WIDTH);
+    const cardWidth = measuredWidth > 0 ? measuredWidth : (cachedMetrics?.cardWidth || EPISODE_VIRTUALIZATION_DEFAULT_CARD_WIDTH);
     const stride = Math.max(1, cardWidth + gap);
-    const viewportWidth = Number(target?.clientWidth || 0);
-    this.episodeVirtualState = {
-      season: Number(this.selectedSeason || 0),
+    this.episodeVirtualMetrics = {
+      season,
       cardWidth,
       gap,
       stride,
-      viewportWidth,
-      measuredAt: Date.now()
+      viewportWidth
     };
-    return this.episodeVirtualState;
+    return this.episodeVirtualMetrics;
   },
 
   getEpisodeVirtualWindowState(episodes = this.getSelectedSeasonEpisodes(), preferredIndex = null) {
@@ -2873,8 +2964,8 @@ export const MetaDetailsScreen = {
       return null;
     }
     const virtualized = total > EPISODE_VIRTUALIZATION_THRESHOLD;
+    const metrics = this.measureEpisodeTrackMetrics();
     if (!virtualized) {
-      const metrics = this.measureEpisodeTrackMetrics();
       return {
         season: Number(this.selectedSeason || 0),
         virtualized: false,
@@ -2889,7 +2980,6 @@ export const MetaDetailsScreen = {
       };
     }
 
-    const metrics = this.measureEpisodeTrackMetrics();
     const visibleEstimate = Math.ceil(Math.max(1, metrics.viewportWidth || 0) / Math.max(1, metrics.stride || 1));
     const windowSize = Math.min(
       total,
@@ -3048,10 +3138,11 @@ export const MetaDetailsScreen = {
     if (!track) {
       return false;
     }
-    const currentFocus = this.container.querySelector(".series-episode-card.focusable.focused") || null;
+    const currentFocus = this.getFocusedEpisodeCard();
+    const currentFocusIndex = this.getEpisodeAbsoluteIndex(currentFocus);
     const focusIndex = Number.isFinite(preferredIndex)
       ? preferredIndex
-      : Number(currentFocus?.dataset?.episodeIndex || this.getRememberedEpisodeIndex(episodes));
+      : (currentFocusIndex >= 0 ? currentFocusIndex : this.getRememberedEpisodeIndex(episodes));
     const nextWindow = this.getEpisodeVirtualWindowState(episodes, focusIndex);
     if (!nextWindow) {
       return false;
@@ -3064,11 +3155,9 @@ export const MetaDetailsScreen = {
       && currentWindow.end === nextWindow.end
       && currentWindow.virtualized === nextWindow.virtualized
     ) {
-      this.episodeVirtualState = nextWindow;
       return false;
     }
     this.episodeVirtualWindow = nextWindow;
-    this.episodeVirtualState = nextWindow;
     this.refreshEpisodeTrack({ episodeIndex: focusIndex, preserveVerticalScroll: true }, focusIndex);
     return true;
   },
@@ -3771,57 +3860,25 @@ export const MetaDetailsScreen = {
     this.episodeHoldRepeatDirection = "";
     this.episodeHoldRepeatStartedAt = 0;
     this.episodeHoldRepeatStepCount = 0;
-    this.episodeHoldRepeatTargetVideoId = "";
   },
 
   getEpisodeHoldRepeatInterval(stepCount = 0, elapsedMs = 0) {
-    if (elapsedMs >= 5000 || stepCount >= 40) {
-      return EPISODE_HOLD_REPEAT_MIN_INTERVAL_MS;
-    }
-    if (elapsedMs >= 3200 || stepCount >= 28) {
-      return 28;
-    }
-    if (elapsedMs >= 2000 || stepCount >= 18) {
-      return 42;
-    }
-    if (elapsedMs >= 1200 || stepCount >= 10) {
-      return 60;
-    }
-    if (elapsedMs >= 650 || stepCount >= 5) {
-      return 86;
-    }
-    return EPISODE_HOLD_REPEAT_MAX_INTERVAL_MS;
+    return resolveEpisodeHoldRepeatProfile(stepCount, elapsedMs).intervalMs;
   },
 
   getEpisodeRepeatStepSize(stepCount = 0, elapsedMs = 0) {
-    if (elapsedMs >= 5000 || stepCount >= 40) {
-      return EPISODE_HOLD_REPEAT_STEP_MULTIPLIER_MAX;
-    }
-    if (elapsedMs >= 3200 || stepCount >= 28) {
-      return 24;
-    }
-    if (elapsedMs >= 2000 || stepCount >= 18) {
-      return 16;
-    }
-    if (elapsedMs >= 1200 || stepCount >= 10) {
-      return 10;
-    }
-    if (elapsedMs >= 650 || stepCount >= 5) {
-      return 6;
-    }
-    return 1;
+    return resolveEpisodeHoldRepeatProfile(stepCount, elapsedMs).stepSize;
   },
 
   moveEpisodeFocusWithAcceleration(direction) {
     if (direction !== "left" && direction !== "right") {
       return false;
     }
-    const current = this.container?.querySelector(".series-episode-card.focusable.focused") || null;
+    const current = this.getFocusedEpisodeCard();
     if (!current) {
       return false;
     }
-    const videoId = String(current.dataset.videoId || "").trim();
-    const currentIndex = Number(current.dataset.episodeIndex || this.getEpisodeIndexByVideoId(videoId));
+    const currentIndex = this.getEpisodeAbsoluteIndex(current);
     if (!Number.isFinite(currentIndex) || currentIndex < 0) {
       return false;
     }
@@ -3842,12 +3899,11 @@ export const MetaDetailsScreen = {
     this.episodeHoldRepeatDirection = direction;
     this.episodeHoldRepeatStartedAt = now;
     this.episodeHoldRepeatStepCount = 0;
-    this.episodeHoldRepeatTargetVideoId = videoId;
     const tick = () => {
       if (!this.episodeHoldRepeatDirection) {
         return;
       }
-      const current = this.container?.querySelector(".series-episode-card.focusable.focused") || null;
+      const current = this.getFocusedEpisodeCard();
       if (!current) {
         this.stopEpisodeHoldRepeat();
         return;
@@ -3861,7 +3917,8 @@ export const MetaDetailsScreen = {
       const moveCount = Math.max(1, stepSize);
       this.episodeHoldRepeatStepCount += 1;
       const step = this.episodeHoldRepeatDirection === "left" ? -moveCount : moveCount;
-      const didMove = this.focusEpisodeByIndex((Number(current.dataset.episodeIndex || this.getEpisodeIndexByVideoId(String(current.dataset.videoId || this.episodeHoldRepeatTargetVideoId || ""))) || 0) + step, {
+      const currentIndex = this.getEpisodeAbsoluteIndex(current);
+      const didMove = this.focusEpisodeByIndex((currentIndex >= 0 ? currentIndex : 0) + step, {
         preserveVerticalScroll: true,
         animated: false
       });
@@ -7170,13 +7227,14 @@ export const MetaDetailsScreen = {
     }
     this.stopEpisodeHoldRepeat();
     this.episodeThumbnailPrefetchCache = new Set();
+    this.selectedSeasonEpisodeState = null;
     if (this.episodeTrackScrollNode && this.episodeTrackScrollHandler) {
       this.episodeTrackScrollNode.removeEventListener("scroll", this.episodeTrackScrollHandler);
     }
     this.episodeTrackScrollNode = null;
     this.episodeTrackScrollHandler = null;
     this.episodeVirtualWindow = null;
-    this.episodeVirtualState = null;
+    this.episodeVirtualMetrics = null;
     this.stopTrailerPlayback({ keepDom: false, restartAutoplay: false });
     if (this.detailScrollHandler && this.container) {
       const content = this.container.querySelector(".series-detail-content");

--- a/js/ui/screens/detail/metaDetailsScreen.js
+++ b/js/ui/screens/detail/metaDetailsScreen.js
@@ -48,6 +48,11 @@ const EPISODE_VIRTUALIZATION_MIN_WINDOW = 20;
 const EPISODE_VIRTUALIZATION_OVERSCAN = 8;
 const EPISODE_VIRTUALIZATION_DEFAULT_CARD_WIDTH = 540;
 const EPISODE_VIRTUALIZATION_DEFAULT_GAP = 34;
+const EPISODE_HOLD_REPEAT_INITIAL_DELAY_MS = 170;
+const EPISODE_HOLD_REPEAT_MIN_INTERVAL_MS = 24;
+const EPISODE_HOLD_REPEAT_MAX_INTERVAL_MS = 140;
+const EPISODE_HOLD_REPEAT_STEP_INTERVAL_MS = 220;
+const EPISODE_HOLD_REPEAT_STEP_MULTIPLIER_MAX = 50;
 const LOCAL_YOUTUBE_PROXY_URL = "youtube-proxy.html";
 
 function t(key, params = {}, fallback = key) {
@@ -1241,6 +1246,12 @@ export const MetaDetailsScreen = {
     this.episodeTrackScrollHandler = null;
     this.episodeTrackScrollNode = null;
     this.episodeVirtualSyncRaf = null;
+    this.episodeHoldRepeatTimer = null;
+    this.episodeHoldRepeatDirection = "";
+    this.episodeHoldRepeatStartedAt = 0;
+    this.episodeHoldRepeatStepCount = 0;
+    this.episodeHoldRepeatTargetVideoId = "";
+    this.episodeThumbnailPrefetchCache = new Set();
     this.railFocusIndexByKey = {};
     this.watchedEpisodeKeys = new Set();
     this.autoOpenedContinueWatchingStream = false;
@@ -2947,6 +2958,27 @@ export const MetaDetailsScreen = {
     `;
   },
 
+  warmEpisodeThumbnails(episodes = [], startIndex = 0, endIndex = 0) {
+    if (!Array.isArray(episodes) || !episodes.length) {
+      return;
+    }
+    const from = Math.max(0, Math.min(episodes.length - 1, Number(startIndex || 0)));
+    const to = Math.max(from, Math.min(episodes.length - 1, Number(endIndex || 0)));
+    const prefetchStart = Math.max(0, from - EPISODE_VIRTUALIZATION_OVERSCAN);
+    const prefetchEnd = Math.min(episodes.length - 1, to + EPISODE_VIRTUALIZATION_OVERSCAN);
+    for (let index = prefetchStart; index <= prefetchEnd; index += 1) {
+      const thumbnail = String(episodes[index]?.thumbnail || "").trim();
+      if (!thumbnail || this.episodeThumbnailPrefetchCache.has(thumbnail)) {
+        continue;
+      }
+      this.episodeThumbnailPrefetchCache.add(thumbnail);
+      const image = new Image();
+      image.decoding = "async";
+      image.loading = "eager";
+      image.src = thumbnail;
+    }
+  },
+
   renderEpisodeCards(preferredIndex = null) {
     const episodes = this.getSelectedSeasonEpisodes();
     if (!episodes.length) {
@@ -2960,6 +2992,7 @@ export const MetaDetailsScreen = {
     const visibleEpisodes = windowState.virtualized
       ? episodes.slice(windowState.start, windowState.end + 1)
       : episodes;
+    this.warmEpisodeThumbnails(episodes, windowState.start, windowState.end);
     const cards = visibleEpisodes.map((episode, offset) => this.renderEpisodeCard(episode, windowState.virtualized ? windowState.start + offset : offset)).join("");
     if (!windowState.virtualized) {
       return cards;
@@ -3728,6 +3761,119 @@ export const MetaDetailsScreen = {
       itemType: node.dataset.itemType || "movie",
       fallbackTitle: node.dataset.itemTitle || "Untitled"
     });
+  },
+
+  stopEpisodeHoldRepeat() {
+    if (this.episodeHoldRepeatTimer) {
+      clearTimeout(this.episodeHoldRepeatTimer);
+      this.episodeHoldRepeatTimer = null;
+    }
+    this.episodeHoldRepeatDirection = "";
+    this.episodeHoldRepeatStartedAt = 0;
+    this.episodeHoldRepeatStepCount = 0;
+    this.episodeHoldRepeatTargetVideoId = "";
+  },
+
+  getEpisodeHoldRepeatInterval(stepCount = 0, elapsedMs = 0) {
+    if (elapsedMs >= 5000 || stepCount >= 40) {
+      return EPISODE_HOLD_REPEAT_MIN_INTERVAL_MS;
+    }
+    if (elapsedMs >= 3200 || stepCount >= 28) {
+      return 28;
+    }
+    if (elapsedMs >= 2000 || stepCount >= 18) {
+      return 42;
+    }
+    if (elapsedMs >= 1200 || stepCount >= 10) {
+      return 60;
+    }
+    if (elapsedMs >= 650 || stepCount >= 5) {
+      return 86;
+    }
+    return EPISODE_HOLD_REPEAT_MAX_INTERVAL_MS;
+  },
+
+  getEpisodeRepeatStepSize(stepCount = 0, elapsedMs = 0) {
+    if (elapsedMs >= 5000 || stepCount >= 40) {
+      return EPISODE_HOLD_REPEAT_STEP_MULTIPLIER_MAX;
+    }
+    if (elapsedMs >= 3200 || stepCount >= 28) {
+      return 24;
+    }
+    if (elapsedMs >= 2000 || stepCount >= 18) {
+      return 16;
+    }
+    if (elapsedMs >= 1200 || stepCount >= 10) {
+      return 10;
+    }
+    if (elapsedMs >= 650 || stepCount >= 5) {
+      return 6;
+    }
+    return 1;
+  },
+
+  moveEpisodeFocusWithAcceleration(direction) {
+    if (direction !== "left" && direction !== "right") {
+      return false;
+    }
+    const current = this.container?.querySelector(".series-episode-card.focusable.focused") || null;
+    if (!current) {
+      return false;
+    }
+    const videoId = String(current.dataset.videoId || "").trim();
+    const currentIndex = Number(current.dataset.episodeIndex || this.getEpisodeIndexByVideoId(videoId));
+    if (!Number.isFinite(currentIndex) || currentIndex < 0) {
+      return false;
+    }
+    const nextIndex = currentIndex + (direction === "left" ? -1 : 1);
+    return this.focusEpisodeByIndex(nextIndex, { preserveVerticalScroll: true });
+  },
+
+  startEpisodeHoldRepeat(direction, node) {
+    if (direction !== "left" && direction !== "right") {
+      return false;
+    }
+    const videoId = String(node?.dataset?.videoId || "").trim();
+    if (!videoId) {
+      return false;
+    }
+    const now = Date.now();
+    this.stopEpisodeHoldRepeat();
+    this.episodeHoldRepeatDirection = direction;
+    this.episodeHoldRepeatStartedAt = now;
+    this.episodeHoldRepeatStepCount = 0;
+    this.episodeHoldRepeatTargetVideoId = videoId;
+    const tick = () => {
+      if (!this.episodeHoldRepeatDirection) {
+        return;
+      }
+      const current = this.container?.querySelector(".series-episode-card.focusable.focused") || null;
+      if (!current) {
+        this.stopEpisodeHoldRepeat();
+        return;
+      }
+      if (!current.matches?.(".series-episode-card")) {
+        this.stopEpisodeHoldRepeat();
+        return;
+      }
+      const elapsedMs = Date.now() - this.episodeHoldRepeatStartedAt;
+      const stepSize = this.getEpisodeRepeatStepSize(this.episodeHoldRepeatStepCount, elapsedMs);
+      const moveCount = Math.max(1, stepSize);
+      this.episodeHoldRepeatStepCount += 1;
+      const step = this.episodeHoldRepeatDirection === "left" ? -moveCount : moveCount;
+      const didMove = this.focusEpisodeByIndex((Number(current.dataset.episodeIndex || this.getEpisodeIndexByVideoId(String(current.dataset.videoId || this.episodeHoldRepeatTargetVideoId || ""))) || 0) + step, {
+        preserveVerticalScroll: true,
+        animated: false
+      });
+      if (!didMove) {
+        this.stopEpisodeHoldRepeat();
+        return;
+      }
+      const nextInterval = this.getEpisodeHoldRepeatInterval(this.episodeHoldRepeatStepCount, elapsedMs);
+      this.episodeHoldRepeatTimer = setTimeout(tick, nextInterval);
+    };
+    this.episodeHoldRepeatTimer = setTimeout(tick, EPISODE_HOLD_REPEAT_INITIAL_DELAY_MS);
+    return true;
   },
 
   cancelPendingEpisodeHold() {
@@ -6710,6 +6856,25 @@ export const MetaDetailsScreen = {
       return;
     }
 
+    const direction = getDpadDirection(event);
+    const isEpisodeDirectionKey = Boolean(direction) && isEpisodeHoldTarget && (direction === "left" || direction === "right");
+    if (isEpisodeDirectionKey) {
+      event?.preventDefault?.();
+      if (event?.repeat) {
+        if (this.episodeHoldRepeatDirection === direction) {
+          return;
+        }
+      } else {
+        this.stopEpisodeHoldRepeat();
+        if (this.moveEpisodeFocusWithAcceleration(direction)) {
+          this.startEpisodeHoldRepeat(direction, currentFocusedNode);
+          return;
+        }
+      }
+    } else if (this.episodeHoldRepeatDirection) {
+      this.stopEpisodeHoldRepeat();
+    }
+
     if (this.handleSeriesDpad(event)) {
       return;
     }
@@ -6957,6 +7122,10 @@ export const MetaDetailsScreen = {
   },
 
   async onKeyUp(event) {
+    const direction = getDpadDirection(event);
+    if (direction === "left" || direction === "right") {
+      this.stopEpisodeHoldRepeat();
+    }
     if (Number(event?.keyCode || 0) !== 13) {
       return;
     }
@@ -6999,6 +7168,8 @@ export const MetaDetailsScreen = {
       cancelAnimationFrame(this.episodeVirtualSyncRaf);
       this.episodeVirtualSyncRaf = null;
     }
+    this.stopEpisodeHoldRepeat();
+    this.episodeThumbnailPrefetchCache = new Set();
     if (this.episodeTrackScrollNode && this.episodeTrackScrollHandler) {
       this.episodeTrackScrollNode.removeEventListener("scroll", this.episodeTrackScrollHandler);
     }

--- a/js/ui/screens/detail/metaDetailsScreen.js
+++ b/js/ui/screens/detail/metaDetailsScreen.js
@@ -1895,7 +1895,8 @@ export const MetaDetailsScreen = {
       resumeDurationMs: routeStartFromBeginning ? 0 : (Number(this.params?.resumeDurationMs || this.resumeProgress?.durationMs || 0) || 0),
       startFromBeginning: routeStartFromBeginning,
       returnToDetail: true,
-      continueWatchingBackHome: true
+      continueWatchingBackHome: true,
+      resumeStreamIdentity: this.params?.resumeStreamIdentity || null
     };
     if (isSeriesDetailMeta(this.meta, this.episodes)) {
       const episode = this.findContinueWatchingEpisodeTarget();

--- a/js/ui/screens/detail/metaDetailsScreen.js
+++ b/js/ui/screens/detail/metaDetailsScreen.js
@@ -222,6 +222,11 @@ function resolvePlayableDetailType(itemType, meta = {}) {
   if (normalizedType === "series") {
     return "series";
   }
+  // Preserve live/channel types so stream requests hit the addon's registered
+  // stream endpoint (e.g. /stream/channel/{id}.json) instead of movie.
+  if (["channel", "live", "tvchannel"].includes(normalizedType)) {
+    return normalizedType;
+  }
   return "movie";
 }
 

--- a/js/ui/screens/home/homeScreen.js
+++ b/js/ui/screens/home/homeScreen.js
@@ -1843,6 +1843,7 @@ function continueWatchingStreamParams(item, options = {}) {
     resumePositionMs: options.startOver ? 0 : (Number(normalized.positionMs || 0) || 0),
     resumeProgressPercent: options.startOver ? null : (normalized.progressPercent ?? null),
     resumeDurationMs: options.startOver ? 0 : (Number(normalized.durationMs || 0) || 0),
+    resumeStreamIdentity: options.startOver ? null : (normalized.streamIdentity || null),
     startFromBeginning: Boolean(options.startOver)
   };
 }
@@ -4098,7 +4099,8 @@ export const HomeScreen = {
       startFromBeginning: Boolean(params.startFromBeginning),
       resumeVideoId: normalized.videoId || null,
       resumeSeason: normalized.season ?? null,
-      resumeEpisode: normalized.episode ?? null
+      resumeEpisode: normalized.episode ?? null,
+      resumeStreamIdentity: params.resumeStreamIdentity || null
     });
     return true;
   },
@@ -7060,7 +7062,14 @@ export const HomeScreen = {
       ? (this.pendingCollectionRouteReturnAnimation ? " nuvio-route-slide-enter" : " home-route-content-enter")
       : "";
     this.pendingCollectionRouteReturnAnimation = false;
-    const sidebarFocusLocked = Boolean(this.sidebarExpanded);
+    // On Back, only keep the sidebar expanded if the restored focus actually
+    // belonged to the sidebar.
+    if (this.isRestoringFocusFromBack && retainedFocusState?.focusKind !== "sidebar") {
+      this.sidebarExpanded = false;
+    }
+    const sidebarFocusLocked = Boolean(
+      this.sidebarExpanded && retainedFocusState?.focusKind === "sidebar"
+    );
 
     this.container.innerHTML = `
       <div class="home-shell home-screen-shell ${layoutClass}"${sizingStyle ? ` style="${escapeAttribute(sizingStyle)}"` : ""}>
@@ -7945,7 +7954,7 @@ export const HomeScreen = {
       if (!rowKey || this._trackScrollHandlers.has(track)) {
         return;
       }
-      const handler = () => {
+      const runPagination = () => {
         if (this._trackPaginationInFlight?.has(rowKey)) {
           return;
         }
@@ -8033,6 +8042,16 @@ export const HomeScreen = {
           console.warn("Home track pagination failed for", rowKey, err);
         }).finally(() => {
           this._trackPaginationInFlight?.delete(rowKey);
+        });
+      };
+      let scrollRaf = 0;
+      const handler = () => {
+        if (scrollRaf) {
+          return;
+        }
+        scrollRaf = requestAnimationFrame(() => {
+          scrollRaf = 0;
+          runPagination();
         });
       };
       this._trackScrollHandlers.set(track, handler);

--- a/js/ui/screens/player/playerScreen.js
+++ b/js/ui/screens/player/playerScreen.js
@@ -1933,7 +1933,8 @@ export const PlayerScreen = {
       background: this.params.playerBackdropUrl || this.params.backdrop || this.params.poster || null,
       episodeTitle: this.params.episodeTitle || this.params.playerSubtitle || null,
       requestHeaders,
-      mediaSourceType
+      mediaSourceType,
+      streamIdentity: streamCandidate ? streamMergeKey(streamCandidate) || null : null
     };
   },
 

--- a/js/ui/screens/plugin/pluginScreen.js
+++ b/js/ui/screens/plugin/pluginScreen.js
@@ -1,5 +1,7 @@
 import { ScreenUtils } from "../../navigation/screen.js";
 import { Router } from "../../navigation/router.js";
+import { AuthManager } from "../../../core/auth/authManager.js";
+import { LibrarySyncService } from "../../../core/profile/librarySyncService.js";
 import { addonRepository } from "../../../data/repository/addonRepository.js";
 import { LayoutPreferences } from "../../../data/local/layoutPreferences.js";
 import { Platform } from "../../../platform/index.js";
@@ -53,6 +55,7 @@ export const PluginScreen = {
     this.contentRow = Number.isFinite(this.contentRow) ? this.contentRow : 0;
     this.contentCol = Number.isFinite(this.contentCol) ? this.contentCol : 0;
     this.qrOverlayOpen = false;
+    this.syncing = false;
     const [sidebarProfile, model] = await Promise.all([
       getSidebarProfileState(),
       this.collectModel()
@@ -60,14 +63,53 @@ export const PluginScreen = {
     this.sidebarProfile = sidebarProfile;
     this.model = model;
     await this.render({ refreshModel: false });
+    if (AuthManager.isAuthenticated) {
+      void this.refreshAddons();
+    }
   },
 
   async collectModel() {
     const addonUrls = addonRepository.getInstalledAddonUrls();
     return {
       addonCount: addonUrls.length,
+      authenticated: AuthManager.isAuthenticated,
+      syncStatus: LibrarySyncService.getLastPullStatus(),
       phoneManagerUrl: await getPhoneManagerUrl()
     };
+  },
+
+  buildSyncStatusText() {
+    if (this.syncing) {
+      return "Syncing addons...";
+    }
+    if (!this.model?.authenticated) {
+      return "Sign in on your phone to link addons.";
+    }
+    const status = this.model?.syncStatus || {};
+    if (status.state === "error") {
+      return "Couldn't reach the addon service. Check the TV internet connection and try Refresh.";
+    }
+    if (this.model?.addonCount > 0) {
+      return "Addons are up to date.";
+    }
+    return "No addons linked yet. Add them on your phone, then press Refresh.";
+  },
+
+  async refreshAddons() {
+    if (this.syncing) {
+      return;
+    }
+    this.syncing = true;
+    await this.render({ refreshModel: true });
+    try {
+      await LibrarySyncService.pull();
+    } catch (error) {
+      console.warn("Addon refresh failed", error);
+    }
+    this.syncing = false;
+    if (Router.getCurrent() === "plugin") {
+      await this.render({ refreshModel: true });
+    }
   },
 
   setRowColumns(row, cols) {
@@ -167,12 +209,16 @@ export const PluginScreen = {
     this.actionMap = new Map();
     this.setRowColumns(0, [0]);
     this.setRowColumns(1, [0]);
+    this.setRowColumns(2, [0]);
 
     this.actionMap.set("manage_from_phone", async () => {
       await this.openQrOverlay();
     });
     this.actionMap.set("reorder_home_catalogs", async () => {
       Router.navigate("catalogOrder");
+    });
+    this.actionMap.set("refresh_addons", async () => {
+      await this.refreshAddons();
     });
     this.actionMap.set("close_qr_overlay", async () => {
       await this.closeQrOverlay();
@@ -195,6 +241,7 @@ export const PluginScreen = {
                 Manage addons and home catalogs from your phone.
               </p>
               <p class="addons-meta">${escapeHtml(`${this.model.addonCount} addon${this.model.addonCount === 1 ? "" : "s"} currently linked`)}</p>
+              <p class="addons-sync-status">${escapeHtml(this.buildSyncStatusText())}</p>
               <div role="button"
                    class="addons-large-row addons-large-row-centered addons-focusable"
                    data-zone="content"
@@ -225,6 +272,23 @@ export const PluginScreen = {
                 </span>
                 <span class="addons-large-row-tail-group">
                   <span class="addons-large-row-tail material-icons" aria-hidden="true">chevron_right</span>
+                </span>
+              </div>
+              <div role="button"
+                   class="addons-large-row addons-large-row-centered addons-focusable"
+                   data-zone="content"
+                   data-row="2"
+                   data-col="0"
+                   data-action-id="refresh_addons"
+                   tabindex="-1"
+                   aria-disabled="${this.syncing ? "true" : "false"}">
+                <span class="addons-large-row-icon material-icons" aria-hidden="true">${this.syncing ? "hourglass_top" : "sync"}</span>
+                <span class="addons-large-row-copy">
+                  <strong>${this.syncing ? "Refreshing..." : "Refresh addons"}</strong>
+                  <small>Re-check your account for addons you enabled on your phone</small>
+                </span>
+                <span class="addons-large-row-tail-group">
+                  <span class="addons-large-row-tail material-icons" aria-hidden="true">refresh</span>
                 </span>
               </div>
             </section>

--- a/js/ui/screens/stream/streamScreen.js
+++ b/js/ui/screens/stream/streamScreen.js
@@ -1334,6 +1334,7 @@ export const StreamScreen = {
     this.addonLogoLookup = {};
     this.addonFilter = "all";
     this.hasRenderedStreamRouteShell = false;
+    this.autoResumeAttempted = false;
     if (this.releaseImageProxyReadyListener) {
       this.releaseImageProxyReadyListener();
       this.releaseImageProxyReadyListener = null;
@@ -1580,6 +1581,7 @@ export const StreamScreen = {
       }
       this.requestRender();
       this.scheduleErrorChipCleanup();
+      this.maybeAutoResumeStream();
     } catch (error) {
       if (token !== this.loadToken) {
         return;
@@ -1591,6 +1593,23 @@ export const StreamScreen = {
       ));
       this.requestRender();
       this.scheduleErrorChipCleanup();
+    }
+  },
+
+  // Continue Watching can pass the identity of the stream that was playing.
+  // If that same source shows up again, resume it directly.
+  maybeAutoResumeStream() {
+    if (this.autoResumeAttempted) {
+      return;
+    }
+    const identity = String(this.params?.resumeStreamIdentity || "").trim();
+    if (!identity || !this.streams.length) {
+      return;
+    }
+    this.autoResumeAttempted = true;
+    const match = this.streams.find((stream) => streamMergeKey(stream) === identity);
+    if (match?.id) {
+      void this.playStream(match.id);
     }
   },
 

--- a/js/ui/screens/stream/streamScreen.js
+++ b/js/ui/screens/stream/streamScreen.js
@@ -223,11 +223,10 @@ function flattenStreams(streamResult) {
         sourceType: stream.sourceType || stream.mimeType || stream.type || stream.source || "",
         raw: stream
       };
-      if (
-        DirectDebridResolver.shouldListStream(entry)
+      const canList = DirectDebridResolver.shouldListStream(entry)
         || WebOsEngineFsResolver.canResolveStream(entry)
-        || TizenStreamingServerResolver.canResolveStream(entry)
-      ) {
+        || TizenStreamingServerResolver.canResolveStream(entry);
+      if (canList) {
         flattened.push(entry);
       }
     });


### PR DESCRIPTION
Clean replacement for #234 after rebasing onto the latest `main` and porting only the behavioral fixes.

## What's included
- #230: addon sync status tracking on TV, auto re-pull on the Addons screen, and a Refresh action
- #231: Tizen subtitle selection fix by selecting the AVPlay subtitle track before unmuting
- #232: modern home scroll pagination throttling, sidebar back-focus fix, and Continue Watching resuming the same stream when possible
- #233: webOS relaunch recovery for resident apps, including `webOSLaunch` / visibility fallbacks and explicit `PalmSystem.activate()` / `webOSSystem.activate()` after relaunch handling
- Detail page episode performance: virtualized large episode rails and accelerated long-press navigation for massive seasons (example One piece with 1100+ episodes in one season would be loaded all at once before which caused massive freezes)

## Scope note
- I checked the issue history for app re-open failures and found only webOS reports: #233 and the older closed #144.
- I did not find a matching Tizen reopen issue, so the relaunch-specific changes in this PR stay scoped to webOS.

## Verification
- `npm run build`

Closes #230
Closes #231
Closes #232
Closes #233