### PR TITLE
fix(runtime): app still crashes at bootstrap on old webOS (Number.isFinite / Math.trunc not a function)

### DIFF
--- a/js/runtime/polyfills.js
+++ b/js/runtime/polyfills.js
@@ -8,6 +8,53 @@
   delete Object.prototype.__magic__;
 }());
 
+// Number/Math ES2015 statics missing on older TV engines. Defined first because
+// other polyfills below (e.g. Array.prototype.flat) rely on Number.isFinite,
+// and the profile store touches Number.isFinite / Math.trunc during bootstrap.
+if (typeof Number.isNaN !== "function") {
+  Number.isNaN = function isNaN(value) {
+    return typeof value === "number" && value !== value;
+  };
+}
+
+if (typeof Number.isFinite !== "function") {
+  Number.isFinite = function isFinite(value) {
+    return typeof value === "number" && globalThis.isFinite(value);
+  };
+}
+
+if (typeof Number.isInteger !== "function") {
+  Number.isInteger = function isInteger(value) {
+    return typeof value === "number" && globalThis.isFinite(value) && Math.floor(value) === value;
+  };
+}
+
+if (typeof Number.parseInt !== "function") {
+  Number.parseInt = globalThis.parseInt;
+}
+
+if (typeof Number.parseFloat !== "function") {
+  Number.parseFloat = globalThis.parseFloat;
+}
+
+if (typeof Number.MAX_SAFE_INTEGER !== "number") {
+  Number.MAX_SAFE_INTEGER = 9007199254740991;
+}
+
+if (typeof Number.MIN_SAFE_INTEGER !== "number") {
+  Number.MIN_SAFE_INTEGER = -9007199254740991;
+}
+
+if (typeof Math.trunc !== "function") {
+  Math.trunc = function trunc(value) {
+    var number = Number(value);
+    if (Number.isNaN(number) || number === 0) {
+      return number;
+    }
+    return number < 0 ? Math.ceil(number) : Math.floor(number);
+  };
+}
+
 // ES2015-2017 builtins missing on older TV engines (webOS 3/4 ship Chromium
 // 38/53). The bundle is transpiled for syntax down to "chrome 38", but builtin
 // APIs are only available through this file, and Object.entries & friends were


### PR DESCRIPTION
Fixes #245 (continuation of #195 / PR #200)

PR #200 added a good set of builtin polyfills but missed the Number and Math ES2015 statics. On the LG MT49S (webOS 6.10.60) those are still undefined, so the app crashes at bootstrap with "TypeError: undefined is not a function" in the profile store path - profileManager uses Number.isFinite and Math.trunc while reading the profile, which runs before the UI renders.

Added polyfills for the ones the codebase actually uses: Number.isFinite (53 files), Number.isInteger, Number.isNaN, Number.parseInt, Number.parseFloat, Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER and Math.trunc (24 files). They're defined first in polyfills.js because the existing Array.prototype.flat polyfill itself calls Number.isFinite.

Tested by removing those statics before the bundle loads to mimic the old engine: on main the app dies with 'App bootstrap failed: Number.isFinite is not a function' and renders nothing (matching the report); with this change the polyfills restore them and the app boots to the profile screen. Math.trunc verified against positive/negative/zero/NaN cases.