### PR TITLE
Hide description on catalog cards

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -4834,7 +4834,6 @@ button:focus-visible {
 
 .home-screen-shell .home-poster-expanded-gradient,
 .home-screen-shell .home-poster-expanded-brand,
-.home-screen-shell .home-poster-expanded-copy,
 .home-screen-shell .home-poster-trailer-layer {
   display: none;
 }
@@ -4907,30 +4906,6 @@ button:focus-visible {
   line-height: 1.2;
   font-weight: 600;
   text-shadow: 0 2px 18px rgba(0, 0, 0, 0.6);
-}
-
-.home-screen-shell .home-poster-expanded-copy {
-  padding-top: 8px;
-}
-
-.home-screen-shell .home-poster-expanded-meta {
-  color: rgba(255, 255, 255, 0.72);
-  font-size: 12px;
-  line-height: 1.35;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: clip;
-}
-
-.home-screen-shell .home-poster-expanded-description {
-  margin-top: 4px;
-  color: #fff;
-  font-size: 14px;
-  line-height: 1.45;
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 2;
-  overflow: hidden;
 }
 
 .home-inline-trailer-frame,
@@ -6335,8 +6310,7 @@ button:focus-visible {
 }
 
 .home-screen-shell.home-layout-modern .home-poster-card.is-expanded .home-poster-expanded-gradient,
-.home-screen-shell.home-layout-modern .home-poster-card.is-expanded .home-poster-expanded-brand,
-.home-screen-shell.home-layout-modern .home-poster-card.is-expanded .home-poster-expanded-copy {
+.home-screen-shell.home-layout-modern .home-poster-card.is-expanded .home-poster-expanded-brand {
   display: block;
 }
 
@@ -6427,8 +6401,7 @@ button:focus-visible {
   transform: none;
 }
 
-.home-screen-shell.home-layout-modern .home-poster-copy,
-.home-screen-shell.home-layout-modern .home-poster-expanded-copy {
+.home-screen-shell.home-layout-modern .home-poster-copy {
   box-sizing: border-box;
   min-height: var(--home-poster-copy-height);
   height: var(--home-poster-copy-height);
@@ -15396,8 +15369,7 @@ button:focus-visible {
 }
 
 .performance-constrained .home-screen-shell .home-poster-title,
-.performance-constrained .home-screen-shell .home-poster-subtitle,
-.performance-constrained .home-screen-shell .home-poster-expanded-meta {
+.performance-constrained .home-screen-shell .home-poster-subtitle {
   text-overflow: ellipsis;
 }
 

--- a/js/ui/screens/home/homeScreen.js
+++ b/js/ui/screens/home/homeScreen.js
@@ -1682,30 +1682,6 @@ function buildPosterSubtitle(item, layoutMode) {
   return firstNonEmpty(extractYear(normalized), normalized.releaseInfo, "");
 }
 
-function buildExpandedPosterMeta(item) {
-  if (isCollectionFolderItem(item)) {
-    return "";
-  }
-  const normalized = normalizeCatalogItem(item);
-  const parts = [];
-  const typeLabel = toTitleCase(normalized.type || normalized.apiType || "movie");
-  if (typeLabel) {
-    parts.push(typeLabel);
-  }
-  if (normalized.genres?.[0]) {
-    parts.push(normalized.genres[0]);
-  }
-  const year = extractYear(normalized);
-  if (year) {
-    parts.push(year);
-  }
-  const imdb = resolveImdbRating(normalized);
-  if (imdb) {
-    parts.push(`IMDb ${imdb}`);
-  }
-  return parts.join("  ·  ");
-}
-
 function renderRowHeader(title, subtitle = "") {
   return `
     <div class="home-row-head">
@@ -2053,7 +2029,6 @@ export function createPosterCardMarkup(item, rowIndex, itemIndex, itemType, rowD
   const isLoading = Boolean(item?.isLoading);
   const normalized = normalizeCatalogItem(item, itemType);
   const subtitle = buildPosterSubtitle(normalized, layoutMode);
-  const expandedMeta = buildExpandedPosterMeta(normalized);
   const preferredLandscapePosterSrc = firstNonEmpty(normalized.landscapePoster);
   const useLandscapePoster = layoutMode === "modern" && preferLandscapePoster;
   const landscapeVisualSrc = firstNonEmpty(
@@ -2126,12 +2101,6 @@ export function createPosterCardMarkup(item, rowIndex, itemIndex, itemType, rowD
           </div>
         ` : ""}
       </div>
-      ${suppressPosterText ? "" : `
-        <div class="home-poster-expanded-copy">
-          ${(!isLoading && expandedMeta) ? `<div class="home-poster-expanded-meta">${escapeHtml(expandedMeta)}</div>` : ""}
-          ${(!isLoading && normalized.description) ? `<div class="home-poster-expanded-description">${escapeHtml(normalized.description)}</div>` : ""}
-        </div>
-      `}
       ${shouldShowLabels ? `
         <div class="home-poster-copy">
           <div class="home-poster-title">${escapeHtml(normalized.name || "Untitled")}</div>
@@ -5065,7 +5034,7 @@ export const HomeScreen = {
     this.homeTruncationScope = null;
     this.applyModernHeroDescriptionBounds(root);
     const nodes = root.querySelectorAll(
-      ".home-hero-description, .home-poster-title, .home-poster-subtitle, .home-poster-expanded-meta, .home-poster-expanded-description"
+      ".home-hero-description, .home-poster-title, .home-poster-subtitle"
     );
     nodes.forEach((node) => {
       if (!(node instanceof HTMLElement)) {


### PR DESCRIPTION
Closes #188

On the home screen, focusing a movie or show in a catalog row expanded the card and showed a plot summary and a small meta line under it. The TV app does not do this, it just shows the backdrop and logo on focus, so the web was out of sync.

This removes the description and meta line from the focused card. The backdrop, logo and title still show as before, and the full description still appears in the hero at the top of the screen.

Checked in the browser that the focused card no longer renders the summary while the hero still does.