### PR TITLE
Add auto stream selection

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -14987,6 +14987,56 @@ button:focus-visible {
   color: var(--text-color);
 }
 
+.stream-route-autoplay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  padding-bottom: 64px;
+  pointer-events: none;
+  z-index: 30;
+}
+
+.stream-route-autoplay-card {
+  min-width: 520px;
+  max-width: 70%;
+  padding: 24px 36px;
+  border-radius: 18px;
+  background: rgb(var(--card-bg-rgb) / 0.96);
+  border: 1px solid var(--secondary-color);
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.45);
+  text-align: center;
+}
+
+.stream-route-autoplay-title {
+  font-size: 20px;
+  color: var(--text-secondary);
+  margin-bottom: 6px;
+}
+
+.stream-route-autoplay-name {
+  font-size: 26px;
+  font-weight: 600;
+  color: var(--text-color);
+  margin-bottom: 12px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.stream-route-autoplay-count {
+  font-size: 30px;
+  font-weight: 700;
+  color: var(--secondary-color);
+  margin-bottom: 10px;
+}
+
+.stream-route-autoplay-hint {
+  font-size: 18px;
+  color: var(--text-secondary);
+}
+
 .stream-route-backdrop,
 .stream-route-backdrop-dim,
 .stream-route-left-gradient,

--- a/js/core/profile/profileSettingsSyncService.js
+++ b/js/core/profile/profileSettingsSyncService.js
@@ -864,7 +864,14 @@ const FEATURE_ADAPTERS = {
         ),
         persist_audio_amplification: Boolean(settings.persistAudioAmplification),
         skip_intro_enabled: Boolean(settings.skipIntroEnabled),
-        stream_auto_play_next_episode_enabled: Boolean(settings.autoplayNextEpisode)
+        stream_auto_play_next_episode_enabled: Boolean(settings.autoplayNextEpisode),
+        stream_auto_play_mode: String(settings.streamAutoPlayMode || "MANUAL"),
+        stream_auto_play_source: String(settings.streamAutoPlaySource || "ALL_SOURCES"),
+        stream_auto_play_regex: String(settings.streamAutoPlayRegex || ""),
+        stream_auto_play_timeout_seconds: Math.max(
+          0,
+          Math.trunc(Number(settings.streamAutoPlayTimeoutSeconds ?? 3) || 0)
+        )
       };
     },
     project(rawFeature = {}) {
@@ -910,6 +917,21 @@ const FEATURE_ADAPTERS = {
           projected[key] = Math.trunc(Number(raw[key]));
         }
       });
+      [
+        "stream_auto_play_mode",
+        "stream_auto_play_source",
+        "stream_auto_play_regex"
+      ].forEach((key) => {
+        if (raw[key] != null) {
+          projected[key] = String(raw[key]);
+        }
+      });
+      if (numberOrNull(raw.stream_auto_play_timeout_seconds) != null) {
+        projected.stream_auto_play_timeout_seconds = Math.max(
+          0,
+          Math.trunc(Number(raw.stream_auto_play_timeout_seconds))
+        );
+      }
       return projected;
     },
     import(profileId, rawFeature = {}) {
@@ -984,6 +1006,18 @@ const FEATURE_ADAPTERS = {
       }
       if (booleanOrNull(raw.stream_auto_play_next_episode_enabled) != null) {
         partial.autoplayNextEpisode = Boolean(raw.stream_auto_play_next_episode_enabled);
+      }
+      if (raw.stream_auto_play_mode != null) {
+        partial.streamAutoPlayMode = String(raw.stream_auto_play_mode);
+      }
+      if (raw.stream_auto_play_source != null) {
+        partial.streamAutoPlaySource = String(raw.stream_auto_play_source);
+      }
+      if (raw.stream_auto_play_regex != null) {
+        partial.streamAutoPlayRegex = String(raw.stream_auto_play_regex);
+      }
+      if (numberOrNull(raw.stream_auto_play_timeout_seconds) != null) {
+        partial.streamAutoPlayTimeoutSeconds = Math.max(0, Math.trunc(Number(raw.stream_auto_play_timeout_seconds)));
       }
       if (Object.keys(subtitleStyle).length) {
         partial.subtitleStyle = subtitleStyle;

--- a/js/core/streams/streamAutoPlaySelector.js
+++ b/js/core/streams/streamAutoPlaySelector.js
@@ -1,0 +1,154 @@
+// Auto stream selection, ported from the Android TV app's StreamAutoPlaySelector
+// and StreamAutoPlayPolicy so the two clients behave the same. Given the list of
+// streams shown in the picker and the user's auto-play settings, it returns the
+// stream that should play automatically, or null to leave the picker open.
+
+export const STREAM_AUTO_PLAY_MODE = {
+  MANUAL: "MANUAL",
+  FIRST_STREAM: "FIRST_STREAM",
+  REGEX_MATCH: "REGEX_MATCH"
+};
+
+export const STREAM_AUTO_PLAY_SOURCE = {
+  ALL_SOURCES: "ALL_SOURCES",
+  INSTALLED_ADDONS_ONLY: "INSTALLED_ADDONS_ONLY",
+  ENABLED_PLUGINS_ONLY: "ENABLED_PLUGINS_ONLY"
+};
+
+function normalizeMode(value) {
+  const mode = String(value || "").trim().toUpperCase();
+  return STREAM_AUTO_PLAY_MODE[mode] ? mode : STREAM_AUTO_PLAY_MODE.MANUAL;
+}
+
+function normalizeSource(value) {
+  const source = String(value || "").trim().toUpperCase();
+  return STREAM_AUTO_PLAY_SOURCE[source] ? source : STREAM_AUTO_PLAY_SOURCE.ALL_SOURCES;
+}
+
+export function isRegexSelectionConfigured(regexPattern) {
+  const pattern = String(regexPattern || "").trim();
+  if (!pattern || !/[a-z0-9]/i.test(pattern)) {
+    return false;
+  }
+  try {
+    // eslint-disable-next-line no-new
+    new RegExp(pattern, "i");
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+// Whether auto-play is active for these settings. Default mode MANUAL is off, so
+// existing users see no change unless they opt in (or sync it from Android TV).
+export function isAutoPlayEffectivelyEnabled(settings = {}) {
+  const mode = normalizeMode(settings.streamAutoPlayMode);
+  if (mode === STREAM_AUTO_PLAY_MODE.FIRST_STREAM) {
+    return true;
+  }
+  if (mode === STREAM_AUTO_PLAY_MODE.REGEX_MATCH) {
+    return isRegexSelectionConfigured(settings.streamAutoPlayRegex);
+  }
+  return false;
+}
+
+// A stream is auto-playable when it can actually start playback. External-url
+// only entries (e.g. an addon's "open this website" cast link) are skipped so
+// auto-play never lands on a non-video page.
+function isPlayableStream(stream = {}) {
+  return Boolean(stream && (stream.url || stream.ytId || stream.infoHash));
+}
+
+function streamSearchableText(stream = {}) {
+  const parts = [
+    stream.addonName,
+    stream.name,
+    stream.title,
+    stream.description,
+    stream.url
+  ];
+  if (stream.infoHash) {
+    parts.push(stream.infoHash);
+  }
+  return parts.map((part) => String(part || "")).join(" ");
+}
+
+function scopeStreamsBySource(streams, source, installedAddonNames) {
+  const installed = installedAddonNames instanceof Set
+    ? installedAddonNames
+    : new Set(Array.isArray(installedAddonNames) ? installedAddonNames : []);
+  if (source === STREAM_AUTO_PLAY_SOURCE.INSTALLED_ADDONS_ONLY) {
+    return streams.filter((stream) => installed.has(String(stream.addonName || "")));
+  }
+  if (source === STREAM_AUTO_PLAY_SOURCE.ENABLED_PLUGINS_ONLY) {
+    return streams.filter((stream) => !installed.has(String(stream.addonName || "")));
+  }
+  return streams;
+}
+
+// Extract excluded words from negative lookaheads like (?!.*(CAM|TS)) so a
+// pattern can both include and exclude, matching the Android TV behaviour.
+function buildExcludeRegex(pattern) {
+  const matches = String(pattern || "").match(/\(\?![^)]*?\(([^)]+)\)/g) || [];
+  const words = matches
+    .map((match) => {
+      const inner = /\(\?![^)]*?\(([^)]+)\)/.exec(match);
+      return inner ? inner[1] : "";
+    })
+    .join("|")
+    .split("|")
+    .map((word) => word.trim())
+    .filter(Boolean);
+  if (!words.length) {
+    return null;
+  }
+  try {
+    return new RegExp(`\\b(${words.join("|")})\\b`, "i");
+  } catch (_) {
+    return null;
+  }
+}
+
+export function selectAutoPlayStream(streams, options = {}) {
+  const list = Array.isArray(streams) ? streams.filter(Boolean) : [];
+  if (!list.length) {
+    return null;
+  }
+  const mode = normalizeMode(options.mode);
+  if (mode === STREAM_AUTO_PLAY_MODE.MANUAL) {
+    return null;
+  }
+  const source = normalizeSource(options.source);
+  const candidates = scopeStreamsBySource(list, source, options.installedAddonNames);
+  if (!candidates.length) {
+    return null;
+  }
+
+  if (mode === STREAM_AUTO_PLAY_MODE.FIRST_STREAM) {
+    return candidates.find((stream) => isPlayableStream(stream)) || null;
+  }
+
+  // REGEX_MATCH
+  const pattern = String(options.regexPattern || "").trim();
+  let includeRegex;
+  try {
+    includeRegex = new RegExp(pattern, "i");
+  } catch (_) {
+    return null;
+  }
+  const excludeRegex = buildExcludeRegex(pattern);
+  const match = candidates.find((stream) => {
+    if (!isPlayableStream(stream)) {
+      return false;
+    }
+    const text = streamSearchableText(stream);
+    if (!includeRegex.test(text)) {
+      return false;
+    }
+    if (excludeRegex && excludeRegex.test(text)) {
+      return false;
+    }
+    return true;
+  });
+  return match || null;
+}

--- a/js/data/local/playerSettingsStore.js
+++ b/js/data/local/playerSettingsStore.js
@@ -24,8 +24,35 @@ const DEFAULTS = {
     useForcedSubtitles: false
   },
   audioAmplificationDb: 0,
-  persistAudioAmplification: false
+  persistAudioAmplification: false,
+  // Auto stream selection (matches the Android TV app). When the mode is not
+  // MANUAL, pressing play auto-selects a stream and plays it after a countdown.
+  streamAutoPlayMode: "MANUAL",
+  streamAutoPlaySource: "ALL_SOURCES",
+  streamAutoPlayRegex: "",
+  streamAutoPlayTimeoutSeconds: 3
 };
+
+const STREAM_AUTO_PLAY_MODES = ["MANUAL", "FIRST_STREAM", "REGEX_MATCH"];
+const STREAM_AUTO_PLAY_SOURCES = ["ALL_SOURCES", "INSTALLED_ADDONS_ONLY", "ENABLED_PLUGINS_ONLY"];
+
+function normalizeStreamAutoPlayMode(value) {
+  const normalized = String(value || "").trim().toUpperCase();
+  return STREAM_AUTO_PLAY_MODES.includes(normalized) ? normalized : "MANUAL";
+}
+
+function normalizeStreamAutoPlaySource(value) {
+  const normalized = String(value || "").trim().toUpperCase();
+  return STREAM_AUTO_PLAY_SOURCES.includes(normalized) ? normalized : "ALL_SOURCES";
+}
+
+function normalizeStreamAutoPlayTimeout(value) {
+  const seconds = Math.trunc(Number(value));
+  if (!Number.isFinite(seconds) || seconds < 0) {
+    return DEFAULTS.streamAutoPlayTimeoutSeconds;
+  }
+  return Math.min(60, seconds);
+}
 
 function extractLanguageCode(value, fallback = "off") {
   if (value && typeof value === "object") {
@@ -102,6 +129,10 @@ function normalizePlayerSettings(settings = {}) {
   return {
     ...DEFAULTS,
     ...settings,
+    streamAutoPlayMode: normalizeStreamAutoPlayMode(settings.streamAutoPlayMode ?? DEFAULTS.streamAutoPlayMode),
+    streamAutoPlaySource: normalizeStreamAutoPlaySource(settings.streamAutoPlaySource ?? DEFAULTS.streamAutoPlaySource),
+    streamAutoPlayRegex: String(settings.streamAutoPlayRegex ?? "").slice(0, 500),
+    streamAutoPlayTimeoutSeconds: normalizeStreamAutoPlayTimeout(settings.streamAutoPlayTimeoutSeconds),
     subtitlesEnabled,
     subtitleLanguage: preferredLanguage,
     secondarySubtitleLanguage: secondaryPreferredLanguage,

--- a/js/ui/screens/settings/settingsScreen.js
+++ b/js/ui/screens/settings/settingsScreen.js
@@ -262,6 +262,31 @@ const PREFERRED_PLAYBACK_LANGUAGE_OPTIONS = [
   ...AVAILABLE_LANGUAGES
 ];
 
+const STREAM_AUTOPLAY_MODE_OPTIONS = [
+  { id: "MANUAL", label: "Off (choose manually)" },
+  { id: "FIRST_STREAM", label: "First stream" },
+  { id: "REGEX_MATCH", label: "Regex match" }
+];
+
+const STREAM_AUTOPLAY_SOURCE_OPTIONS = [
+  { id: "ALL_SOURCES", label: "All sources" },
+  { id: "INSTALLED_ADDONS_ONLY", label: "Installed addons only" },
+  { id: "ENABLED_PLUGINS_ONLY", label: "Plugins only" }
+];
+
+const STREAM_AUTOPLAY_TIMEOUT_OPTIONS = [
+  { id: 0, label: "Instant" },
+  { id: 3, label: "3 seconds" },
+  { id: 5, label: "5 seconds" },
+  { id: 10, label: "10 seconds" },
+  { id: 15, label: "15 seconds" }
+];
+
+function labelForOptionId(options, id, fallback) {
+  const match = options.find((option) => String(option.id) === String(id));
+  return match ? match.label : fallback;
+}
+
 const TMDB_LANGUAGE_OPTIONS = [
   { id: "en-US", label: "English" },
   { id: "en-AU", label: "English (Australia)" },
@@ -3828,6 +3853,50 @@ export const SettingsScreen = {
     this.actionMap.set("playback:skipIntro", () => {
       PlayerSettingsStore.set({ skipIntroEnabled: !PlayerSettingsStore.get().skipIntroEnabled });
     });
+    this.actionMap.set("playback:autoStreamMode", () => {
+      this.openOptionDialog({
+        title: t("settings.playback.autoStream.title", {}, "Auto Stream Selection"),
+        options: STREAM_AUTOPLAY_MODE_OPTIONS,
+        selectedId: PlayerSettingsStore.get().streamAutoPlayMode,
+        returnFocusKey: "playback:autoStreamMode",
+        onSelect: (option) => {
+          PlayerSettingsStore.set({ streamAutoPlayMode: option.id });
+        }
+      });
+    });
+    this.actionMap.set("playback:autoStreamTimeout", () => {
+      this.openOptionDialog({
+        title: t("settings.playback.autoStreamTimeout.title", {}, "Auto-play countdown"),
+        options: STREAM_AUTOPLAY_TIMEOUT_OPTIONS,
+        selectedId: PlayerSettingsStore.get().streamAutoPlayTimeoutSeconds,
+        returnFocusKey: "playback:autoStreamTimeout",
+        onSelect: (option) => {
+          PlayerSettingsStore.set({ streamAutoPlayTimeoutSeconds: Number(option.id) });
+        }
+      });
+    });
+    this.actionMap.set("playback:autoStreamSource", () => {
+      this.openOptionDialog({
+        title: t("settings.playback.autoStreamSource.title", {}, "Auto-play source"),
+        options: STREAM_AUTOPLAY_SOURCE_OPTIONS,
+        selectedId: PlayerSettingsStore.get().streamAutoPlaySource,
+        returnFocusKey: "playback:autoStreamSource",
+        onSelect: (option) => {
+          PlayerSettingsStore.set({ streamAutoPlaySource: option.id });
+        }
+      });
+    });
+    this.actionMap.set("playback:autoStreamRegex", () => {
+      this.openTextDialog({
+        title: t("settings.playback.autoStreamRegex.title", {}, "Auto-play regex"),
+        value: PlayerSettingsStore.get().streamAutoPlayRegex || "",
+        returnFocusKey: "playback:autoStreamRegex",
+        onSubmit: (value) => {
+          PlayerSettingsStore.set({ streamAutoPlayRegex: String(value || "").trim() });
+          return true;
+        }
+      });
+    });
     this.actionMap.set("playback:audioLanguage", () => {
       this.openOptionDialog({
         title: t("settings.dialogs.preferredAudioLanguage"),
@@ -3933,6 +4002,32 @@ export const SettingsScreen = {
           ),
           checked: Boolean(model.player.skipIntroEnabled)
         })}
+        ${this.renderActionRow({
+          focusKey: "playback:autoStreamMode",
+          title: t("settings.playback.autoStream.title", {}, "Auto Stream Selection"),
+          subtitle: t("settings.playback.autoStream.subtitle", {}, "Automatically play a stream when you press play"),
+          value: labelForOptionId(STREAM_AUTOPLAY_MODE_OPTIONS, model.player.streamAutoPlayMode, "Off (choose manually)")
+        })}
+        ${String(model.player.streamAutoPlayMode || "MANUAL") !== "MANUAL" ? `
+        ${this.renderActionRow({
+          focusKey: "playback:autoStreamTimeout",
+          title: t("settings.playback.autoStreamTimeout.title", {}, "Auto-play countdown"),
+          subtitle: t("settings.playback.autoStreamTimeout.subtitle", {}, "How long to wait before playing the selected stream"),
+          value: labelForOptionId(STREAM_AUTOPLAY_TIMEOUT_OPTIONS, model.player.streamAutoPlayTimeoutSeconds, `${model.player.streamAutoPlayTimeoutSeconds}s`)
+        })}
+        ${this.renderActionRow({
+          focusKey: "playback:autoStreamSource",
+          title: t("settings.playback.autoStreamSource.title", {}, "Auto-play source"),
+          subtitle: t("settings.playback.autoStreamSource.subtitle", {}, "Which sources auto-play can pick from"),
+          value: labelForOptionId(STREAM_AUTOPLAY_SOURCE_OPTIONS, model.player.streamAutoPlaySource, "All sources")
+        })}` : ""}
+        ${String(model.player.streamAutoPlayMode || "MANUAL") === "REGEX_MATCH" ? `
+        ${this.renderActionRow({
+          focusKey: "playback:autoStreamRegex",
+          title: t("settings.playback.autoStreamRegex.title", {}, "Auto-play regex"),
+          subtitle: t("settings.playback.autoStreamRegex.subtitle", {}, "Play the first stream whose details match this pattern"),
+          value: String(model.player.streamAutoPlayRegex || "").trim() || t("common.notSet", {}, "Not set")
+        })}` : ""}
       </div>
     `;
 

--- a/js/ui/screens/stream/streamScreen.js
+++ b/js/ui/screens/stream/streamScreen.js
@@ -1,7 +1,13 @@
 import { Router } from "../../navigation/router.js";
 import { ScreenUtils } from "../../navigation/screen.js";
 import { streamRepository } from "../../../data/repository/streamRepository.js";
+import { addonRepository } from "../../../data/repository/addonRepository.js";
 import { watchProgressRepository } from "../../../data/repository/watchProgressRepository.js";
+import { PlayerSettingsStore } from "../../../data/local/playerSettingsStore.js";
+import {
+  selectAutoPlayStream,
+  isAutoPlayEffectivelyEnabled
+} from "../../../core/streams/streamAutoPlaySelector.js";
 import { DirectDebridResolver } from "../../../core/debrid/directDebridResolver.js";
 import { DirectDebridStreamPreparer } from "../../../core/debrid/directDebridStreamPreparer.js";
 import { WebOsEngineFsResolver } from "../../../core/p2p/webosEngineFsResolver.js";
@@ -1360,6 +1366,8 @@ export const StreamScreen = {
     this.addonFilter = "all";
     this.hasRenderedStreamRouteShell = false;
     this.autoResumeAttempted = false;
+    this.autoPlayAttempted = false;
+    this.cancelAutoPlayCountdown();
     this.webOsNativePlayerAppId = "";
     this.nativePlayerPendingStreamId = "";
     this.nativePlayerRequestToken = 0;
@@ -1652,6 +1660,7 @@ export const StreamScreen = {
       this.requestRender();
       this.scheduleErrorChipCleanup();
       this.maybeAutoResumeStream();
+      this.maybeAutoPlayStream();
     } catch (error) {
       if (token !== this.loadToken) {
         return;
@@ -1681,6 +1690,97 @@ export const StreamScreen = {
     if (match?.id) {
       void this.playStream(match.id);
     }
+  },
+
+  maybeAutoPlayStream() {
+    if (this.autoPlayAttempted || this.autoPlayCountdown) {
+      return;
+    }
+    // Resume already navigated away, or there is nothing to play.
+    if (Router.getCurrent() !== "stream" || !this.streams.length) {
+      return;
+    }
+    const settings = PlayerSettingsStore.get();
+    if (!isAutoPlayEffectivelyEnabled(settings)) {
+      return;
+    }
+    this.autoPlayAttempted = true;
+    const installedAddonNames = new Set(
+      (addonRepository.getCachedInstalledAddons() || [])
+        .map((addon) => String(addon?.displayName || addon?.name || "").trim())
+        .filter(Boolean)
+    );
+    const selected = selectAutoPlayStream(this.getFilteredStreams(), {
+      mode: settings.streamAutoPlayMode,
+      source: settings.streamAutoPlaySource,
+      regexPattern: settings.streamAutoPlayRegex,
+      installedAddonNames
+    });
+    if (!selected?.id) {
+      return;
+    }
+    this.startAutoPlayCountdown(selected, Number(settings.streamAutoPlayTimeoutSeconds || 0));
+  },
+
+  startAutoPlayCountdown(stream, seconds) {
+    this.cancelAutoPlayCountdown();
+    // Focus the chosen stream so cancelling leaves the user on it.
+    const visible = this.getFilteredStreams();
+    const idx = visible.findIndex((entry) => String(entry?.id || "") === String(stream.id || ""));
+    if (idx >= 0) {
+      this.focusState = { zone: "card", index: idx, row: idx, action: "play" };
+    }
+    const total = Math.max(0, Math.trunc(Number(seconds) || 0));
+    if (total <= 0) {
+      void this.playStream(stream.id);
+      return;
+    }
+    this.autoPlayCountdown = {
+      streamId: stream.id,
+      label: getStreamHeadline(stream) || stream.addonName || "stream",
+      secondsLeft: total
+    };
+    this.requestRender({ delayMs: 0 });
+    this.autoPlayTimer = setInterval(() => {
+      if (!this.autoPlayCountdown) {
+        return;
+      }
+      this.autoPlayCountdown.secondsLeft -= 1;
+      if (this.autoPlayCountdown.secondsLeft <= 0) {
+        const targetId = this.autoPlayCountdown.streamId;
+        this.cancelAutoPlayCountdown();
+        void this.playStream(targetId);
+        return;
+      }
+      this.requestRender({ delayMs: 0 });
+    }, 1000);
+  },
+
+  cancelAutoPlayCountdown() {
+    if (this.autoPlayTimer) {
+      clearInterval(this.autoPlayTimer);
+      this.autoPlayTimer = null;
+    }
+    if (this.autoPlayCountdown) {
+      this.autoPlayCountdown = null;
+      this.requestRender({ delayMs: 0 });
+    }
+  },
+
+  renderAutoPlayOverlay() {
+    if (!this.autoPlayCountdown) {
+      return "";
+    }
+    const { label, secondsLeft } = this.autoPlayCountdown;
+    return `
+      <div class="stream-route-autoplay">
+        <div class="stream-route-autoplay-card">
+          <div class="stream-route-autoplay-title">${escapeHtml(t("stream_autoplay_title", {}, "Auto-playing"))}</div>
+          <div class="stream-route-autoplay-name">${escapeHtml(label)}</div>
+          <div class="stream-route-autoplay-count">${escapeHtml(t("stream_autoplay_countdown", [secondsLeft], `Starting in ${secondsLeft}s`))}</div>
+          <div class="stream-route-autoplay-hint">${escapeHtml(t("stream_autoplay_hint", {}, "Press OK to play now, or any key to choose manually"))}</div>
+        </div>
+      </div>`;
   },
 
   scheduleErrorChipCleanup() {
@@ -2371,6 +2471,7 @@ export const StreamScreen = {
             </div>
           </section>
         </div>
+        ${this.renderAutoPlayOverlay()}
       </div>
     `;
 
@@ -2417,6 +2518,7 @@ export const StreamScreen = {
   },
 
   async playStream(streamId) {
+    this.cancelAutoPlayCountdown();
     const filtered = this.getFilteredStreams();
     const selected = filtered.find((stream) => stream.id === streamId) || filtered[0];
     if (!selected) {
@@ -2543,6 +2645,17 @@ export const StreamScreen = {
   },
 
   onKeyDown(event) {
+    // Any key during the auto-play countdown hands control back to the user.
+    // Back just cancels and stays on the picker; other keys cancel and then do
+    // their normal thing (OK on the highlighted stream plays it right away).
+    if (this.autoPlayCountdown) {
+      this.cancelAutoPlayCountdown();
+      if (isBackEvent(event)) {
+        event?.preventDefault?.();
+        return;
+      }
+    }
+
     if (isBackEvent(event)) {
       event?.preventDefault?.();
       if (!this.navigateBackFromStream()) {
@@ -2689,6 +2802,7 @@ export const StreamScreen = {
   },
 
   cleanup() {
+    this.cancelAutoPlayCountdown();
     this.loadToken = (this.loadToken || 0) + 1;
     this.playResolveToken = Number(this.playResolveToken || 0) + 1;
     this.nativePlayerRequestToken = Number(this.nativePlayerRequestToken || 0) + 1;


### PR DESCRIPTION
Closes #225

Brings the auto stream selection feature over from the Android TV app so the two stay in sync.

You can now pick how a stream starts:
- Off (choose manually): same as today, the picker stays open.
- First stream: plays the first playable stream.
- Regex match: plays the first stream whose name matches your pattern.

When auto play kicks in there is a short countdown overlay, and pressing any key cancels it and keeps you on the picker. You can set the countdown length and limit auto play to a source (all, installed addons, or plugins). Off by default so nothing changes for current users unless they turn it on or sync it from the TV app.

Settings are under Playback and sync with the TV backend using the same keys. The selection logic is ported from StreamAutoPlaySelector in the TV app and covered by unit tests.