### PR TITLE
Add remember last profile option

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -135,16 +135,25 @@ async function shouldShowProfileSelection() {
     pinStates?.[String(activeProfileId)] || pinStates?.[Number(activeProfileId)]
   );
 
-  return !hasSelectedProfileThisSession && (profiles.length > 1 || activeProfileHasPin);
-}
-
-async function routeAfterAuthentication() {
-  const showProfileSelection = await shouldShowProfileSelection();
-  if (showProfileSelection) {
-    Router.navigate("profileSelection");
-    return;
+  if (hasSelectedProfileThisSession) {
+    return false;
   }
 
+  // Remember last profile: when enabled and the last used profile has no PIN,
+  // skip the picker and go straight in, matching the Android TV app. A profile
+  // with a PIN always shows the picker so the PIN can be entered.
+  if (
+    ProfileManager.isRememberLastProfileEnabled() &&
+    ProfileManager.hasEverSelectedProfile() &&
+    !activeProfileHasPin
+  ) {
+    return false;
+  }
+
+  return profiles.length > 1 || activeProfileHasPin;
+}
+
+async function enterWithLastProfile() {
   hasSelectedProfileThisSession = true;
   const profiles = await ProfileManager.getProfiles();
   const activeProfileId = ProfileManager.getActiveProfileId();
@@ -158,6 +167,16 @@ async function routeAfterAuthentication() {
     await ProfileSettingsSyncService.pull(activeProfile.id);
   }
   Router.navigate("home");
+}
+
+async function routeAfterAuthentication() {
+  const showProfileSelection = await shouldShowProfileSelection();
+  if (showProfileSelection) {
+    Router.navigate("profileSelection");
+    return;
+  }
+
+  await enterWithLastProfile();
 }
 
 function setupWebOsAppLifecycle() {
@@ -316,6 +335,21 @@ async function bootstrapApp() {
         return;
       }
       if (shouldBypassQr) {
+        // Honor "remember last profile" for guests too: skip the picker and go
+        // straight in with the last profile (guests have no PIN).
+        if (
+          ProfileManager.isRememberLastProfileEnabled() &&
+          ProfileManager.hasEverSelectedProfile()
+        ) {
+          enterWithLastProfile().catch((error) => {
+            console.warn("Failed to enter with last profile", error);
+            ProfileManager.clearActiveProfile();
+            if (Router.getCurrent() !== "profileSelection") {
+              Router.navigate("profileSelection", {}, { replaceHistory: true, skipStackPush: true });
+            }
+          });
+          return;
+        }
         ProfileManager.clearActiveProfile();
         if (Router.getCurrent() !== "profileSelection") {
           Router.navigate(

--- a/js/core/profile/profileManager.js
+++ b/js/core/profile/profileManager.js
@@ -2,6 +2,8 @@ import { LocalStore } from "../storage/localStore.js";
 
 const PROFILES_KEY = "profiles";
 const ACTIVE_PROFILE_ID_KEY = "activeProfileId";
+const REMEMBER_LAST_PROFILE_KEY = "rememberLastProfile";
+const HAS_EVER_SELECTED_PROFILE_KEY = "hasEverSelectedProfile";
 
 const DEFAULT_PROFILES = [
   { id: "1", profileIndex: 1, name: "Profile 1", avatarColorHex: "#1E88E5", isPrimary: true }
@@ -48,6 +50,19 @@ export const ProfileManager = {
 
   async setActiveProfile(id) {
     LocalStore.set(ACTIVE_PROFILE_ID_KEY, String(id));
+    LocalStore.set(HAS_EVER_SELECTED_PROFILE_KEY, true);
+  },
+
+  isRememberLastProfileEnabled() {
+    return Boolean(LocalStore.get(REMEMBER_LAST_PROFILE_KEY, false));
+  },
+
+  setRememberLastProfileEnabled(enabled) {
+    LocalStore.set(REMEMBER_LAST_PROFILE_KEY, Boolean(enabled));
+  },
+
+  hasEverSelectedProfile() {
+    return Boolean(LocalStore.get(HAS_EVER_SELECTED_PROFILE_KEY, false));
   },
 
   clearActiveProfile() {

--- a/js/ui/screens/settings/settingsScreen.js
+++ b/js/ui/screens/settings/settingsScreen.js
@@ -2356,6 +2356,9 @@ export const SettingsScreen = {
         returnRoute: "settings"
       })
     );
+    this.actionMap.set("profiles:rememberLast", () => {
+      ProfileManager.setRememberLastProfileEnabled(!ProfileManager.isRememberLastProfileEnabled());
+    });
 
     return `
       ${this.renderSectionHeader(SECTION_META.find((item) => item.id === "profiles"))}
@@ -2367,6 +2370,16 @@ export const SettingsScreen = {
             subtitle: "",
             icon: null,
             classes: "settings-profile-manage-row"
+          })}
+          ${this.renderToggleRow({
+            focusKey: "profiles:rememberLast",
+            title: t("settings.profiles.rememberLast.title", {}, "Remember Last Profile"),
+            subtitle: t(
+              "settings.profiles.rememberLast.subtitle",
+              {},
+              "Skip the profile picker at startup and use the last selected profile. Profiles with a PIN are always asked."
+            ),
+            checked: ProfileManager.isRememberLastProfileEnabled()
           })}
         </div>
       </div>


### PR DESCRIPTION
Closes #269

Adds a Remember Last Profile toggle under Settings > Profiles, matching the Android TV app (it has the same setting under Network & Advanced).

When it is on, startup skips the profile picker and goes straight in with the last used profile. A profile that has a PIN still shows the picker so the PIN can be entered. Off by default, so current users see no change unless they turn it on. Works the same way for signed in and guest startup.

Verified in the browser:
- Off (default): picker shows as before with multiple profiles.
- On, after a profile has been picked once: startup skips the picker and opens home.
- On but no profile picked yet: picker still shows.
- The toggle persists its value.