### PR TITLE
fix(stream): stream list scaling/scroll broken on older webOS

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -15633,6 +15633,69 @@ button:focus-visible {
   transform: none !important;
 }
 
+/* webOS 6 and older report as legacy but were missing the fixed stream-screen
+   layout that legacy Tizen already has. Without it the panel relies on flexbox
+   min-height:0 / vh sizing, which these older engines do not bound reliably, so
+   the stream list never gets a scrollable height (only the first few results are
+   reachable) and the cards scale inconsistently. Mirror the legacy Tizen sizing
+   (both render at 1920x1080) so the list scrolls and the layout is consistent. */
+.legacy-webos .stream-route-shell {
+  width: 1920px;
+  height: 1080px;
+}
+
+.legacy-webos .stream-route-content {
+  display: -webkit-box;
+  display: flex;
+  padding: 56px 64px;
+}
+
+.legacy-webos .stream-route-left {
+  width: 560px;
+  flex: 0 0 560px;
+  padding-right: 44px;
+}
+
+.legacy-webos .stream-route-left-inner {
+  width: 420px;
+  max-width: 420px;
+}
+
+.legacy-webos .stream-route-logo {
+  width: 420px;
+  max-width: 420px;
+  max-height: 150px;
+}
+
+.legacy-webos .stream-route-right {
+  width: 1232px;
+  flex: 0 0 1232px;
+  max-width: 1232px;
+  height: 968px;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.legacy-webos .stream-route-chip-wrap {
+  height: 78px;
+  margin-bottom: 20px;
+}
+
+.legacy-webos .stream-route-panel-shell {
+  border-radius: 18px;
+  height: 870px;
+  min-height: 0;
+  overflow: hidden;
+  -webkit-box-flex: 1;
+}
+
+.legacy-webos .stream-route-list {
+  height: 100%;
+  max-height: 100%;
+  min-height: 0;
+  overflow-y: auto;
+}
+
 .legacy-tizen .stream-route-shell {
   width: 1920px;
   height: 1080px;


### PR DESCRIPTION
Relates to #250, #241

On older LG webOS TVs (the app flags webOS major <= 6 as legacy) the stream picker is scaled wrong and the list will not scroll, so only the first few results are reachable, which reads as 'only 4 results'.

Cause: legacy Tizen has a full fixed stream-screen layout (fixed shell, panes, a bounded panel height and a list with overflow-y auto), but legacy webOS never got the same treatment. It only had a couple of transform overrides and otherwise fell back to the default layout, which sizes the panel/list with flexbox min-height:0 and vh. Those older webOS engines do not bound that reliably, so the list gets no scrollable height and the cards scale inconsistently.

This mirrors the legacy Tizen sizing for legacy webOS (both render at 1920x1080). It is scoped to .legacy-webos only, so it has no effect on any other device.

What I verified: forcing the legacy-webos class in a browser, the stream list now becomes a bounded, scrollable container (clientHeight 826, scrollHeight 2784, overflow-y auto) with the panel at its fixed 870px height, and all cards render. 

Honest caveat: I do not have an old webOS TV, so I could not confirm the final rendering on the actual device. The values are copied from the legacy Tizen layout that already works, and the change only touches the currently-broken legacy-webos path, so it should not regress anything. Worth a quick check on a real webOS 6 TV before merging, and the pixel values can be tuned if needed.