### PR TITLE
fix(theme): apply accent color & AMOLED in packaged builds (#274)

### DIFF
--- a/js/ui/theme/themeManager.js
+++ b/js/ui/theme/themeManager.js
@@ -7,6 +7,13 @@ const FONT_STACKS = {
   OPEN_SANS: '"Open Sans", "Segoe UI", Arial, sans-serif'
 };
 
+// Cached once at module load. Chrome 38 / legacy webOS 3.x lack CSS.supports → false.
+const SUPPORTS_CSS_VARS =
+  typeof window !== "undefined" &&
+  !!window.CSS &&
+  typeof window.CSS.supports === "function" &&
+  window.CSS.supports("--probe", "0");
+
 function toRgbChannels(hex, fallback = "255 255 255") {
   const value = String(hex || "").trim();
   const match = value.match(/^#([0-9a-f]{6})$/i);
@@ -15,6 +22,85 @@ function toRgbChannels(hex, fallback = "255 255 255") {
   }
   const normalized = match[1];
   return `${parseInt(normalized.slice(0, 2), 16)} ${parseInt(normalized.slice(2, 4), 16)} ${parseInt(normalized.slice(4, 6), 16)}`;
+}
+
+/**
+ * Pure function — no DOM access. Returns a CSS string for legacy engines that
+ * do not support CSS custom properties (e.g. Chromium 38 / webOS 3.x).
+ *
+ * colorMap keys:
+ *   bg, bgElevated, cardBg, secondary, onSecondary,
+ *   focusColor, focusBg, text, textSecondary, textTertiary, border
+ *
+ * @param {{ bg:string, bgElevated:string, cardBg:string, secondary:string,
+ *           onSecondary:string, focusColor:string, focusBg:string,
+ *           text:string, textSecondary:string, textTertiary:string,
+ *           border:string }} colorMap
+ * @returns {string}
+ */
+export function buildLegacyThemeCss(colorMap) {
+  const { bg, bgElevated, cardBg, secondary, onSecondary, focusColor, focusBg, text } = colorMap;
+
+  return [
+    // 1. Base document surfaces
+    `html, body { background: ${bg}; color: ${text}; }`,
+
+    // 2. Full-screen shells (AMOLED: bg → true black)
+    `.home-shell, .home-sidebar, .profile-screen, .search-screen-shell,` +
+      ` .discover-shell, .library-shell { background: ${bg}; }`,
+
+    // 3. Elevated surfaces (cards, dialogs, panels)
+    `.account-info, .sync-card, .status-card, .profile-editor-panel,` +
+      ` .nuvio-dialog-panel { background: ${bgElevated}; }`,
+
+    // 4. Card/input surfaces
+    `.card, .account-settings-card, .search-input-field,` +
+      ` .library-action-button { background: ${cardBg}; }`,
+
+    // 5. Accent-fill surfaces (secondary color)
+    `.profile-overlay-button-primary,` +
+      ` .home-sidebar.content-expanded .home-nav-item.selected,` +
+      ` .library-picker-option.focused,` +
+      ` .library-watched-badge { background: ${secondary}; color: ${onSecondary}; }`,
+
+    // 6. Focus rings — structures copied verbatim from components.css,
+    //    only the color token values are substituted.
+
+    // .auth-simple-card.focused / .account-settings-card.focused
+    // Source: components.css line 290-294 → box-shadow: 0 0 0 2px var(--focus-color)
+    `.auth-simple-card.focused,` +
+      ` .account-settings-card.focused {` +
+      ` background: ${focusBg}; box-shadow: 0 0 0 2px ${focusColor}; }`,
+
+    // .profile-avatar-tile.focused
+    // Source: components.css line 1278-1279 → box-shadow: inset 0 0 0 0.3125vw var(--focus-color)
+    `.profile-avatar-tile.is-selected,` +
+      ` .profile-avatar-tile.focused { box-shadow: inset 0 0 0 0.3125vw ${focusColor}; }`,
+
+    // .library-grid-card.focused .library-grid-poster
+    // Source: components.css line 3590-3593 → box-shadow: 0 0 0 4px var(--focus-color)
+    `.library-grid-card.focused .library-grid-poster {` +
+      ` box-shadow: 0 0 0 4px ${focusColor}; background-color: ${focusBg}; border-color: ${focusColor}; }`,
+
+    // .library-action-button.focused (standalone, not in .library-actions-row context)
+    // Source: components.css line 3520-3528 → box-shadow: 0 0 0 2px var(--focus-color)
+    `.library-action-button.focused {` +
+      ` border-color: ${focusColor}; box-shadow: 0 0 0 2px ${focusColor}; background: ${focusBg}; }`
+  ].join("\n");
+}
+
+const LEGACY_STYLE_ID = "nuvio-legacy-theme";
+
+function injectLegacyTheme(css) {
+  let el = document.getElementById(LEGACY_STYLE_ID);
+  if (!el) {
+    el = document.createElement("style");
+    el.id = LEGACY_STYLE_ID;
+  }
+  el.textContent = css;
+  // Re-append keeps it LAST in <head> so equal-specificity rules win
+  // over the baked static fallback.
+  document.head.appendChild(el);
 }
 
 export const ThemeManager = {
@@ -56,5 +142,22 @@ export const ThemeManager = {
       FONT_STACKS[String(theme.fontFamily || "INTER").toUpperCase()] || FONT_STACKS.INTER
     );
     document.documentElement.style.setProperty("color-scheme", "dark");
+
+    if (!SUPPORTS_CSS_VARS) {
+      const colorMap = {
+        bg: colors["--bg-color"],
+        bgElevated: colors["--bg-elevated"],
+        cardBg: colors["--card-bg"],
+        secondary: colors["--secondary-color"],
+        onSecondary: colors["--on-secondary"],
+        focusColor: colors["--focus-color"],
+        focusBg: colors["--focus-bg"],
+        text: colors["--text-color"],
+        textSecondary: colors["--text-secondary"],
+        textTertiary: colors["--text-tertiary"],
+        border: colors["--border-color"]
+      };
+      injectLegacyTheme(buildLegacyThemeCss(colorMap));
+    }
   }
 };

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -34,7 +34,7 @@ async function buildCSS() {
     const css = await readFile(cssPath, "utf8");
     const result = await postcss([
       postcssGlobalData({ files: [path.join(cssDir, "base.css")] }),
-      postcssCustomProperties({ preserve: false }),
+      postcssCustomProperties({ preserve: true }),
       autoprefixer({ overrideBrowserslist: ["Chrome 38"], grid: "autoplace" }),
       cssnano()
     ]).process(css, { from: cssPath, to: outPath });


### PR DESCRIPTION
## Summary
Fixes #274 — on packaged webOS/Tizen builds, changing the accent/theme color or toggling AMOLED in Settings had no effect (accent stayed white, AMOLED was a no-op).

## Root cause
`scripts/build.mjs` processed CSS with `postcss-custom-properties({ preserve: false })`, which strips every `var()` and inlines the `:root` defaults at build time. `ThemeManager.apply()` themes at runtime via `documentElement.style.setProperty('--…')`, but with the `var()` references gone from the packaged CSS there was nothing to override — so the baked-in defaults (white accent, dark bg) always won. It worked in browser dev only because `serve.mjs` serves the raw CSS with `var()` intact.

## Changes
- **`scripts/build.mjs`** — `preserve: true`. Packaged CSS now keeps both the static fallback and the `var()` declaration, restoring runtime theming on every CSS-variable-capable engine (webOS 4+/Chromium 49+, Tizen, modern browsers). The static fallback still covers legacy Chromium 38.
- **`js/ui/theme/themeManager.js`** — for engines with no CSS-variable support (Chromium 38 / legacy webOS 3.x), inject a regenerated `<style id="nuvio-legacy-theme">` with concrete color values for the main themed surfaces (backgrounds/AMOLED, accent fills, focus rings). Modern path unchanged.

## Verification
- `npm run build` succeeds; `dist/css/components.css` retains ~1173 `var(` (was ~481) with the dual fallback (e.g. `background:#222;background:var(--card-bg)`) surviving cssnano.
- Verified on-device: accent color and AMOLED now apply.

Closes #274
