### PR TITLE
feat(stream): show full stream info on cards to match Android TV

### DIFF
--- a/js/ui/screens/stream/streamScreen.js
+++ b/js/ui/screens/stream/streamScreen.js
@@ -785,11 +785,18 @@ function isMetaNoiseLine(line = "") {
 }
 
 function getStreamDescriptionLines(stream = {}) {
+  const descriptionText = String(stream.description || "");
+  const filename = String(stream.behaviorHints?.filename || "").trim();
+  // Only surface the filename as its own line when the description does not
+  // already include it, otherwise it shows up twice.
+  const extraFilename = filename && !descriptionText.toLowerCase().includes(filename.toLowerCase())
+    ? filename
+    : "";
   const candidates = [
     stream.name,
     stream.description,
     stream.title,
-    stream.behaviorHints?.filename
+    extraFilename
   ].reduce((items, value) => {
     String(value || "").split(/\r?\n/).forEach((line) => {
       const normalized = String(line || "").trim();
@@ -812,7 +819,12 @@ function getStreamDescriptionLines(stream = {}) {
       const normalized = entry.toLowerCase();
       return normalized !== headline && normalized !== quality && !isMetaNoiseLine(entry);
     })
-    .slice(0, 2);
+    // Show the full set of description lines (codec, audio, scraper, filename,
+    // bitrate, ...) like the Android TV app does, instead of trimming to 2.
+    // The headline/quality/noise lines are already filtered out above so this
+    // only adds the remaining useful detail. A high cap guards against an addon
+    // returning a pathologically long description.
+    .slice(0, 12);
 }
 
 function normalizeBadgeText(value = "") {


### PR DESCRIPTION
Relates to #250

On the stream picker, the web app trimmed each addon's description down to 2 lines. AIOStreams (and similar addons) pack the useful detail into that description, the audio codec, video codec, scraper, filename and bitrate, so most of it never showed up. People had no easy way to tell results apart, the filename especially.

The Android TV app shows the whole description on the card with no line limit. This lines the web version up with it: it now shows all the meaningful description lines instead of just 2. The headline, quality and noise lines are still filtered out so nothing is duplicated, and the filename is no longer shown twice when the description already contains it. A high cap is kept as a guard against an addon sending a huge description.

Tested in the browser with an AIOStreams style multi line description plus a filename in behaviorHints:
- before: only 2 lines, filename hidden
- after: all lines show including the filename, shown once
- also checked the case where the filename is only in behaviorHints and not in the description, it still shows

Note: this makes cards a bit taller, which ties into the other half of #250 about card sizing on big screens. Happy to follow up with the sizing side too.