### PR TITLE
Scroll home to top when reselecting Home

### DIFF
--- a/js/ui/components/sidebarNavigation.js
+++ b/js/ui/components/sidebarNavigation.js
@@ -243,7 +243,13 @@ export function activateLegacySidebarAction(action, currentRoute = "") {
   }
 
   const target = getItemForAction(normalizedAction);
-  if (!target || target.route === currentRoute) {
+  if (!target) {
+    return;
+  }
+  if (target.route === currentRoute) {
+    // Re-selecting the tab you are already on. Let the screen react, e.g. Home
+    // scrolls back to the top, matching the Android TV app.
+    Router.getCurrentScreen()?.onSidebarReselect?.();
     return;
   }
   Router.navigate(target.route);

--- a/js/ui/screens/home/homeScreen.js
+++ b/js/ui/screens/home/homeScreen.js
@@ -5350,6 +5350,18 @@ export const HomeScreen = {
     return this.focusNode(current, target, "right") || true;
   },
 
+  // Selecting Home while already on Home scrolls back to the top, matching the
+  // Android TV app. Clears the remembered content focus so we land on the very
+  // first row, resets the scroll position, then moves focus into the content.
+  onSidebarReselect() {
+    const viewport = this.getHomeViewport();
+    if (viewport) {
+      viewport.scrollTop = 0;
+    }
+    this.lastMainFocus = null;
+    this.closeSidebarToContent();
+  },
+
   getMainFocusAnchor(node) {
     if (!node) {
       return null;


### PR DESCRIPTION
Addresses the back to top request in #286

Selecting Home from the sidebar while you are already on Home now scrolls back to the top and focuses the first row. Before, it did nothing, so after scrolling down through the catalogs there was no quick way back up.

This matches the Android TV app, which scrolls Home to the top when you pick Home again from the menu.

Works for both pointer click and remote OK. Reselecting other tabs is unchanged, and switching between tabs works as before.

Verified in the browser: scrolled the home rows down (scroll offset ~2074, focus on row 5), selected Home from the sidebar, and the page jumped back to the top (offset 0, focus on row 0).