### PR TITLE
fix(discover): addons with optional search are missing from Discovery

### DIFF
--- a/js/ui/screens/search/discoverScreen.js
+++ b/js/ui/screens/search/discoverScreen.js
@@ -337,7 +337,10 @@ export const DiscoverScreen = {
     this.catalogs = [];
     addons.forEach((addon) => {
       addon.catalogs.forEach((catalog) => {
-        const isSearchOnly = (catalog.extra || []).some((extra) => extra?.name === "search");
+        // Only skip catalogs that REQUIRE a search query (truly search-only).
+        // Catalogs that merely support optional search are still browsable and
+        // belong in Discover (e.g. some addons declare an optional search extra).
+        const isSearchOnly = (catalog.extra || []).some((extra) => extra?.name === "search" && Boolean(extra?.isRequired));
         if (isSearchOnly) return;
         const type = String(catalog.apiType || "").trim();
         if (!type) return;


### PR DESCRIPTION
Fixes #212

The Discover screen skipped any catalog that declared a `search` extra at all, regardless of whether search is required. Lots of addons (e.g. NexoTV) declare an *optional* search extra on a catalog that's otherwise fully browsable - those catalogs were being dropped from Discovery entirely, so the addon never showed up there.

Changed the check to only skip catalogs where search is actually required (truly search-only). Catalogs that merely support optional search are browsable and now appear in Discovery, the same way the home screen already treats them. Search-required catalogs are still excluded.

Verified the predicate against catalog shapes: optional-search and genre catalogs are now included, search-required stays excluded - the old code wrongly excluded the optional-search one.