### PR TITLE
Apply theme accent to Library and Discover focus

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -1791,7 +1791,6 @@ button:focus-visible {
   --modern-sidebar-pill-chip-start: 10px;
   --modern-sidebar-pill-chip-end: 24px;
   --modern-sidebar-pill-chip-gap: 18px;
-  --focus-color: #f5f8fc;
   background:
     radial-gradient(120% 90% at 75% 8%, rgba(190, 40, 18, 0.26), transparent 45%), #06090e;
   color: #f8fbff;
@@ -3364,8 +3363,8 @@ button:focus-visible {
 
 .library-picker-anchor.focused,
 .library-picker.open .library-picker-anchor {
-  border-color: rgb(255 255 255 / 0.1);
-  box-shadow: inset 0 0 0 3px rgb(255 255 255 / 0.96);
+  border-color: var(--focus-color);
+  box-shadow: inset 0 0 0 3px var(--focus-color);
   background: var(--focus-bg);
 }
 


### PR DESCRIPTION
Addresses #289 (the theming part)

Changing the accent theme had no effect on the Library and Discover screens, where the focused filter buttons stayed outlined white.

Two causes:
- The shared shell pinned the focus color to a fixed white value, which overrode the theme color for everything inside it (Library, Discover, Home, Search).
- The Library and Discover filter buttons (shared component) used a hardcoded white outline instead of the theme focus color.

Both now use the theme focus color, so the accent applies on these screens like everywhere else. On the default theme the color stays white, so nothing changes unless an accent is picked.

Verified in the browser: with a colored theme the filter button focus ring and the surrounding focus rings now use the accent color instead of white.

Note: this covers the theming part of the report. The separate buffer/spacing point is not included here.