### PR TITLE
Fix legacy TV browser support

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -16993,22 +16993,19 @@ html.no-css-grid .cast-detail-meta {
 }
 
 .no-css-math .settings-layout-preview-grid-canvas {
+  display: grid;
   top: 2.5%;
   left: 2.5%;
   width: 95%;
   height: 660px;
-  gap: 0;
-  row-gap: 0;
-  column-gap: 0;
-  animation-name: settingsLayoutGridPreviewScrollLegacy;
-}
-
-.no-css-math:not(.no-css-grid) .settings-layout-preview-grid-canvas {
-  display: grid;
   grid-template-columns: repeat(5, 18%);
   grid-auto-rows: 82px;
   justify-content: space-between;
   align-content: flex-start;
+  gap: 0;
+  row-gap: 0;
+  column-gap: 0;
+  animation-name: settingsLayoutGridPreviewScrollLegacy;
 }
 
 .no-css-math .settings-layout-preview-grid-cell {
@@ -17055,6 +17052,99 @@ html.no-css-grid .cast-detail-meta {
 .no-css-math.no-css-grid .settings-layout-preview-grid-cell {
   flex: 0 0 18%;
   width: 18%;
+}
+
+.no-css-math .settings-layout-preview {
+  background-color: #0d0d0d;
+}
+
+.no-css-math .settings-layout-preview-modern,
+.no-css-math .settings-layout-preview-grid,
+.no-css-math .settings-layout-preview-classic {
+  overflow: hidden;
+}
+
+.no-css-math .settings-layout-preview-modern::before,
+.no-css-math .settings-layout-preview-modern::after,
+.no-css-math .settings-layout-preview-grid::before,
+.no-css-math .settings-layout-preview-grid::after,
+.no-css-math .settings-layout-preview-classic::before,
+.no-css-math .settings-layout-preview-classic::after {
+  content: "";
+  display: block;
+  position: absolute;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.no-css-math .settings-layout-preview-modern::before {
+  top: 6%;
+  left: 5%;
+  width: 90%;
+  height: 62%;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.38);
+}
+
+.no-css-math .settings-layout-preview-modern::after {
+  left: 5%;
+  bottom: 7%;
+  width: 78px;
+  height: 24%;
+  border-radius: 5px;
+  background: rgba(255, 255, 255, 0.28);
+  box-shadow:
+    90px 0 0 rgba(255, 255, 255, 0.46),
+    180px 0 0 rgba(255, 255, 255, 0.28),
+    270px 0 0 rgba(255, 255, 255, 0.28);
+  animation: settingsLayoutModernPreviewShadowScrollLegacy 4.2s linear infinite;
+}
+
+.no-css-math .settings-layout-preview-grid::before {
+  top: 2.5%;
+  left: 2.5%;
+  width: 18%;
+  height: 82px;
+  border-radius: 5px;
+  background: rgba(255, 255, 255, 0.5);
+  box-shadow:
+    20.5% 0 0 rgba(255, 255, 255, 0.5),
+    41% 0 0 rgba(255, 255, 255, 0.5),
+    61.5% 0 0 rgba(255, 255, 255, 0.5),
+    82% 0 0 rgba(255, 255, 255, 0.5),
+    0 94px 0 rgba(255, 255, 255, 0.5),
+    20.5% 94px 0 rgba(255, 255, 255, 0.5),
+    41% 94px 0 rgba(255, 255, 255, 0.5),
+    61.5% 94px 0 rgba(255, 255, 255, 0.5),
+    82% 94px 0 rgba(255, 255, 255, 0.5);
+  animation: settingsLayoutGridPreviewShadowScrollLegacy 4s linear infinite;
+}
+
+.no-css-math .settings-layout-preview-classic::before,
+.no-css-math .settings-layout-preview-classic::after {
+  left: 4.5%;
+  width: 118px;
+  height: 25%;
+  border-radius: 5px;
+  background: rgba(255, 255, 255, 0.3);
+  box-shadow:
+    132px 0 0 rgba(255, 255, 255, 0.3),
+    264px 0 0 rgba(255, 255, 255, 0.3),
+    396px 0 0 rgba(255, 255, 255, 0.3);
+}
+
+.no-css-math .settings-layout-preview-classic::before {
+  top: 4%;
+}
+
+.no-css-math .settings-layout-preview-classic::after {
+  top: 35.333%;
+  background: rgba(255, 255, 255, 0.6);
+  box-shadow:
+    132px 0 0 rgba(255, 255, 255, 0.6),
+    264px 0 0 rgba(255, 255, 255, 0.6),
+    396px 0 0 rgba(255, 255, 255, 0.6);
+  animation: settingsLayoutClassicPreviewShadowScrollLegacy 4s linear infinite;
 }
 
 .no-css-grid .profile-editor-avatar-grid {
@@ -17377,6 +17467,33 @@ html.no-css-grid .cast-detail-meta {
 }
 
 @keyframes settingsLayoutClassicPreviewScrollLegacy {
+  from {
+    left: 4.5%;
+  }
+  to {
+    left: -36%;
+  }
+}
+
+@keyframes settingsLayoutModernPreviewShadowScrollLegacy {
+  from {
+    left: 5%;
+  }
+  to {
+    left: -44%;
+  }
+}
+
+@keyframes settingsLayoutGridPreviewShadowScrollLegacy {
+  from {
+    top: 2.5%;
+  }
+  to {
+    top: -52%;
+  }
+}
+
+@keyframes settingsLayoutClassicPreviewShadowScrollLegacy {
   from {
     left: 4.5%;
   }

--- a/css/components.css
+++ b/css/components.css
@@ -16776,6 +16776,288 @@ html.no-css-grid .cast-detail-meta {
   font-size: 32px;
 }
 
+.no-css-math .library-picker-title {
+  font-size: 19px;
+  line-height: 24px;
+}
+
+.no-css-math .library-picker-value {
+  font-size: 30px;
+  line-height: 40px;
+}
+
+.no-css-math .library-picker-icon {
+  width: 40px;
+  height: 40px;
+}
+
+.no-css-math .library-picker-chevron {
+  width: 32px;
+  height: 32px;
+}
+
+.no-css-math .library-picker-menu {
+  max-height: 640px;
+  padding: 4px 10px;
+  border-radius: 36px;
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.38);
+}
+
+.no-css-math .library-picker-option {
+  min-height: 84px;
+  padding: 0 20px;
+  border-radius: 24px;
+  font-size: 26px;
+}
+
+/* Chromium 68 and older ignore flex gap. Keep these source-level fallbacks
+   scoped to legacy feature classes so modern Chromium keeps the authored UI. */
+.no-flex-gap .search-sidebar > * + *,
+.no-flex-gap .settings-sidebar > * + * {
+  margin-top: 28px;
+}
+
+.no-flex-gap .search-sidebar > * + * {
+  margin-top: 16px;
+}
+
+.no-flex-gap .library-actions-row > * + *,
+.no-flex-gap .library-picker-row > .library-picker + .library-picker {
+  margin-left: 24px;
+}
+
+.no-flex-gap .search-results-track > * + * {
+  margin-left: 16px;
+}
+
+.no-flex-gap .settings-theme-row > * + * {
+  margin-left: 20px;
+}
+
+.no-flex-gap .search-seeall-inner > * + * {
+  margin-top: 14px;
+}
+
+.no-flex-gap .discover-content > * + *,
+.no-flex-gap .settings-account-list > * + *,
+.no-flex-gap .settings-trakt-header-row + *,
+.no-flex-gap .settings-trakt-footer-row + * {
+  margin-top: 12px;
+}
+
+.no-flex-gap .discover-hero > * + *,
+.no-flex-gap .settings-action-row > * + *,
+.no-flex-gap .settings-collapsible-trigger > * + *,
+.no-flex-gap .settings-subsection-card .settings-action-row > * + * {
+  margin-left: 24px;
+}
+
+.no-flex-gap .discover-hero-copy > * + *,
+.no-flex-gap .discover-loading-state > * + *,
+.no-flex-gap .discover-empty-state > * + *,
+.no-flex-gap .settings-collapsible > * + *,
+.no-flex-gap .settings-trakt-scroll-area > * + *,
+.no-flex-gap .settings-trakt-options-stack > * + *,
+.no-flex-gap .settings-stream-badge-preview-section > * + * {
+  margin-top: 8px;
+}
+
+.no-flex-gap .discover-meta-line > *,
+.no-flex-gap .settings-profile-summary > * {
+  margin-right: 8px;
+  margin-bottom: 8px;
+}
+
+.no-flex-gap .settings-profile-summary > * {
+  margin-right: 12px;
+  margin-bottom: 12px;
+}
+
+.no-flex-gap .discover-results-head > * + *,
+.no-flex-gap .settings-account-signout-button > * + *,
+.no-flex-gap .settings-row-tail > * + *,
+.no-flex-gap .settings-collapsible-trigger .settings-row-tail > * + *,
+.no-flex-gap .settings-subsection-card .settings-row-tail > * + *,
+.no-flex-gap .settings-plugin-repo-card > * + * {
+  margin-left: 20px;
+}
+
+.no-flex-gap .library-picker-groups > .library-picker-row + .library-picker-row,
+.no-flex-gap .settings-stack > * + *,
+.no-flex-gap .settings-subsection-card .settings-stack > * + *,
+.no-flex-gap .settings-appearance-group-card > * + * {
+  margin-top: 20px;
+}
+
+.no-flex-gap .library-picker-anchor > .library-picker-icon,
+.no-flex-gap .settings-account-action-button > * + * {
+  margin-left: 24px;
+}
+
+.no-flex-gap .library-picker-copy > * + *,
+.no-flex-gap .settings-row-copy > * + *,
+.no-flex-gap .settings-collapsible-trigger .settings-row-copy > * + *,
+.no-flex-gap .settings-subsection-card .settings-row-copy > * + * {
+  margin-top: 4px;
+}
+
+.no-flex-gap .library-dialog-field > * + *,
+.no-flex-gap .settings-account-status-card > * + *,
+.no-flex-gap .settings-language-option-meta > * + * {
+  margin-top: 16px;
+}
+
+.no-flex-gap .settings-account-status-card > * + *,
+.no-flex-gap .settings-language-option-meta > * + * {
+  margin-top: 0;
+}
+
+.no-flex-gap .settings-account-status-card > * + * {
+  margin-left: 16px;
+}
+
+.no-flex-gap .settings-language-option-meta > * + * {
+  margin-left: 12px;
+}
+
+.no-flex-gap .library-grid-card > * + * {
+  margin-top: 16px;
+}
+
+.no-flex-gap .settings-layout-card > * + *,
+.no-flex-gap .settings-dialog-list > * + * {
+  margin-top: 12px;
+}
+
+.no-flex-gap .library-empty-state > * + * {
+  margin-top: 18px;
+}
+
+.no-flex-gap .library-loading-state > * + *,
+.no-flex-gap .library-manage-stack > * + *,
+.no-flex-gap .library-dialog-title + *,
+.no-flex-gap .settings-dialog > * + * {
+  margin-top: 28px;
+}
+
+.no-flex-gap .library-delete-dialog > * + * {
+  margin-top: 32px;
+}
+
+.no-flex-gap .library-manage-list > * + *,
+.no-flex-gap .library-manage-actions-row > * + *,
+.no-flex-gap .library-dialog-actions > * + *,
+.no-flex-gap .library-privacy-row > * + * {
+  margin-left: 20px;
+}
+
+.no-flex-gap .library-manage-list > * + *,
+.no-flex-gap .library-dialog-actions.stacked > * + *,
+.no-flex-gap .library-dialog-field > * + *,
+.no-flex-gap .settings-content > * + * {
+  margin-left: 0;
+  margin-top: 20px;
+}
+
+.no-flex-gap .settings-plugin-repo-list > * + * {
+  margin-top: 14px;
+}
+
+.no-flex-gap .settings-content > * + * {
+  margin-top: 24px;
+}
+
+.no-flex-gap .settings-content-header > * + * {
+  margin-top: 12px;
+}
+
+.no-flex-gap .settings-group-heading > * + *,
+.no-flex-gap .settings-plugin-repo-copy > * + * {
+  margin-top: 6px;
+}
+
+.no-flex-gap .settings-nav-leading > * + *,
+.no-flex-gap .settings-nav-label-wrap > * + * {
+  margin-left: 20px;
+}
+
+.no-flex-gap .settings-nav-label-wrap > * + * {
+  margin-left: 12px;
+}
+
+.no-flex-gap .settings-account-button-copy > * + *,
+.no-flex-gap .settings-account-stat > * + *,
+.no-flex-gap .settings-trakt-stat > * + * {
+  margin-top: 2px;
+}
+
+.no-flex-gap .settings-account-sync-overview > * + * {
+  margin-top: 12px;
+}
+
+.no-flex-gap .settings-theme-card > * + * {
+  margin-top: 16px;
+}
+
+.no-flex-gap .settings-profile-pill > * + *,
+.no-flex-gap .settings-plugin-repo-actions > * + * {
+  margin-left: 10px;
+}
+
+.no-flex-gap .settings-plugin-builder > * + *,
+.no-flex-gap .settings-plugin-provider-heading {
+  margin-top: 18px;
+}
+
+.no-flex-gap .settings-plugin-add > * + * {
+  margin-left: 14px;
+}
+
+.no-flex-gap .settings-dialog > * + * {
+  margin-top: 32px;
+}
+
+.no-css-grid .search-header {
+  display: flex;
+  align-items: center;
+}
+
+.no-css-grid .search-header > * + * {
+  margin-left: 24px;
+}
+
+.no-css-grid .search-input-field {
+  flex: 1 1 auto;
+}
+
+.no-css-grid .discover-filters,
+.no-css-grid .settings-plugin-builder-row,
+.no-css-grid .settings-text-dialog-actions {
+  display: flex;
+}
+
+.no-css-grid .discover-filters > *,
+.no-css-grid .settings-text-dialog-actions > * {
+  flex: 1 1 0;
+}
+
+.no-css-grid .discover-filters > * + *,
+.no-css-grid .settings-text-dialog-actions > * + * {
+  margin-left: 16px;
+}
+
+.no-css-grid .settings-plugin-input {
+  flex: 1 1 auto;
+}
+
+.no-css-grid .settings-plugin-add {
+  flex: 0 0 180px;
+}
+
+.no-css-grid .settings-plugin-builder-row > * + * {
+  margin-left: 18px;
+}
+
 @supports not (font-size: clamp(1px, 2px, 3px)) {
   .home-screen-shell.home-layout-modern .home-hero,
   .home-screen-shell.home-layout-modern .home-modern-hero-card {

--- a/css/components.css
+++ b/css/components.css
@@ -16969,6 +16969,70 @@ html.no-css-grid .cast-detail-meta {
   width: 118px;
 }
 
+.no-css-math .settings-layout-preview-modern-hero {
+  top: 6%;
+  left: 5%;
+  width: 90%;
+  height: 62%;
+}
+
+.no-css-math .settings-layout-preview-modern-row {
+  top: 73%;
+  left: 5%;
+  width: 780px;
+  height: 24%;
+  gap: 0;
+  animation-name: settingsLayoutModernPreviewScrollLegacy;
+}
+
+.no-css-math .settings-layout-preview-modern-card {
+  flex: 0 0 78px;
+  width: 78px;
+  height: 100%;
+  margin-right: 12px;
+}
+
+.no-css-math .settings-layout-preview-grid-canvas {
+  top: 2.5%;
+  left: 2.5%;
+  width: 95%;
+  height: 660px;
+  gap: 0;
+  row-gap: 0;
+  column-gap: 0;
+  animation-name: settingsLayoutGridPreviewScrollLegacy;
+}
+
+.no-css-math:not(.no-css-grid) .settings-layout-preview-grid-canvas {
+  display: grid;
+  grid-template-columns: repeat(5, 18%);
+  grid-auto-rows: 82px;
+  justify-content: space-between;
+  align-content: flex-start;
+}
+
+.no-css-math .settings-layout-preview-grid-cell {
+  width: 100%;
+  height: 82px;
+}
+
+.no-css-math .settings-layout-preview-classic-row {
+  left: 4.5%;
+  width: 920px;
+  gap: 0;
+}
+
+.no-css-math .settings-layout-preview-classic-row.is-featured {
+  animation-name: settingsLayoutClassicPreviewScrollLegacy;
+}
+
+.no-css-math .settings-layout-preview-classic-card {
+  flex: 0 0 118px;
+  width: 118px;
+  height: 85%;
+  margin-right: 14px;
+}
+
 .no-css-grid .settings-layout-preview-grid-canvas {
   display: flex;
   flex-wrap: wrap;
@@ -16986,6 +17050,11 @@ html.no-css-grid .cast-detail-meta {
   height: 82px;
   margin-bottom: 2.5%;
   margin-right: 0;
+}
+
+.no-css-math.no-css-grid .settings-layout-preview-grid-cell {
+  flex: 0 0 18%;
+  width: 18%;
 }
 
 .no-css-grid .profile-editor-avatar-grid {
@@ -17286,6 +17355,33 @@ html.no-css-grid .cast-detail-meta {
   .no-flex-gap .profile-grid > * {
     margin-right: 44px;
     margin-bottom: 44px;
+  }
+}
+
+@keyframes settingsLayoutModernPreviewScrollLegacy {
+  from {
+    left: 5%;
+  }
+  to {
+    left: -44%;
+  }
+}
+
+@keyframes settingsLayoutGridPreviewScrollLegacy {
+  from {
+    top: 2.5%;
+  }
+  to {
+    top: -52%;
+  }
+}
+
+@keyframes settingsLayoutClassicPreviewScrollLegacy {
+  from {
+    left: 4.5%;
+  }
+  to {
+    left: -36%;
   }
 }
 

--- a/css/components.css
+++ b/css/components.css
@@ -8655,13 +8655,9 @@ button:focus-visible {
   height: 224px;
   --settings-layout-modern-side: 5%;
   --settings-layout-modern-top: 6%;
-  --settings-layout-modern-gap: 3%;
+  --settings-layout-modern-gap: 8px;
   --settings-layout-modern-card-width: 78px;
-  --settings-layout-modern-cycle-width: calc(
-    var(--settings-layout-modern-card-width) + var(--settings-layout-modern-gap) +
-      var(--settings-layout-modern-card-width) + var(--settings-layout-modern-gap) +
-      var(--settings-layout-modern-card-width) + var(--settings-layout-modern-gap)
-  );
+  --settings-layout-modern-cycle-width: 258px;
 }
 
 .settings-layout-preview-modern-hero {
@@ -8682,7 +8678,7 @@ button:focus-visible {
   height: 24%;
   display: flex;
   align-items: stretch;
-  gap: var(--settings-layout-modern-gap);
+  gap: 0;
   width: max-content;
   animation: settingsLayoutModernPreviewScroll 5.7s linear infinite;
   will-change: transform;
@@ -8692,6 +8688,7 @@ button:focus-visible {
   flex: 0 0 var(--settings-layout-modern-card-width);
   width: var(--settings-layout-modern-card-width);
   height: 100%;
+  margin-right: var(--settings-layout-modern-gap);
   aspect-ratio: 1.45 / 1;
   background: rgba(255, 255, 255, 0.28);
   background: rgb(255 255 255 / 0.28);
@@ -8707,14 +8704,11 @@ button:focus-visible {
   display: block;
   width: 100%;
   height: 224px;
-  --settings-layout-grid-gap: 2.5%;
-  --settings-layout-grid-card-width: calc((100% - (var(--settings-layout-grid-gap) * 4)) / 5);
-  --settings-layout-grid-card-height: calc(var(--settings-layout-grid-card-width) * 1.4);
-  --settings-layout-grid-cycle-height: calc(
-    var(--settings-layout-grid-card-height) + var(--settings-layout-grid-gap) +
-      var(--settings-layout-grid-card-height) + var(--settings-layout-grid-gap) +
-      var(--settings-layout-grid-card-height) + var(--settings-layout-grid-gap)
-  );
+  --settings-layout-grid-gap: 8px;
+  --settings-layout-grid-card-width: 44px;
+  --settings-layout-grid-card-height: 62px;
+  --settings-layout-grid-canvas-height: 482px;
+  --settings-layout-grid-cycle-height: 210px;
 }
 
 .settings-layout-preview-grid-canvas {
@@ -8722,9 +8716,7 @@ button:focus-visible {
   top: var(--settings-layout-grid-gap);
   left: var(--settings-layout-grid-gap);
   width: calc(100% - (var(--settings-layout-grid-gap) * 2));
-  height: calc(
-    (var(--settings-layout-grid-card-height) * 7) + (var(--settings-layout-grid-gap) * 6)
-  );
+  height: var(--settings-layout-grid-canvas-height);
   display: grid;
   grid-template-columns: repeat(5, var(--settings-layout-grid-card-width));
   grid-auto-rows: var(--settings-layout-grid-card-height);
@@ -8751,21 +8743,20 @@ button:focus-visible {
   width: 100%;
   height: 224px;
   --settings-layout-classic-side: 4.5%;
-  --settings-layout-classic-gap: 2.5%;
-  --settings-layout-classic-card-width: 18.2%;
-  --settings-layout-classic-cycle-width: calc(
-    var(--settings-layout-classic-card-width) + var(--settings-layout-classic-gap) +
-      var(--settings-layout-classic-card-width) + var(--settings-layout-classic-gap)
-  );
+  --settings-layout-classic-gap: 8px;
+  --settings-layout-classic-row-spacing: 9px;
+  --settings-layout-classic-row-height: 63px;
+  --settings-layout-classic-card-width: 47px;
+  --settings-layout-classic-cycle-width: 110px;
 }
 
 .settings-layout-preview-classic-row {
   position: absolute;
   left: var(--settings-layout-classic-side);
-  height: 29.333%;
+  height: var(--settings-layout-classic-row-height);
   display: flex;
   align-items: center;
-  gap: var(--settings-layout-classic-gap);
+  gap: 0;
   width: max-content;
 }
 
@@ -8773,6 +8764,7 @@ button:focus-visible {
   flex: 0 0 var(--settings-layout-classic-card-width);
   width: var(--settings-layout-classic-card-width);
   height: 85%;
+  margin-right: var(--settings-layout-classic-gap);
   aspect-ratio: 2.1 / 1;
   background: rgba(255, 255, 255, 0.3);
   background: rgb(255 255 255 / 0.3);
@@ -8789,17 +8781,17 @@ button:focus-visible {
 }
 
 .settings-layout-preview-classic-row.is-top {
-  top: 4%;
+  top: var(--settings-layout-classic-row-spacing);
 }
 
 .settings-layout-preview-classic-row.is-featured {
-  top: 35.333%;
+  top: calc(var(--settings-layout-classic-row-spacing) * 2 + var(--settings-layout-classic-row-height));
   animation: settingsLayoutClassicPreviewScroll 4s linear infinite;
   will-change: transform;
 }
 
 .settings-layout-preview-classic-row.is-bottom {
-  top: 66.666%;
+  top: calc(var(--settings-layout-classic-row-spacing) * 3 + var(--settings-layout-classic-row-height) * 2);
 }
 
 .settings-layout-card.focused .settings-layout-preview,
@@ -17068,13 +17060,13 @@ html.no-css-grid .cast-detail-meta {
 }
 
 .no-aspect-ratio .settings-layout-preview-modern-card {
-  flex-basis: 78px;
-  width: 78px;
+  flex-basis: var(--settings-layout-modern-card-width);
+  width: var(--settings-layout-modern-card-width);
 }
 
 .no-aspect-ratio .settings-layout-preview-classic-card {
-  flex-basis: 118px;
-  width: 118px;
+  flex-basis: var(--settings-layout-classic-card-width);
+  width: var(--settings-layout-classic-card-width);
 }
 
 .no-css-math .settings-layout-preview-modern-hero {
@@ -17087,43 +17079,43 @@ html.no-css-grid .cast-detail-meta {
 .no-css-math .settings-layout-preview-modern-row {
   top: 73%;
   left: 5%;
-  width: 1776px;
+  width: max-content;
   height: 24%;
   gap: 0;
   animation-name: settingsLayoutModernPreviewScrollLegacy;
 }
 
 .no-css-math .settings-layout-preview-modern-card {
-  flex: 0 0 134px;
-  width: 134px;
+  flex: 0 0 var(--settings-layout-modern-card-width);
+  width: var(--settings-layout-modern-card-width);
   height: 100%;
-  margin-right: 14px;
+  margin-right: var(--settings-layout-modern-gap);
 }
 
 .no-css-math .settings-layout-preview-grid-canvas {
   display: grid;
-  top: 2.5%;
-  left: 2.5%;
-  width: 95%;
-  height: 822px;
-  grid-template-columns: repeat(5, 18%);
-  grid-auto-rows: 108px;
+  top: var(--settings-layout-grid-gap);
+  left: var(--settings-layout-grid-gap);
+  width: calc(100% - (var(--settings-layout-grid-gap) * 2));
+  height: var(--settings-layout-grid-canvas-height);
+  grid-template-columns: repeat(5, var(--settings-layout-grid-card-width));
+  grid-auto-rows: var(--settings-layout-grid-card-height);
   justify-content: space-between;
   align-content: flex-start;
   gap: 0;
-  row-gap: 11px;
-  column-gap: 0;
+  row-gap: var(--settings-layout-grid-gap);
+  column-gap: var(--settings-layout-grid-gap);
   animation-name: settingsLayoutGridPreviewScrollLegacy;
 }
 
 .no-css-math .settings-layout-preview-grid-cell {
   width: 100%;
-  height: 108px;
+  height: var(--settings-layout-grid-card-height);
 }
 
 .no-css-math .settings-layout-preview-classic-row {
   left: 4.5%;
-  width: 1883px;
+  width: max-content;
   gap: 0;
 }
 
@@ -17132,10 +17124,10 @@ html.no-css-grid .cast-detail-meta {
 }
 
 .no-css-math .settings-layout-preview-classic-card {
-  flex: 0 0 258px;
-  width: 258px;
+  flex: 0 0 var(--settings-layout-classic-card-width);
+  width: var(--settings-layout-classic-card-width);
   height: 85%;
-  margin-right: 11px;
+  margin-right: var(--settings-layout-classic-gap);
 }
 
 .no-css-grid .settings-layout-preview-grid-canvas {
@@ -17146,20 +17138,20 @@ html.no-css-grid .cast-detail-meta {
   gap: 0;
   row-gap: 12px;
   column-gap: 0;
-  height: 822px;
+  height: var(--settings-layout-grid-canvas-height);
 }
 
 .no-css-grid .settings-layout-preview-grid-cell {
-  flex: 0 0 18%;
-  width: 18%;
-  height: 108px;
-  margin-bottom: 11px;
+  flex: 0 0 var(--settings-layout-grid-card-width);
+  width: var(--settings-layout-grid-card-width);
+  height: var(--settings-layout-grid-card-height);
+  margin-bottom: var(--settings-layout-grid-gap);
   margin-right: 0;
 }
 
 .no-css-math.no-css-grid .settings-layout-preview-grid-cell {
-  flex: 0 0 18%;
-  width: 18%;
+  flex: 0 0 var(--settings-layout-grid-card-width);
+  width: var(--settings-layout-grid-card-width);
 }
 
 .no-css-math .settings-layout-preview {
@@ -17486,7 +17478,7 @@ html.no-css-grid .cast-detail-meta {
     transform: translateX(0);
   }
   to {
-    transform: translateX(-444px);
+    transform: translateX(calc(0px - var(--settings-layout-modern-cycle-width)));
   }
 }
 
@@ -17495,7 +17487,7 @@ html.no-css-grid .cast-detail-meta {
     transform: translateY(0);
   }
   to {
-    transform: translateY(-357px);
+    transform: translateY(calc(0px - var(--settings-layout-grid-cycle-height)));
   }
 }
 
@@ -17504,7 +17496,7 @@ html.no-css-grid .cast-detail-meta {
     transform: translateX(0);
   }
   to {
-    transform: translateX(-538px);
+    transform: translateX(calc(0px - var(--settings-layout-classic-cycle-width)));
   }
 }
 

--- a/css/components.css
+++ b/css/components.css
@@ -16839,8 +16839,223 @@ html.no-css-grid .cast-detail-meta {
   font-size: 26px;
 }
 
+.no-css-math .profile-editor-panel {
+  padding: 64px;
+  border-radius: 40px;
+}
+
+.no-css-math .profile-editor-header {
+  gap: 56px;
+  padding-left: 48px;
+}
+
+.no-css-math .profile-editor-heading-title {
+  font-size: 50px;
+}
+
+.no-css-math .profile-editor-heading-stack {
+  gap: 4px;
+}
+
+.no-css-math .profile-editor-heading-kicker {
+  font-size: 32px;
+}
+
+.no-css-math .profile-editor-heading-name {
+  font-size: 60px;
+}
+
+.no-css-math .profile-editor-body {
+  margin-top: 48px;
+  min-height: 720px;
+}
+
+.no-css-math .profile-editor-preview {
+  width: 560px;
+  padding: 104px 48px 48px;
+  gap: 36px;
+}
+
+.no-css-math .profile-editor-preview-avatar {
+  width: 210px;
+  height: 210px;
+  font-size: 80px;
+}
+
+.no-css-math .profile-editor-preview-name {
+  font-size: 42px;
+}
+
+.no-css-math .profile-editor-field-shell {
+  padding: 28px;
+  border-radius: 26px;
+}
+
+.no-css-math .profile-editor-name-input {
+  font-size: 30px;
+}
+
+.no-css-math .profile-editor-divider {
+  min-height: 640px;
+  margin-top: 68px;
+  margin-left: 36px;
+  margin-right: 36px;
+}
+
+.no-css-math .profile-editor-avatar-pane {
+  gap: 24px;
+}
+
+.no-css-math .profile-editor-avatar-title {
+  font-size: 26px;
+}
+
+.no-css-math .profile-editor-category-row {
+  gap: 16px;
+  row-gap: 16px;
+  padding-bottom: 8px;
+}
+
+.no-css-math .profile-editor-avatar-grid {
+  gap: 24px;
+  max-height: 420px;
+  padding: 8px 16px;
+}
+
+.no-css-math .profile-avatar-tile {
+  width: 160px;
+  height: 160px;
+}
+
+.no-css-math .profile-avatar-tile.is-selected,
+.no-css-math .profile-avatar-tile.focused {
+  box-shadow: inset 0 0 0 6px var(--focus-color);
+}
+
+.no-css-math .profile-editor-avatar-hint {
+  min-height: 48px;
+  margin-top: 8px;
+  font-size: 34px;
+}
+
+.no-css-math .profile-overlay-button {
+  padding: 24px 56px;
+  border-radius: 24px;
+  font-size: 30px;
+}
+
+.no-css-math .profile-editor-header .profile-overlay-button {
+  padding: 18px 44px;
+  border-radius: 22px;
+  font-size: 27px;
+}
+
+.no-css-math .poster-list-picker-dialog-panel {
+  max-height: 900px;
+}
+
+.no-css-math .profile-dialog {
+  width: 500px;
+  max-width: 92vw;
+}
+
+.no-aspect-ratio .settings-layout-preview-modern-card {
+  flex-basis: 78px;
+  width: 78px;
+}
+
+.no-aspect-ratio .settings-layout-preview-classic-card {
+  flex-basis: 118px;
+  width: 118px;
+}
+
+.no-css-grid .settings-layout-preview-grid-canvas {
+  display: flex;
+  flex-wrap: wrap;
+  align-content: flex-start;
+  justify-content: space-between;
+  gap: 0;
+  row-gap: 0;
+  column-gap: 0;
+  height: 660px;
+}
+
+.no-css-grid .settings-layout-preview-grid-cell {
+  flex: 0 0 18%;
+  width: 18%;
+  height: 82px;
+  margin-bottom: 2.5%;
+  margin-right: 0;
+}
+
+.no-css-grid .profile-editor-avatar-grid {
+  display: flex;
+  flex-wrap: wrap;
+  align-content: flex-start;
+}
+
+.no-css-grid .profile-avatar-tile {
+  flex: 0 0 160px;
+  width: 160px;
+  height: 160px;
+  margin: 0 24px 24px 0;
+}
+
+.no-css-grid .profile-avatar-tile:nth-child(4n) {
+  margin-right: 0;
+}
+
 /* Chromium 68 and older ignore flex gap. Keep these source-level fallbacks
    scoped to legacy feature classes so modern Chromium keeps the authored UI. */
+.no-flex-gap .profile-grid > * {
+  margin-right: 56px;
+  margin-bottom: 56px;
+}
+
+.no-flex-gap .home-nav-list > * + * {
+  margin-top: var(--legacy-sidebar-item-gap);
+}
+
+.no-flex-gap .home-sidebar.content-expanded .home-nav-item > * + * {
+  margin-left: 16px;
+}
+
+.no-flex-gap .home-profile-pill > * + * {
+  margin-left: 10px;
+}
+
+.no-flex-gap .modern-sidebar-nav-list > * + * {
+  margin-top: var(--modern-sidebar-list-gap);
+}
+
+.no-flex-gap .modern-sidebar-profile > * + * {
+  margin-left: 36px;
+}
+
+.no-flex-gap .modern-sidebar-nav-item > * + * {
+  margin-left: var(--modern-sidebar-button-gap);
+}
+
+.no-flex-gap .modern-sidebar-pill > * + * {
+  margin-left: 1px;
+}
+
+.no-flex-gap .modern-sidebar-pill-chip > * + * {
+  margin-left: var(--modern-sidebar-pill-chip-gap);
+}
+
+.no-css-vars.no-flex-gap .home-nav-list > * + * {
+  margin-top: 20px;
+}
+
+.no-css-vars.no-flex-gap .modern-sidebar-nav-list > * + * {
+  margin-top: 12px;
+}
+
+.no-css-vars.no-flex-gap .modern-sidebar-nav-item > * + * {
+  margin-left: 28px;
+}
+
 .no-flex-gap .search-sidebar > * + *,
 .no-flex-gap .settings-sidebar > * + * {
   margin-top: 28px;
@@ -17028,9 +17243,50 @@ html.no-css-grid .cast-detail-meta {
   margin-top: 16px;
 }
 
+.no-flex-gap .profile-editor-header > * + * {
+  margin-left: 56px;
+}
+
+.no-flex-gap .profile-editor-heading-stack > * + * {
+  margin-top: 4px;
+}
+
+.no-flex-gap .profile-editor-preview > * + * {
+  margin-top: 36px;
+}
+
+.no-flex-gap .profile-editor-avatar-pane > * + * {
+  margin-top: 24px;
+}
+
+.no-flex-gap .profile-editor-category-row > * {
+  margin-right: 16px;
+  margin-bottom: 16px;
+}
+
+.no-flex-gap .nuvio-dialog-panel > * + *,
+.no-flex-gap .nuvio-dialog-actions > * + * {
+  margin-top: 32px;
+}
+
+.no-flex-gap .poster-list-picker-actions > * + * {
+  margin-top: 20px;
+}
+
+.no-flex-gap .nuvio-dialog-button.poster-list-picker-list-button > * + * {
+  margin-left: 14px;
+}
+
 .no-flex-gap .settings-profile-pill > * + *,
 .no-flex-gap .settings-plugin-repo-actions > * + * {
   margin-left: 10px;
+}
+
+@media (max-height: 820px), (max-width: 1280px) {
+  .no-flex-gap .profile-grid > * {
+    margin-right: 44px;
+    margin-bottom: 44px;
+  }
 }
 
 .no-flex-gap .settings-plugin-builder > * + *,

--- a/css/components.css
+++ b/css/components.css
@@ -1861,6 +1861,10 @@ button:focus-visible {
   opacity: 1;
 }
 
+.home-shell.has-expanded-sidebar::before {
+  opacity: 1;
+}
+
 .root-sidebar-icon {
   width: 100%;
   height: 100%;
@@ -2134,6 +2138,10 @@ button:focus-visible {
 
 /* Collapsible sidebar takes no space — no margin needed */
 .home-shell:has(.home-sidebar[data-collapsible="true"]) .home-main {
+  margin-left: 0;
+}
+
+.home-shell.has-collapsible-sidebar .home-main {
   margin-left: 0;
 }
 
@@ -6427,6 +6435,7 @@ button:focus-visible {
 }
 
 .settings-root-sidebar-slot {
+  display: block;
   display: contents;
 }
 
@@ -6459,7 +6468,18 @@ button:focus-visible {
   margin-left: 64px;
 }
 
+.settings-shell.has-collapsible-sidebar .settings-workspace {
+  width: calc(100vw - 128px);
+  margin-left: 64px;
+}
+
 .settings-shell:has(.modern-sidebar-shell) .settings-workspace {
+  width: calc(100vw - 128px);
+  margin: 68px 64px 24px;
+  height: calc(100vh - 92px);
+}
+
+.settings-shell.has-modern-sidebar .settings-workspace {
   width: calc(100vw - 128px);
   margin: 68px 64px 24px;
   height: calc(100vh - 92px);
@@ -16414,6 +16434,346 @@ button:focus-visible {
 
 .no-aspect-ratio .cast-credit-poster {
   height: 360px;
+}
+
+.no-backdrop-filter .modern-sidebar-panel,
+.no-backdrop-filter .modern-sidebar-pill-chip,
+.no-backdrop-filter .player-pause-overlay,
+.no-backdrop-filter .detail-trailer-control-bar,
+.no-backdrop-filter .series-episode-card,
+.no-backdrop-filter .series-stream-panel,
+.no-backdrop-filter .stream-route-panel-shell,
+.no-backdrop-filter .settings-trakt-card,
+.no-backdrop-filter .settings-layout-badge {
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
+}
+
+.no-backdrop-filter .modern-sidebar-shell.blur-enabled .modern-sidebar-panel {
+  background:
+    linear-gradient(180deg, rgba(22, 24, 28, 0.96), rgba(22, 24, 28, 0.96)),
+    linear-gradient(180deg, #4a4f59, #3f454f, #40474f);
+}
+
+.no-backdrop-filter .modern-sidebar-shell.blur-enabled .modern-sidebar-pill-chip {
+  background:
+    linear-gradient(180deg, rgba(22, 24, 28, 0.92), rgba(22, 24, 28, 0.92)),
+    linear-gradient(180deg, #424851, #3b4149);
+}
+
+html.no-css-grid .qr-layout,
+html.no-css-grid .settings-workspace,
+html.no-css-grid .settings-trakt-panel,
+html.no-css-grid .cast-detail-hero-content,
+html.no-css-grid .stream-route-content,
+html.no-css-grid .addon-list-header,
+html.no-css-grid .parental-overlay-row {
+  display: flex;
+  flex-wrap: nowrap;
+}
+
+html.no-css-grid .qr-left-panel {
+  flex: 0 0 45%;
+  width: 45%;
+  margin-right: 36px;
+}
+
+html.no-css-grid .qr-card-panel {
+  flex: 1 1 0;
+  width: auto;
+}
+
+html.no-css-grid .settings-workspace {
+  align-items: stretch;
+}
+
+html.no-css-grid .settings-sidebar-frame {
+  flex: 0 0 440px;
+  width: 440px;
+  margin-right: 32px;
+}
+
+html.no-css-grid .settings-content-frame {
+  flex: 1 1 0;
+  width: auto;
+}
+
+html.no-css-grid .settings-trakt-hero {
+  flex: 0 0 45%;
+  width: 45%;
+  margin-right: 36px;
+}
+
+html.no-css-grid .settings-trakt-card {
+  flex: 1 1 0;
+  width: auto;
+}
+
+html.no-css-grid .settings-layout-grid,
+html.no-css-grid .settings-trakt-stats-row,
+html.no-css-grid .settings-trakt-grid-dialog .settings-dialog-list,
+html.no-css-grid .discover-grid,
+html.no-css-grid .library-grid,
+html.no-css-grid .seeall-grid,
+html.no-css-grid .series-episode-ratings-grid {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+html.no-css-grid .settings-layout-grid > *,
+html.no-css-grid .settings-trakt-stats-row > *,
+html.no-css-grid .settings-trakt-grid-dialog .settings-dialog-list > *,
+html.no-css-grid .discover-grid > *,
+html.no-css-grid .library-grid > *,
+html.no-css-grid .seeall-grid > *,
+html.no-css-grid .series-episode-ratings-grid > * {
+  margin-right: 24px;
+  margin-bottom: 24px;
+}
+
+html.no-css-grid .settings-layout-card {
+  flex: 0 0 calc((100% - 48px) / 3);
+  width: calc((100% - 48px) / 3);
+}
+
+html.no-css-grid .settings-trakt-stat {
+  flex: 0 0 25%;
+  width: 25%;
+}
+
+html.no-css-grid .discover-card,
+html.no-css-grid .discover-action-card,
+html.no-css-grid .seeall-card {
+  flex: 0 0 248px;
+  width: 248px;
+}
+
+html.no-css-grid .library-grid-card {
+  flex: 0 0 var(--library-poster-width, 252px);
+  width: var(--library-poster-width, 252px);
+}
+
+html.no-css-grid .cast-detail-avatar {
+  flex: 0 0 220px;
+  margin-right: 20px;
+}
+
+html.no-css-grid .cast-detail-meta {
+  flex: 1 1 0;
+}
+
+.no-css-vars {
+  background: #0d0d0d;
+  color: #fff;
+  font-family: "Inter", "Segoe UI", Arial, sans-serif;
+}
+
+.no-css-vars body,
+.no-css-vars #app,
+.no-css-vars .screen,
+.no-css-vars .settings-shell,
+.no-css-vars .library-shell,
+.no-css-vars .home-main,
+.no-css-vars .seeall-shell {
+  background: #0d0d0d;
+  color: #fff;
+}
+
+.no-css-vars .home-shell {
+  background:
+    radial-gradient(120% 90% at 75% 8%, rgba(190, 40, 18, 0.26), transparent 45%), #06090e;
+  color: #f8fbff;
+}
+
+.no-css-vars .home-sidebar {
+  width: 144px;
+  padding: 24px;
+  background: #0d0d0d;
+}
+
+.no-css-vars .home-sidebar.expanded {
+  width: 392px;
+  flex-basis: 392px;
+}
+
+.no-css-vars .home-sidebar[data-collapsible="true"]:not(.expanded) {
+  width: 0;
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.no-css-vars .home-main {
+  margin-left: 144px;
+}
+
+.no-css-vars .home-nav-list {
+  gap: 20px;
+}
+
+.no-css-vars .home-nav-item {
+  width: 96px;
+  height: 104px;
+  border-radius: 64px;
+  color: #808080;
+  font-family: "Inter", "Segoe UI", Arial, sans-serif;
+}
+
+.no-css-vars .home-sidebar.content-expanded .home-nav-item {
+  width: 312px;
+  padding: 0 28px 0 26px;
+  color: #b3b3b3;
+}
+
+.no-css-vars .home-nav-item.selected,
+.no-css-vars .home-sidebar.content-expanded .home-nav-item.selected {
+  background: #f5f5f5;
+  color: #111;
+}
+
+.no-css-vars .home-nav-item.focused,
+.no-css-vars .home-sidebar.content-expanded .home-nav-item.selected.focused {
+  background: #303030;
+  color: #fff;
+}
+
+.no-css-vars .home-sidebar.content-expanded .home-nav-item.focused {
+  transform: scale(1.1);
+}
+
+.no-css-vars .home-nav-icon-wrap,
+.no-css-vars .home-nav-icon {
+  width: 44px;
+  height: 44px;
+}
+
+.no-css-vars .home-nav-label {
+  font-size: 32px;
+}
+
+.no-css-vars .home-sidebar.content-expanded .home-nav-label {
+  width: 176px;
+}
+
+.no-css-vars .modern-sidebar-shell {
+  width: 368px;
+}
+
+.no-css-vars .modern-sidebar-shell.expanded:not(.opening):not(.collapsing) {
+  width: 524px;
+}
+
+.no-css-vars .modern-sidebar-panel {
+  top: 32px;
+  left: 28px;
+  width: 480px;
+  min-height: calc(100vh - 56px);
+  padding: 28px 24px;
+}
+
+.no-css-vars .modern-sidebar-nav-list {
+  gap: 12px;
+}
+
+.no-css-vars .modern-sidebar-profile,
+.no-css-vars .modern-sidebar-nav-item {
+  min-height: 108px;
+  width: 92%;
+  border-radius: 999px;
+  gap: 28px;
+}
+
+.no-css-vars .modern-sidebar-nav-label,
+.no-css-vars .modern-sidebar-pill-label {
+  font-size: 40px;
+}
+
+.no-css-vars .modern-sidebar-pill {
+  top: 32px;
+  left: 28px;
+}
+
+.no-css-vars .modern-sidebar-pill-chip {
+  min-height: 88px;
+  padding: 0 24px 0 10px;
+  gap: 18px;
+}
+
+.no-css-vars .settings-workspace {
+  width: calc(100vw - 208px);
+  height: calc(100vh - 96px);
+  margin: 48px 64px 48px 144px;
+  background: #1a1a1a;
+  border-color: #333;
+}
+
+.no-css-vars .settings-shell.has-collapsible-sidebar .settings-workspace,
+.no-css-vars .settings-shell.has-modern-sidebar .settings-workspace {
+  width: calc(100vw - 128px);
+  margin-left: 64px;
+}
+
+.no-css-vars .settings-nav-item,
+.no-css-vars .settings-action-row,
+.no-css-vars .settings-theme-card,
+.no-css-vars .settings-layout-card,
+.no-css-vars .library-action-button,
+.no-css-vars .qr-status,
+.no-css-vars .qr-action-btn,
+.no-css-vars .seeall-card-poster,
+.no-css-vars .discover-card-poster,
+.no-css-vars .library-grid-poster,
+.no-css-vars .stream-route-card {
+  background: #222;
+  color: #fff;
+  border-color: #333;
+}
+
+.no-css-vars .settings-nav-item.selected,
+.no-css-vars .settings-nav-item.focused,
+.no-css-vars .settings-action-row.focused,
+.no-css-vars .library-action-button.focused,
+.no-css-vars .qr-action-btn.focused {
+  background: #303030;
+  color: #fff;
+  border-color: #fff !important;
+}
+
+.no-css-vars .series-detail-shell {
+  color: #fff;
+  background: #0d0d0d;
+}
+
+.no-css-math .home-nav-label {
+  font-size: 32px;
+}
+
+.no-css-math .modern-sidebar-nav-label,
+.no-css-math .modern-sidebar-pill-label {
+  font-size: 40px;
+}
+
+.no-css-math .settings-nav-label {
+  font-size: 32px;
+}
+
+.no-css-math .library-picker-groups {
+  gap: 20px;
+  margin-bottom: 32px;
+}
+
+.no-css-math .library-picker-row {
+  gap: 24px;
+}
+
+.no-css-math .library-picker-anchor {
+  min-height: 100px;
+  padding: 18px 28px;
+  border-radius: 36px;
+  gap: 24px;
+}
+
+.no-css-math .library-grid-title {
+  font-size: 32px;
 }
 
 @supports not (font-size: clamp(1px, 2px, 3px)) {

--- a/css/components.css
+++ b/css/components.css
@@ -8517,6 +8517,7 @@ button:focus-visible {
   text-align: left;
   display: flex;
   flex-direction: column;
+  align-items: stretch;
   gap: 12px;
   position: relative;
   overflow: hidden;
@@ -8541,22 +8542,28 @@ button:focus-visible {
 }
 
 .settings-layout-preview {
+  width: 100%;
   height: 224px;
   border-radius: 24px;
   background: var(--bg-color);
   position: relative;
   overflow: hidden;
   display: block;
+  align-self: stretch;
+  box-sizing: border-box;
   isolation: isolate;
 }
 
 .settings-layout-preview-placeholder {
+  width: 100%;
   height: 224px;
   border-radius: 24px;
   background: var(--bg-elevated);
+  box-sizing: border-box;
   padding: 20px;
   display: flex;
   flex-direction: column;
+  align-self: stretch;
   gap: 16px;
 }
 
@@ -8596,8 +8603,13 @@ button:focus-visible {
   display: none;
 }
 
-.settings-layout-card:not(.focused):not(.is-selected) .settings-layout-preview {
+.settings-layout-card .settings-layout-preview {
   display: none;
+}
+
+.settings-layout-card.focused .settings-layout-preview,
+.settings-layout-card.is-selected .settings-layout-preview {
+  display: block;
 }
 
 .settings-layout-preview::after {
@@ -8640,11 +8652,11 @@ button:focus-visible {
   position: relative;
   display: block;
   width: 100%;
-  height: 100%;
+  height: 224px;
   --settings-layout-modern-side: 5%;
   --settings-layout-modern-top: 6%;
   --settings-layout-modern-gap: 3%;
-  --settings-layout-modern-card-width: 18.5%;
+  --settings-layout-modern-card-width: 78px;
   --settings-layout-modern-cycle-width: calc(
     var(--settings-layout-modern-card-width) + var(--settings-layout-modern-gap) +
       var(--settings-layout-modern-card-width) + var(--settings-layout-modern-gap) +
@@ -8694,7 +8706,7 @@ button:focus-visible {
   position: relative;
   display: block;
   width: 100%;
-  height: 100%;
+  height: 224px;
   --settings-layout-grid-gap: 2.5%;
   --settings-layout-grid-card-width: calc((100% - (var(--settings-layout-grid-gap) * 4)) / 5);
   --settings-layout-grid-card-height: calc(var(--settings-layout-grid-card-width) * 1.4);
@@ -8737,7 +8749,7 @@ button:focus-visible {
   position: relative;
   display: block;
   width: 100%;
-  height: 100%;
+  height: 224px;
   --settings-layout-classic-side: 4.5%;
   --settings-layout-classic-gap: 2.5%;
   --settings-layout-classic-card-width: 18.2%;
@@ -15920,6 +15932,30 @@ button:focus-visible {
   animation: streamRouteSpin 700ms linear infinite !important;
 }
 
+.performance-constrained .settings-layout-preview-modern-row {
+  animation: settingsLayoutModernPreviewScroll 5.7s linear infinite !important;
+}
+
+.performance-constrained .settings-layout-preview-grid-canvas {
+  animation: settingsLayoutGridPreviewScroll 8.8s linear infinite !important;
+}
+
+.performance-constrained .settings-layout-preview-classic-row.is-featured {
+  animation: settingsLayoutClassicPreviewScroll 4s linear infinite !important;
+}
+
+.performance-constrained.no-css-math .settings-layout-preview-modern-row {
+  animation: settingsLayoutModernPreviewScrollLegacy 5.7s linear infinite !important;
+}
+
+.performance-constrained.no-css-math .settings-layout-preview-grid-canvas {
+  animation: settingsLayoutGridPreviewScrollLegacy 8.8s linear infinite !important;
+}
+
+.performance-constrained.no-css-math .settings-layout-preview-classic-row.is-featured {
+  animation: settingsLayoutClassicPreviewScrollLegacy 4s linear infinite !important;
+}
+
 .performance-constrained .nuvio-route-slide-enter,
 .performance-constrained .home-route-content-enter,
 .performance-constrained .addons-route-enter,
@@ -17051,17 +17087,17 @@ html.no-css-grid .cast-detail-meta {
 .no-css-math .settings-layout-preview-modern-row {
   top: 73%;
   left: 5%;
-  width: 780px;
+  width: 1776px;
   height: 24%;
   gap: 0;
   animation-name: settingsLayoutModernPreviewScrollLegacy;
 }
 
 .no-css-math .settings-layout-preview-modern-card {
-  flex: 0 0 78px;
-  width: 78px;
+  flex: 0 0 134px;
+  width: 134px;
   height: 100%;
-  margin-right: 12px;
+  margin-right: 14px;
 }
 
 .no-css-math .settings-layout-preview-grid-canvas {
@@ -17069,25 +17105,25 @@ html.no-css-grid .cast-detail-meta {
   top: 2.5%;
   left: 2.5%;
   width: 95%;
-  height: 660px;
+  height: 822px;
   grid-template-columns: repeat(5, 18%);
-  grid-auto-rows: 82px;
+  grid-auto-rows: 108px;
   justify-content: space-between;
   align-content: flex-start;
   gap: 0;
-  row-gap: 12px;
+  row-gap: 11px;
   column-gap: 0;
   animation-name: settingsLayoutGridPreviewScrollLegacy;
 }
 
 .no-css-math .settings-layout-preview-grid-cell {
   width: 100%;
-  height: 82px;
+  height: 108px;
 }
 
 .no-css-math .settings-layout-preview-classic-row {
   left: 4.5%;
-  width: 920px;
+  width: 1883px;
   gap: 0;
 }
 
@@ -17096,10 +17132,10 @@ html.no-css-grid .cast-detail-meta {
 }
 
 .no-css-math .settings-layout-preview-classic-card {
-  flex: 0 0 118px;
-  width: 118px;
+  flex: 0 0 258px;
+  width: 258px;
   height: 85%;
-  margin-right: 14px;
+  margin-right: 11px;
 }
 
 .no-css-grid .settings-layout-preview-grid-canvas {
@@ -17110,14 +17146,14 @@ html.no-css-grid .cast-detail-meta {
   gap: 0;
   row-gap: 12px;
   column-gap: 0;
-  height: 660px;
+  height: 822px;
 }
 
 .no-css-grid .settings-layout-preview-grid-cell {
   flex: 0 0 18%;
   width: 18%;
-  height: 82px;
-  margin-bottom: 12px;
+  height: 108px;
+  margin-bottom: 11px;
   margin-right: 0;
 }
 
@@ -17134,112 +17170,6 @@ html.no-css-grid .cast-detail-meta {
 .no-css-math .settings-layout-preview-grid,
 .no-css-math .settings-layout-preview-classic {
   overflow: hidden;
-}
-
-.no-css-math .settings-layout-preview-modern::before,
-.no-css-math .settings-layout-preview-modern::after,
-.no-css-math .settings-layout-preview-grid::before,
-.no-css-math .settings-layout-preview-grid::after,
-.no-css-math .settings-layout-preview-classic::before,
-.no-css-math .settings-layout-preview-classic::after {
-  content: "";
-  display: block;
-  position: absolute;
-  pointer-events: none;
-  z-index: 0;
-}
-
-.no-css-math .settings-layout-preview-modern::before {
-  top: 6%;
-  left: 5%;
-  width: 90%;
-  height: 62%;
-  border-radius: 6px;
-  background: rgba(255, 255, 255, 0.38);
-}
-
-.no-css-math .settings-layout-preview-modern::after {
-  left: 5%;
-  bottom: 7%;
-  width: 78px;
-  height: 24%;
-  border-radius: 5px;
-  background: rgba(255, 255, 255, 0.28);
-  box-shadow:
-    90px 0 0 rgba(255, 255, 255, 0.46),
-    180px 0 0 rgba(255, 255, 255, 0.28),
-    270px 0 0 rgba(255, 255, 255, 0.28),
-    360px 0 0 rgba(255, 255, 255, 0.46),
-    450px 0 0 rgba(255, 255, 255, 0.28),
-    540px 0 0 rgba(255, 255, 255, 0.28);
-  animation: settingsLayoutModernPreviewShadowScrollLegacy 5.7s linear infinite;
-  will-change: transform;
-}
-
-.no-css-math .settings-layout-preview-grid::before {
-  top: 2.5%;
-  left: 2.5%;
-  width: 18%;
-  height: 82px;
-  border-radius: 5px;
-  background: rgba(255, 255, 255, 0.5);
-  box-shadow:
-    20.5% 0 0 rgba(255, 255, 255, 0.5),
-    41% 0 0 rgba(255, 255, 255, 0.5),
-    61.5% 0 0 rgba(255, 255, 255, 0.5),
-    82% 0 0 rgba(255, 255, 255, 0.5),
-    0 94px 0 rgba(255, 255, 255, 0.5),
-    20.5% 94px 0 rgba(255, 255, 255, 0.5),
-    41% 94px 0 rgba(255, 255, 255, 0.5),
-    61.5% 94px 0 rgba(255, 255, 255, 0.5),
-    82% 94px 0 rgba(255, 255, 255, 0.5),
-    0 188px 0 rgba(255, 255, 255, 0.3),
-    20.5% 188px 0 rgba(255, 255, 255, 0.3),
-    41% 188px 0 rgba(255, 255, 255, 0.3),
-    61.5% 188px 0 rgba(255, 255, 255, 0.3),
-    82% 188px 0 rgba(255, 255, 255, 0.3),
-    0 282px 0 rgba(255, 255, 255, 0.5),
-    20.5% 282px 0 rgba(255, 255, 255, 0.5),
-    41% 282px 0 rgba(255, 255, 255, 0.5),
-    61.5% 282px 0 rgba(255, 255, 255, 0.5),
-    82% 282px 0 rgba(255, 255, 255, 0.5),
-    0 376px 0 rgba(255, 255, 255, 0.5),
-    20.5% 376px 0 rgba(255, 255, 255, 0.5),
-    41% 376px 0 rgba(255, 255, 255, 0.5),
-    61.5% 376px 0 rgba(255, 255, 255, 0.5),
-    82% 376px 0 rgba(255, 255, 255, 0.5);
-  animation: settingsLayoutGridPreviewShadowScrollLegacy 8.8s linear infinite;
-  will-change: transform;
-}
-
-.no-css-math .settings-layout-preview-classic::before,
-.no-css-math .settings-layout-preview-classic::after {
-  left: 4.5%;
-  width: 118px;
-  height: 25%;
-  border-radius: 5px;
-  background: rgba(255, 255, 255, 0.3);
-  box-shadow:
-    132px 0 0 rgba(255, 255, 255, 0.3),
-    264px 0 0 rgba(255, 255, 255, 0.3),
-    396px 0 0 rgba(255, 255, 255, 0.3);
-}
-
-.no-css-math .settings-layout-preview-classic::before {
-  top: 4%;
-}
-
-.no-css-math .settings-layout-preview-classic::after {
-  top: 35.333%;
-  background: rgba(255, 255, 255, 0.6);
-  box-shadow:
-    132px 0 0 rgba(255, 255, 255, 0.6),
-    264px 0 0 rgba(255, 255, 255, 0.6),
-    396px 0 0 rgba(255, 255, 255, 0.6),
-    528px 0 0 rgba(255, 255, 255, 0.6),
-    660px 0 0 rgba(255, 255, 255, 0.6);
-  animation: settingsLayoutClassicPreviewShadowScrollLegacy 4s linear infinite;
-  will-change: transform;
 }
 
 .no-css-grid .profile-editor-avatar-grid {
@@ -17556,7 +17486,7 @@ html.no-css-grid .cast-detail-meta {
     transform: translateX(0);
   }
   to {
-    transform: translateX(-270px);
+    transform: translateX(-444px);
   }
 }
 
@@ -17565,7 +17495,7 @@ html.no-css-grid .cast-detail-meta {
     transform: translateY(0);
   }
   to {
-    transform: translateY(-282px);
+    transform: translateY(-357px);
   }
 }
 
@@ -17574,34 +17504,7 @@ html.no-css-grid .cast-detail-meta {
     transform: translateX(0);
   }
   to {
-    transform: translateX(-264px);
-  }
-}
-
-@keyframes settingsLayoutModernPreviewShadowScrollLegacy {
-  from {
-    transform: translateX(0);
-  }
-  to {
-    transform: translateX(-270px);
-  }
-}
-
-@keyframes settingsLayoutGridPreviewShadowScrollLegacy {
-  from {
-    transform: translateY(0);
-  }
-  to {
-    transform: translateY(-282px);
-  }
-}
-
-@keyframes settingsLayoutClassicPreviewShadowScrollLegacy {
-  from {
-    transform: translateX(0);
-  }
-  to {
-    transform: translateX(-264px);
+    transform: translateX(-538px);
   }
 }
 

--- a/css/components.css
+++ b/css/components.css
@@ -722,6 +722,10 @@ button:focus-visible {
 .profile-editor-backdrop,
 .profile-dialog-backdrop {
   position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
   inset: 0;
   background: rgba(0, 0, 0, 0.85);
   display: flex;
@@ -732,6 +736,10 @@ button:focus-visible {
 
 .profile-pin-layer {
   position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
   inset: 0;
   display: flex;
   align-items: center;
@@ -1396,6 +1404,10 @@ button:focus-visible {
 /* Backdrop / scrim — ATV dialogs dim the app heavily behind the focused panel. */
 .nuvio-dialog-backdrop {
   position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
   inset: 0;
   background: rgba(0, 0, 0, 0.84);
   display: flex;
@@ -2165,6 +2177,10 @@ button:focus-visible {
 
 .modern-sidebar-shell {
   position: absolute;
+  top: 0;
+  right: auto;
+  bottom: 0;
+  left: 0;
   inset: 0 auto 0 0;
   width: var(--modern-sidebar-collapsed-width);
   z-index: 18;

--- a/css/components.css
+++ b/css/components.css
@@ -8530,6 +8530,7 @@ button:focus-visible {
   padding: 6px 12px;
   border-radius: 999px;
   border: 1px solid var(--border-color);
+  background: rgba(26, 26, 26, 0.94);
   background: rgb(var(--bg-elevated-rgb) / 0.94);
   color: var(--text-secondary);
   font-size: 12px;
@@ -8552,7 +8553,12 @@ button:focus-visible {
 .settings-layout-preview::after {
   content: "";
   position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
   inset: 0;
+  border: 1px solid rgba(255, 255, 255, 0.05);
   border: 1px solid rgb(255 255 255 / 0.05);
   border-radius: inherit;
   pointer-events: none;
@@ -8598,6 +8604,7 @@ button:focus-visible {
   width: calc(100% - (var(--settings-layout-modern-side) * 2));
   height: 62%;
   border-radius: 6px;
+  background: rgba(255, 255, 255, 0.38);
   background: rgb(255 255 255 / 0.38);
 }
 
@@ -8618,10 +8625,12 @@ button:focus-visible {
   flex: 0 0 auto;
   height: 100%;
   aspect-ratio: 1.45 / 1;
+  background: rgba(255, 255, 255, 0.28);
   background: rgb(255 255 255 / 0.28);
 }
 
 .settings-layout-preview-modern-card.is-strong {
+  background: rgba(255, 255, 255, 0.46);
   background: rgb(255 255 255 / 0.46);
 }
 
@@ -8654,10 +8663,12 @@ button:focus-visible {
 .settings-layout-preview-grid-cell {
   width: 100%;
   height: 100%;
+  background: rgba(255, 255, 255, 0.5);
   background: rgb(255 255 255 / 0.5);
 }
 
 .settings-layout-preview-grid-cell.is-dim {
+  background: rgba(255, 255, 255, 0.3);
   background: rgb(255 255 255 / 0.3);
 }
 
@@ -8685,10 +8696,12 @@ button:focus-visible {
   flex: 0 0 auto;
   height: 85%;
   aspect-ratio: 2.1 / 1;
+  background: rgba(255, 255, 255, 0.3);
   background: rgb(255 255 255 / 0.3);
 }
 
 .settings-layout-preview-classic-card.is-strong {
+  background: rgba(255, 255, 255, 0.6);
   background: rgb(255 255 255 / 0.6);
 }
 

--- a/css/components.css
+++ b/css/components.css
@@ -8550,6 +8550,56 @@ button:focus-visible {
   isolation: isolate;
 }
 
+.settings-layout-preview-placeholder {
+  height: 224px;
+  border-radius: 24px;
+  background: var(--bg-elevated);
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.settings-layout-placeholder-line,
+.settings-layout-placeholder-panel {
+  display: block;
+  background: var(--border-color);
+}
+
+.settings-layout-placeholder-line {
+  height: 20px;
+  border-radius: 999px;
+}
+
+.settings-layout-placeholder-line.is-short {
+  width: 70%;
+}
+
+.settings-layout-placeholder-panel {
+  flex: 1 1 auto;
+  min-height: 0;
+  border-radius: 20px;
+  background: var(--bg-color);
+}
+
+.settings-layout-placeholder-bars {
+  display: flex;
+  gap: 12px;
+}
+
+.settings-layout-placeholder-bars .settings-layout-placeholder-line {
+  flex: 1 1 0;
+}
+
+.settings-layout-card.focused .settings-layout-preview-placeholder,
+.settings-layout-card.is-selected .settings-layout-preview-placeholder {
+  display: none;
+}
+
+.settings-layout-card:not(.focused):not(.is-selected) .settings-layout-preview {
+  display: none;
+}
+
 .settings-layout-preview::after {
   content: "";
   position: absolute;
@@ -8595,6 +8645,11 @@ button:focus-visible {
   --settings-layout-modern-top: 6%;
   --settings-layout-modern-gap: 3%;
   --settings-layout-modern-card-width: 18.5%;
+  --settings-layout-modern-cycle-width: calc(
+    var(--settings-layout-modern-card-width) + var(--settings-layout-modern-gap) +
+      var(--settings-layout-modern-card-width) + var(--settings-layout-modern-gap) +
+      var(--settings-layout-modern-card-width) + var(--settings-layout-modern-gap)
+  );
 }
 
 .settings-layout-preview-modern-hero {
@@ -8617,12 +8672,13 @@ button:focus-visible {
   align-items: stretch;
   gap: var(--settings-layout-modern-gap);
   width: max-content;
-  animation: settingsLayoutModernPreviewScroll 4.2s linear infinite;
-  will-change: left;
+  animation: settingsLayoutModernPreviewScroll 5.7s linear infinite;
+  will-change: transform;
 }
 
 .settings-layout-preview-modern-card {
-  flex: 0 0 auto;
+  flex: 0 0 var(--settings-layout-modern-card-width);
+  width: var(--settings-layout-modern-card-width);
   height: 100%;
   aspect-ratio: 1.45 / 1;
   background: rgba(255, 255, 255, 0.28);
@@ -8642,6 +8698,11 @@ button:focus-visible {
   --settings-layout-grid-gap: 2.5%;
   --settings-layout-grid-card-width: calc((100% - (var(--settings-layout-grid-gap) * 4)) / 5);
   --settings-layout-grid-card-height: calc(var(--settings-layout-grid-card-width) * 1.4);
+  --settings-layout-grid-cycle-height: calc(
+    var(--settings-layout-grid-card-height) + var(--settings-layout-grid-gap) +
+      var(--settings-layout-grid-card-height) + var(--settings-layout-grid-gap) +
+      var(--settings-layout-grid-card-height) + var(--settings-layout-grid-gap)
+  );
 }
 
 .settings-layout-preview-grid-canvas {
@@ -8656,8 +8717,8 @@ button:focus-visible {
   grid-template-columns: repeat(5, var(--settings-layout-grid-card-width));
   grid-auto-rows: var(--settings-layout-grid-card-height);
   gap: var(--settings-layout-grid-gap);
-  animation: settingsLayoutGridPreviewScroll 4s linear infinite;
-  will-change: top;
+  animation: settingsLayoutGridPreviewScroll 8.8s linear infinite;
+  will-change: transform;
 }
 
 .settings-layout-preview-grid-cell {
@@ -8680,6 +8741,10 @@ button:focus-visible {
   --settings-layout-classic-side: 4.5%;
   --settings-layout-classic-gap: 2.5%;
   --settings-layout-classic-card-width: 18.2%;
+  --settings-layout-classic-cycle-width: calc(
+    var(--settings-layout-classic-card-width) + var(--settings-layout-classic-gap) +
+      var(--settings-layout-classic-card-width) + var(--settings-layout-classic-gap)
+  );
 }
 
 .settings-layout-preview-classic-row {
@@ -8693,7 +8758,8 @@ button:focus-visible {
 }
 
 .settings-layout-preview-classic-card {
-  flex: 0 0 auto;
+  flex: 0 0 var(--settings-layout-classic-card-width);
+  width: var(--settings-layout-classic-card-width);
   height: 85%;
   aspect-ratio: 2.1 / 1;
   background: rgba(255, 255, 255, 0.3);
@@ -8717,7 +8783,7 @@ button:focus-visible {
 .settings-layout-preview-classic-row.is-featured {
   top: 35.333%;
   animation: settingsLayoutClassicPreviewScroll 4s linear infinite;
-  will-change: left;
+  will-change: transform;
 }
 
 .settings-layout-preview-classic-row.is-bottom {
@@ -8731,34 +8797,28 @@ button:focus-visible {
 
 @keyframes settingsLayoutClassicPreviewScroll {
   from {
-    left: var(--settings-layout-classic-side);
+    transform: translateX(0);
   }
   to {
-    left: calc(
-      var(--settings-layout-classic-side) -
-        ((var(--settings-layout-classic-card-width) + var(--settings-layout-classic-gap)) * 2)
-    );
+    transform: translateX(calc(0px - var(--settings-layout-classic-cycle-width)));
   }
 }
 
 @keyframes settingsLayoutGridPreviewScroll {
   from {
-    top: var(--settings-layout-grid-gap);
+    transform: translateY(0);
   }
   to {
-    top: calc(var(--settings-layout-grid-gap) - (var(--settings-layout-grid-card-height) * 1.5));
+    transform: translateY(calc(0px - var(--settings-layout-grid-cycle-height)));
   }
 }
 
 @keyframes settingsLayoutModernPreviewScroll {
   from {
-    left: var(--settings-layout-modern-side);
+    transform: translateX(0);
   }
   to {
-    left: calc(
-      var(--settings-layout-modern-side) -
-        ((var(--settings-layout-modern-card-width) + var(--settings-layout-modern-gap)) * 2.2)
-    );
+    transform: translateX(calc(0px - var(--settings-layout-modern-cycle-width)));
   }
 }
 
@@ -16767,6 +16827,18 @@ html.no-css-grid .cast-detail-meta {
   border-color: #fff !important;
 }
 
+.no-css-vars .settings-layout-preview-placeholder {
+  background: #242424;
+}
+
+.no-css-vars .settings-layout-placeholder-line {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.no-css-vars .settings-layout-placeholder-panel {
+  background: #121212;
+}
+
 .no-css-vars .series-detail-shell {
   color: #fff;
   background: #0d0d0d;
@@ -17003,7 +17075,7 @@ html.no-css-grid .cast-detail-meta {
   justify-content: space-between;
   align-content: flex-start;
   gap: 0;
-  row-gap: 0;
+  row-gap: 12px;
   column-gap: 0;
   animation-name: settingsLayoutGridPreviewScrollLegacy;
 }
@@ -17036,7 +17108,7 @@ html.no-css-grid .cast-detail-meta {
   align-content: flex-start;
   justify-content: space-between;
   gap: 0;
-  row-gap: 0;
+  row-gap: 12px;
   column-gap: 0;
   height: 660px;
 }
@@ -17045,7 +17117,7 @@ html.no-css-grid .cast-detail-meta {
   flex: 0 0 18%;
   width: 18%;
   height: 82px;
-  margin-bottom: 2.5%;
+  margin-bottom: 12px;
   margin-right: 0;
 }
 
@@ -17096,8 +17168,12 @@ html.no-css-grid .cast-detail-meta {
   box-shadow:
     90px 0 0 rgba(255, 255, 255, 0.46),
     180px 0 0 rgba(255, 255, 255, 0.28),
-    270px 0 0 rgba(255, 255, 255, 0.28);
-  animation: settingsLayoutModernPreviewShadowScrollLegacy 4.2s linear infinite;
+    270px 0 0 rgba(255, 255, 255, 0.28),
+    360px 0 0 rgba(255, 255, 255, 0.46),
+    450px 0 0 rgba(255, 255, 255, 0.28),
+    540px 0 0 rgba(255, 255, 255, 0.28);
+  animation: settingsLayoutModernPreviewShadowScrollLegacy 5.7s linear infinite;
+  will-change: transform;
 }
 
 .no-css-math .settings-layout-preview-grid::before {
@@ -17116,8 +17192,24 @@ html.no-css-grid .cast-detail-meta {
     20.5% 94px 0 rgba(255, 255, 255, 0.5),
     41% 94px 0 rgba(255, 255, 255, 0.5),
     61.5% 94px 0 rgba(255, 255, 255, 0.5),
-    82% 94px 0 rgba(255, 255, 255, 0.5);
-  animation: settingsLayoutGridPreviewShadowScrollLegacy 4s linear infinite;
+    82% 94px 0 rgba(255, 255, 255, 0.5),
+    0 188px 0 rgba(255, 255, 255, 0.3),
+    20.5% 188px 0 rgba(255, 255, 255, 0.3),
+    41% 188px 0 rgba(255, 255, 255, 0.3),
+    61.5% 188px 0 rgba(255, 255, 255, 0.3),
+    82% 188px 0 rgba(255, 255, 255, 0.3),
+    0 282px 0 rgba(255, 255, 255, 0.5),
+    20.5% 282px 0 rgba(255, 255, 255, 0.5),
+    41% 282px 0 rgba(255, 255, 255, 0.5),
+    61.5% 282px 0 rgba(255, 255, 255, 0.5),
+    82% 282px 0 rgba(255, 255, 255, 0.5),
+    0 376px 0 rgba(255, 255, 255, 0.5),
+    20.5% 376px 0 rgba(255, 255, 255, 0.5),
+    41% 376px 0 rgba(255, 255, 255, 0.5),
+    61.5% 376px 0 rgba(255, 255, 255, 0.5),
+    82% 376px 0 rgba(255, 255, 255, 0.5);
+  animation: settingsLayoutGridPreviewShadowScrollLegacy 8.8s linear infinite;
+  will-change: transform;
 }
 
 .no-css-math .settings-layout-preview-classic::before,
@@ -17143,8 +17235,11 @@ html.no-css-grid .cast-detail-meta {
   box-shadow:
     132px 0 0 rgba(255, 255, 255, 0.6),
     264px 0 0 rgba(255, 255, 255, 0.6),
-    396px 0 0 rgba(255, 255, 255, 0.6);
+    396px 0 0 rgba(255, 255, 255, 0.6),
+    528px 0 0 rgba(255, 255, 255, 0.6),
+    660px 0 0 rgba(255, 255, 255, 0.6);
   animation: settingsLayoutClassicPreviewShadowScrollLegacy 4s linear infinite;
+  will-change: transform;
 }
 
 .no-css-grid .profile-editor-avatar-grid {
@@ -17402,6 +17497,14 @@ html.no-css-grid .cast-detail-meta {
   margin-top: 16px;
 }
 
+.no-flex-gap .settings-layout-preview-placeholder > * + * {
+  margin-top: 16px;
+}
+
+.no-flex-gap .settings-layout-placeholder-bars > * + * {
+  margin-left: 12px;
+}
+
 .no-flex-gap .profile-editor-header > * + * {
   margin-left: 56px;
 }
@@ -17450,55 +17553,55 @@ html.no-css-grid .cast-detail-meta {
 
 @keyframes settingsLayoutModernPreviewScrollLegacy {
   from {
-    left: 5%;
+    transform: translateX(0);
   }
   to {
-    left: -44%;
+    transform: translateX(-270px);
   }
 }
 
 @keyframes settingsLayoutGridPreviewScrollLegacy {
   from {
-    top: 2.5%;
+    transform: translateY(0);
   }
   to {
-    top: -52%;
+    transform: translateY(-282px);
   }
 }
 
 @keyframes settingsLayoutClassicPreviewScrollLegacy {
   from {
-    left: 4.5%;
+    transform: translateX(0);
   }
   to {
-    left: -36%;
+    transform: translateX(-264px);
   }
 }
 
 @keyframes settingsLayoutModernPreviewShadowScrollLegacy {
   from {
-    left: 5%;
+    transform: translateX(0);
   }
   to {
-    left: -44%;
+    transform: translateX(-270px);
   }
 }
 
 @keyframes settingsLayoutGridPreviewShadowScrollLegacy {
   from {
-    top: 2.5%;
+    transform: translateY(0);
   }
   to {
-    top: -52%;
+    transform: translateY(-282px);
   }
 }
 
 @keyframes settingsLayoutClassicPreviewShadowScrollLegacy {
   from {
-    left: 4.5%;
+    transform: translateX(0);
   }
   to {
-    left: -36%;
+    transform: translateX(-264px);
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -1,5 +1,8 @@
 <!doctype html>
-<html lang="en">
+<html
+  lang="en"
+  class="no-flex-gap no-css-grid no-css-vars no-css-math no-backdrop-filter no-aspect-ratio"
+>
   <head>
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
@@ -8,6 +11,54 @@
       content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
     />
     <script>
+      (function detectLegacyFeatureSupport() {
+        var root = document.documentElement;
+        function removeClass(name) {
+          root.className = (" " + root.className + " ")
+            .replace(new RegExp(" " + name + " ", "g"), " ")
+            .replace(/^\s+|\s+$/g, "");
+        }
+        function supports(prop, value) {
+          var css = window.CSS;
+          return Boolean(css && typeof css.supports === "function" && css.supports(prop, value));
+        }
+        try {
+          var test = document.createElement("div");
+          var child = document.createElement("div");
+          test.style.position = "absolute";
+          test.style.left = "-9999px";
+          test.style.top = "-9999px";
+          test.style.display = "flex";
+          test.style.flexDirection = "column";
+          test.style.rowGap = "1px";
+          child.style.height = "1px";
+          test.appendChild(child.cloneNode());
+          test.appendChild(child.cloneNode());
+          root.appendChild(test);
+          if (test.scrollHeight === 3) {
+            removeClass("no-flex-gap");
+          }
+          root.removeChild(test);
+        } catch (error) {
+          removeClass("no-flex-gap");
+        }
+        if (supports("display", "grid")) {
+          removeClass("no-css-grid");
+        }
+        if (supports("--nuvio-probe", "0")) {
+          removeClass("no-css-vars");
+        }
+        if (supports("font-size", "clamp(1px, 2px, 3px)")) {
+          removeClass("no-css-math");
+        }
+        if (supports("aspect-ratio", "1 / 1")) {
+          removeClass("no-aspect-ratio");
+        }
+        if (supports("backdrop-filter", "blur(1px)") || supports("-webkit-backdrop-filter", "blur(1px)")) {
+          removeClass("no-backdrop-filter");
+        }
+      })();
+
       (function configureTizenLaunch() {
         var root = typeof globalThis !== "undefined" ? globalThis : window;
         var search = String((window.location && window.location.search) || "").toLowerCase();

--- a/js/app.js
+++ b/js/app.js
@@ -1,3 +1,5 @@
+import "core-js/stable/url";
+import "core-js/stable/url-search-params";
 import "./runtime/polyfills.js";
 import "intersection-observer";
 import "whatwg-fetch";
@@ -101,23 +103,73 @@ function supportsAspectRatio() {
   return css.supports("aspect-ratio", "1 / 1");
 }
 
+function supportsCssGrid() {
+  const css = globalThis.CSS;
+  if (!css || typeof css.supports !== "function") {
+    return false;
+  }
+  return css.supports("display", "grid");
+}
+
+function supportsCssVars() {
+  const css = globalThis.CSS;
+  if (!css || typeof css.supports !== "function") {
+    return false;
+  }
+  return css.supports("--nuvio-probe", "0");
+}
+
+function supportsCssMath() {
+  const css = globalThis.CSS;
+  if (!css || typeof css.supports !== "function") {
+    return false;
+  }
+  return css.supports("font-size", "clamp(1px, 2px, 3px)");
+}
+
+function supportsBackdropFilter() {
+  const css = globalThis.CSS;
+  if (!css || typeof css.supports !== "function") {
+    return false;
+  }
+  return (
+    css.supports("backdrop-filter", "blur(1px)") ||
+    css.supports("-webkit-backdrop-filter", "blur(1px)")
+  );
+}
+
 function applyPerformanceMode() {
   const constrained = Platform.isWebOS() || Platform.isTizen() || isLowEndDevice();
   const webOsMajorVersion = Platform.isWebOS() ? Number(Platform.getWebOsMajorVersion() || 0) : 0;
   const legacyWebOs = webOsMajorVersion > 0 && webOsMajorVersion <= 6;
+  const legacyWebOs38 = webOsMajorVersion > 0 && webOsMajorVersion <= 3;
   const legacyTizen = Platform.isTizen();
   const flexGapUnsupported = !supportsFlexGap();
   const aspectRatioUnsupported = !supportsAspectRatio();
+  const cssGridUnsupported = !supportsCssGrid();
+  const cssVarsUnsupported = !supportsCssVars();
+  const cssMathUnsupported = !supportsCssMath();
+  const backdropFilterUnsupported = !supportsBackdropFilter();
   document.documentElement.classList.toggle("performance-constrained", constrained);
   document.body.classList.toggle("performance-constrained", constrained);
   document.documentElement.classList.toggle("legacy-webos", legacyWebOs);
   document.body.classList.toggle("legacy-webos", legacyWebOs);
+  document.documentElement.classList.toggle("legacy-webos38", legacyWebOs38);
+  document.body.classList.toggle("legacy-webos38", legacyWebOs38);
   document.documentElement.classList.toggle("legacy-tizen", legacyTizen);
   document.body.classList.toggle("legacy-tizen", legacyTizen);
   document.documentElement.classList.toggle("no-flex-gap", flexGapUnsupported);
   document.body.classList.toggle("no-flex-gap", flexGapUnsupported);
   document.documentElement.classList.toggle("no-aspect-ratio", aspectRatioUnsupported);
   document.body.classList.toggle("no-aspect-ratio", aspectRatioUnsupported);
+  document.documentElement.classList.toggle("no-css-grid", cssGridUnsupported);
+  document.body.classList.toggle("no-css-grid", cssGridUnsupported);
+  document.documentElement.classList.toggle("no-css-vars", cssVarsUnsupported);
+  document.body.classList.toggle("no-css-vars", cssVarsUnsupported);
+  document.documentElement.classList.toggle("no-css-math", cssMathUnsupported);
+  document.body.classList.toggle("no-css-math", cssMathUnsupported);
+  document.documentElement.classList.toggle("no-backdrop-filter", backdropFilterUnsupported);
+  document.body.classList.toggle("no-backdrop-filter", backdropFilterUnsupported);
 }
 
 function isAddonRemoteMode() {

--- a/js/runtime/polyfills.js
+++ b/js/runtime/polyfills.js
@@ -528,3 +528,41 @@ function installElementScrollToPolyfill(target) {
 
 installElementScrollToPolyfill(globalThis.Element && globalThis.Element.prototype);
 installElementScrollToPolyfill(globalThis.HTMLElement && globalThis.HTMLElement.prototype);
+
+if (globalThis.Element && !Element.prototype.remove) {
+  Object.defineProperty(Element.prototype, "remove", {
+    value: function removePolyfill() {
+      if (this.parentNode) {
+        this.parentNode.removeChild(this);
+      }
+    },
+    configurable: true,
+    writable: true
+  });
+}
+
+if (globalThis.Node && !("isConnected" in Node.prototype)) {
+  Object.defineProperty(Node.prototype, "isConnected", {
+    get: function isConnectedPolyfill() {
+      var root = globalThis.document && globalThis.document.documentElement;
+      return Boolean(root && root.contains(this));
+    },
+    configurable: true
+  });
+}
+
+if (globalThis.Element && Element.prototype.scrollIntoView) {
+  (function installScrollIntoViewOptionsFallback() {
+    var nativeScrollIntoView = Element.prototype.scrollIntoView;
+    Element.prototype.scrollIntoView = function scrollIntoViewPolyfill(arg) {
+      try {
+        return nativeScrollIntoView.call(this, arg);
+      } catch (error) {
+        if (arg && typeof arg === "object") {
+          return nativeScrollIntoView.call(this, false);
+        }
+        throw error;
+      }
+    };
+  })();
+}

--- a/js/ui/components/nuvioDialog.js
+++ b/js/ui/components/nuvioDialog.js
@@ -75,6 +75,14 @@ export class NuvioDialog {
     this._keyUpHandler = this._onKeyUp.bind(this);
   }
 
+  _scheduleFrame(callback) {
+    if (typeof requestAnimationFrame === "function") {
+      requestAnimationFrame(callback);
+      return;
+    }
+    setTimeout(callback, 0);
+  }
+
   _eventKey(e) {
     const key = String(e?.key || "");
     const keyName = String(e?.keyName || e?.detail?.keyName || "");
@@ -172,10 +180,10 @@ export class NuvioDialog {
     window.addEventListener("keyup", this._keyUpHandler, { capture: true });
 
     // Focus first button after 2 frames (matches ATV LaunchedEffect repeat(2) { withFrameNanos })
-    requestAnimationFrame(() => requestAnimationFrame(() => this._focusIndex(0)));
+    this._scheduleFrame(() => this._scheduleFrame(() => this._focusIndex(0)));
 
     // Trigger enter animation
-    requestAnimationFrame(() => {
+    this._scheduleFrame(() => {
       backdrop.classList.add("nuvio-dialog-backdrop-enter");
       panel.classList.add("nuvio-dialog-panel-enter");
     });
@@ -202,11 +210,25 @@ export class NuvioDialog {
 
   _setButtonSelected(el, selected) {
     el.classList.toggle("selected", selected);
-    const existing = el.querySelector(":scope > .nuvio-dialog-button-check");
+    let existing = null;
+    for (let index = 0; index < el.children.length; index += 1) {
+      const child = el.children[index];
+      if (child && child.classList && child.classList.contains("nuvio-dialog-button-check")) {
+        existing = child;
+        break;
+      }
+    }
     if (selected && !existing) {
-      el.prepend(this._createCheckElement());
+      const check = this._createCheckElement();
+      if (el.firstChild) {
+        el.insertBefore(check, el.firstChild);
+      } else {
+        el.appendChild(check);
+      }
     } else if (!selected && existing) {
-      existing.remove();
+      if (existing.parentNode) {
+        existing.parentNode.removeChild(existing);
+      }
     }
   }
 

--- a/js/ui/components/sidebarNavigation.js
+++ b/js/ui/components/sidebarNavigation.js
@@ -79,6 +79,25 @@ function itemLabel(item) {
   return t(item?.labelKey, {}, String(item?.label || item?.route || ""));
 }
 
+function syncSidebarStateClasses(container) {
+  const root = container?.closest?.(".home-shell, .settings-shell, .library-shell") || container;
+  if (!root?.classList) {
+    return;
+  }
+
+  const legacySidebar = root.querySelector?.(".root-sidebar-legacy");
+  const modernSidebar = root.querySelector?.(".modern-sidebar-shell");
+  root.classList.toggle("has-modern-sidebar", Boolean(modernSidebar));
+  root.classList.toggle(
+    "has-collapsible-sidebar",
+    Boolean(legacySidebar?.getAttribute("data-collapsible") === "true")
+  );
+  root.classList.toggle(
+    "has-expanded-sidebar",
+    Boolean(legacySidebar?.classList?.contains("expanded") || modernSidebar?.classList?.contains("expanded"))
+  );
+}
+
 function getSidebarTextFitTargets(container) {
   return Array.from(
     container?.querySelectorAll(
@@ -464,6 +483,7 @@ export function bindRootSidebarEvents(
     });
 
   scheduleRootSidebarTextFit(container);
+  syncSidebarStateClasses(container);
 }
 
 export function setLegacySidebarExpanded(container, expanded) {
@@ -479,14 +499,17 @@ export function setLegacySidebarExpanded(container, expanded) {
   if (shouldExpand) {
     sidebar.classList.add("opening");
     sidebar.classList.add("content-expanded");
+    syncSidebarStateClasses(container);
     void sidebar.offsetWidth;
     requestAnimationFrame(() => {
       sidebar.classList.add("expanded");
+      syncSidebarStateClasses(container);
     });
     sidebar._legacyOpenTimer = setTimeout(() => {
       sidebar.classList.remove("opening");
       sidebar._legacyOpenTimer = null;
       scheduleRootSidebarTextFit(container);
+      syncSidebarStateClasses(container);
     }, 350);
     scheduleRootSidebarTextFit(container);
     return;
@@ -494,10 +517,12 @@ export function setLegacySidebarExpanded(container, expanded) {
 
   sidebar.classList.remove("opening");
   sidebar.classList.remove("content-expanded");
+  syncSidebarStateClasses(container);
   void sidebar.offsetWidth;
   requestAnimationFrame(() => {
     sidebar.classList.remove("expanded");
     scheduleRootSidebarTextFit(container);
+    syncSidebarStateClasses(container);
   });
   scheduleRootSidebarTextFit(container);
 }
@@ -617,6 +642,7 @@ export function setModernSidebarExpanded(container, expanded) {
   if (expanded) {
     shell.classList.add("panel-visible", "opening");
     shell.classList.remove("collapsing");
+    syncSidebarStateClasses(container);
     if (panel) {
       panel.setAttribute("aria-hidden", "false");
     }
@@ -625,11 +651,13 @@ export function setModernSidebarExpanded(container, expanded) {
     }
     requestAnimationFrame(() => {
       shell.classList.add("expanded");
+      syncSidebarStateClasses(container);
     });
     shell._modernOpenTimer = setTimeout(() => {
       shell.classList.remove("opening");
       shell._modernOpenTimer = null;
       scheduleRootSidebarTextFit(container);
+      syncSidebarStateClasses(container);
     }, 365);
     scheduleRootSidebarTextFit(container);
     return true;
@@ -637,12 +665,14 @@ export function setModernSidebarExpanded(container, expanded) {
 
   shell.classList.add("collapsing");
   shell.classList.remove("opening");
+  syncSidebarStateClasses(container);
   if (pill) {
     pill.setAttribute("aria-expanded", "false");
   }
   shell._modernCloseStartTimer = setTimeout(() => {
     shell.classList.remove("expanded");
     shell._modernCloseStartTimer = null;
+    syncSidebarStateClasses(container);
   }, 70);
   shell._modernCloseEndTimer = setTimeout(() => {
     shell.classList.remove("panel-visible", "collapsing");
@@ -651,6 +681,7 @@ export function setModernSidebarExpanded(container, expanded) {
     }
     shell._modernCloseEndTimer = null;
     scheduleRootSidebarTextFit(container);
+    syncSidebarStateClasses(container);
   }, 430);
   scheduleRootSidebarTextFit(container);
   return true;

--- a/js/ui/screens/settings/settingsScreen.js
+++ b/js/ui/screens/settings/settingsScreen.js
@@ -629,7 +629,7 @@ function renderLayoutPreviewMarkup(layoutId) {
       <span class="settings-layout-preview-modern-stage">
         <span class="settings-layout-preview-modern-hero"></span>
         <span class="settings-layout-preview-modern-row">
-          ${Array.from({ length: 9 }, (_, index) => `<span class="settings-layout-preview-modern-card${index % 3 === 1 ? " is-strong" : ""}"></span>`).join("")}
+          ${Array.from({ length: 12 }, (_, index) => `<span class="settings-layout-preview-modern-card${index % 3 === 1 ? " is-strong" : ""}"></span>`).join("")}
         </span>
       </span>
     `;
@@ -658,6 +658,20 @@ function renderLayoutPreviewMarkup(layoutId) {
       </span>
       <span class="settings-layout-preview-classic-row is-bottom">
         ${Array.from({ length: 7 }, () => '<span class="settings-layout-preview-classic-card"></span>').join("")}
+      </span>
+    </span>
+  `;
+}
+
+function renderLayoutPreviewPlaceholderMarkup() {
+  return `
+    <span class="settings-layout-preview-placeholder" aria-hidden="true">
+      <span class="settings-layout-placeholder-line is-short"></span>
+      <span class="settings-layout-placeholder-panel"></span>
+      <span class="settings-layout-placeholder-bars">
+        <span class="settings-layout-placeholder-line"></span>
+        <span class="settings-layout-placeholder-line"></span>
+        <span class="settings-layout-placeholder-line"></span>
       </span>
     </span>
   `;
@@ -1940,6 +1954,7 @@ export const SettingsScreen = {
               data-zone="content"
               ${this.registerAction(focusKey, this.actionMap.get(focusKey))}>
         <span class="settings-layout-badge">${escapeHtml(t("common.beta", {}, "Beta"))}</span>
+        ${renderLayoutPreviewPlaceholderMarkup()}
         <span class="settings-layout-preview settings-layout-preview-${escapeHtml(option.id)}">${renderLayoutPreviewMarkup(option.id)}</span>
         <span class="settings-layout-name">${escapeHtml(translateOptionLabel(option))}</span>
       </button>

--- a/js/ui/screens/settings/settingsScreen.js
+++ b/js/ui/screens/settings/settingsScreen.js
@@ -677,6 +677,77 @@ function renderLayoutPreviewPlaceholderMarkup() {
   `;
 }
 
+function setLayoutPreviewMetric(node, name, value) {
+  if (!node?.style || !Number.isFinite(value)) return;
+  node.style.setProperty(name, `${Math.round(value * 100) / 100}px`);
+}
+
+function syncLayoutPreviewMetrics(root) {
+  const previews = Array.from(root?.querySelectorAll?.(".settings-layout-preview") || []);
+  previews.forEach((preview) => {
+    const card = preview.closest?.(".settings-layout-card");
+    const cardRect = card?.getBoundingClientRect?.();
+    if (!card || !cardRect) return;
+
+    const cardStyle = getComputedStyle(card);
+    const previewStyle = getComputedStyle(preview);
+    const paddingX =
+      (parseFloat(cardStyle.paddingLeft) || 0) + (parseFloat(cardStyle.paddingRight) || 0);
+    const borderX =
+      (parseFloat(cardStyle.borderLeftWidth) || 0) + (parseFloat(cardStyle.borderRightWidth) || 0);
+    const previewRect = preview.getBoundingClientRect?.();
+    const width = Math.max(
+      0,
+      previewRect?.width || cardRect.width - paddingX - borderX
+    );
+    const height = Math.max(0, parseFloat(previewStyle.height) || previewRect?.height || 224);
+    if (!width || !height) return;
+
+    if (preview.classList.contains("settings-layout-preview-modern")) {
+      const cardHeight = height * 0.24;
+      const cardWidth = cardHeight * 1.45;
+      const gap = width * 0.03;
+      setLayoutPreviewMetric(preview, "--settings-layout-modern-card-width", cardWidth);
+      setLayoutPreviewMetric(preview, "--settings-layout-modern-gap", gap);
+      setLayoutPreviewMetric(preview, "--settings-layout-modern-cycle-width", (cardWidth + gap) * 3);
+      return;
+    }
+
+    if (preview.classList.contains("settings-layout-preview-grid")) {
+      const gap = width * 0.025;
+      const cardWidth = (width - gap * 6) / 5;
+      const cardHeight = cardWidth * 1.4;
+      setLayoutPreviewMetric(preview, "--settings-layout-grid-gap", gap);
+      setLayoutPreviewMetric(preview, "--settings-layout-grid-card-width", cardWidth);
+      setLayoutPreviewMetric(preview, "--settings-layout-grid-card-height", cardHeight);
+      setLayoutPreviewMetric(preview, "--settings-layout-grid-canvas-height", cardHeight * 7 + gap * 6);
+      setLayoutPreviewMetric(preview, "--settings-layout-grid-cycle-height", (cardHeight + gap) * 3);
+      return;
+    }
+
+    if (preview.classList.contains("settings-layout-preview-classic")) {
+      const rowSpacing = height * 0.04;
+      const rowHeight = (height - rowSpacing * 4) / 3;
+      const cardWidth = width / 5.5;
+      const gap = width / 40;
+      setLayoutPreviewMetric(preview, "--settings-layout-classic-row-spacing", rowSpacing);
+      setLayoutPreviewMetric(preview, "--settings-layout-classic-row-height", rowHeight);
+      setLayoutPreviewMetric(preview, "--settings-layout-classic-card-width", cardWidth);
+      setLayoutPreviewMetric(preview, "--settings-layout-classic-gap", gap);
+      setLayoutPreviewMetric(preview, "--settings-layout-classic-cycle-width", (cardWidth + gap) * 2);
+    }
+  });
+}
+
+function syncLayoutPreviewMetricsSoon(root) {
+  if (!root) return;
+  if (typeof requestAnimationFrame === "function") {
+    requestAnimationFrame(() => syncLayoutPreviewMetrics(root));
+    return;
+  }
+  syncLayoutPreviewMetrics(root);
+}
+
 function iconSvg(path, className = "settings-inline-icon", viewBox = "0 0 24 24") {
   return `<svg class="${className}" viewBox="${viewBox}" aria-hidden="true" focusable="false">${path}</svg>`;
 }
@@ -5007,6 +5078,7 @@ export const SettingsScreen = {
     bindSettingsScrollIndicators(this.container);
     this.settingsRouteEnterPending = false;
     this.applyFocus();
+    syncLayoutPreviewMetricsSoon(this.container);
     updateSettingsRailIndicatorsSoon(navSlot);
     updateSettingsScrollIndicatorsSoon(contentSlot);
   },

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -20,6 +20,414 @@ const tempBundlePath = path.join(cacheDir, "__app.bundle.build.js");
 const requireConfiguredRuntimeEnv = /^(1|true|yes|on)$/i.test(
   String(process.env.NUVIO_REQUIRE_LOCAL_PROPERTIES || "")
 );
+const legacyViewport = {
+  width: 1920,
+  height: 1080,
+  remPx: 20
+};
+const rgbVariableFallbacks = {
+  "--bg-color-rgb": "13 13 13",
+  "--bg-elevated-rgb": "26 26 26",
+  "--card-bg-rgb": "34 34 34",
+  "--secondary-color-rgb": "245 245 245",
+  "--focus-color-rgb": "255 255 255"
+};
+
+function splitTopLevelSpaces(value) {
+  const parts = [];
+  let current = "";
+  let depth = 0;
+
+  for (const char of value) {
+    if (char === "(") {
+      depth += 1;
+    } else if (char === ")") {
+      depth = Math.max(0, depth - 1);
+    }
+
+    if (/\s/.test(char) && depth === 0) {
+      if (current.trim()) {
+        parts.push(current.trim());
+        current = "";
+      }
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (current.trim()) {
+    parts.push(current.trim());
+  }
+
+  return parts;
+}
+
+function splitFunctionArgs(value) {
+  const args = [];
+  let current = "";
+  let depth = 0;
+
+  for (const char of value) {
+    if (char === "(") {
+      depth += 1;
+    } else if (char === ")") {
+      depth = Math.max(0, depth - 1);
+    }
+
+    if (char === "," && depth === 0) {
+      args.push(current.trim());
+      current = "";
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (current.trim()) {
+    args.push(current.trim());
+  }
+
+  return args;
+}
+
+function toLegacyLengthValue(value) {
+  let result = value.trim();
+  let changed = true;
+
+  while (changed) {
+    changed = false;
+    result = result.replace(/\b(min|max|clamp)\(([^()]*(?:\([^()]*\)[^()]*)*)\)/g, (match, fn, argsText) => {
+      const args = splitFunctionArgs(argsText).map(toLegacyLengthValue);
+      const computed = computeLegacyMathValue(fn, args);
+      const replacement =
+        computed || (fn === "clamp" ? args[2] || args[1] || args[0] : chooseStaticMathFallback(fn, args));
+      changed = true;
+      return replacement || match;
+    });
+  }
+
+  return result;
+}
+
+function parseLengthToPx(value) {
+  const match = String(value || "")
+    .trim()
+    .match(/^(-?\d*\.?\d+)(px|vw|vh|rem)$/i);
+  if (!match) {
+    return null;
+  }
+
+  const amount = Number(match[1]);
+  const unit = match[2].toLowerCase();
+  if (!Number.isFinite(amount)) {
+    return null;
+  }
+  if (unit === "px") {
+    return amount;
+  }
+  if (unit === "vw") {
+    return (amount * legacyViewport.width) / 100;
+  }
+  if (unit === "vh") {
+    return (amount * legacyViewport.height) / 100;
+  }
+  if (unit === "rem") {
+    return amount * legacyViewport.remPx;
+  }
+  return null;
+}
+
+function formatPx(value) {
+  const rounded = Math.round(value * 1000) / 1000;
+  return `${String(rounded).replace(/\.0+$/, "").replace(/(\.\d*?)0+$/, "$1")}px`;
+}
+
+function computeLegacyMathValue(fn, args) {
+  const values = args.map(parseLengthToPx);
+  if (values.some((value) => value === null)) {
+    return "";
+  }
+
+  if (fn === "min") {
+    return formatPx(Math.min(...values));
+  }
+  if (fn === "max") {
+    return formatPx(Math.max(...values));
+  }
+  if (fn === "clamp") {
+    const min = values[0];
+    const preferred = values[1] ?? min;
+    const max = values[2] ?? preferred;
+    return formatPx(Math.max(min, Math.min(max, preferred)));
+  }
+  return "";
+}
+
+function chooseStaticMathFallback(fn, args) {
+  const parseable = args
+    .map((value) => ({ value, px: parseLengthToPx(value) }))
+    .filter((entry) => entry.px !== null);
+  if (!parseable.length) {
+    return args[args.length - 1] || "";
+  }
+  if (fn === "max") {
+    return parseable.reduce((max, entry) => (entry.px > max.px ? entry : max), parseable[0]).value;
+  }
+  if (fn === "min") {
+    return parseable.reduce((min, entry) => (entry.px < min.px ? entry : min), parseable[0]).value;
+  }
+  return args[2] || args[1] || args[0] || "";
+}
+
+function splitRgbChannels(channels) {
+  const parts = String(channels || "")
+    .trim()
+    .split(/\s+/)
+    .map((part) => Number(part));
+  if (parts.length < 3 || parts.some((part) => !Number.isFinite(part))) {
+    return null;
+  }
+  return parts.slice(0, 3);
+}
+
+function toLegacyColorValue(value) {
+  let result = String(value || "");
+
+  result = result.replace(
+    /\brgba?\(\s*var\((--[\w-]+)\)\s*\/\s*([^)]+?)\s*\)/g,
+    (match, variableName, alpha) => {
+      const channels = splitRgbChannels(rgbVariableFallbacks[variableName]);
+      if (!channels) {
+        return match;
+      }
+      return `rgba(${channels[0]}, ${channels[1]}, ${channels[2]}, ${alpha.trim()})`;
+    }
+  );
+
+  result = result.replace(
+    /\brgba?\(\s*(-?\d*\.?\d+)\s+(-?\d*\.?\d+)\s+(-?\d*\.?\d+)\s*\/\s*([^)]+?)\s*\)/g,
+    (_match, red, green, blue, alpha) => `rgba(${red}, ${green}, ${blue}, ${alpha.trim()})`
+  );
+
+  return result;
+}
+
+function insertInsetFallbacks(decl) {
+  if (decl.prop.toLowerCase() !== "inset") {
+    return;
+  }
+
+  const values = splitTopLevelSpaces(decl.value);
+  if (!values.length || values.length > 4) {
+    return;
+  }
+
+  const top = values[0];
+  const right = values[1] || top;
+  const bottom = values[2] || top;
+  const left = values[3] || right;
+  const fallbacks = [
+    ["top", top],
+    ["right", right],
+    ["bottom", bottom],
+    ["left", left]
+  ];
+
+  for (const [prop, value] of fallbacks) {
+    decl.cloneBefore({ prop, value });
+  }
+}
+
+function legacyDeclarationFallbackPlugin() {
+  return {
+    postcssPlugin: "nuvio-legacy-declaration-fallbacks",
+    Declaration(decl) {
+      insertInsetFallbacks(decl);
+
+      const legacyValue = toLegacyColorValue(toLegacyLengthValue(decl.value));
+      if (legacyValue && legacyValue !== decl.value) {
+        const previous = decl.prev();
+        if (!previous || previous.type !== "decl" || previous.prop !== decl.prop || previous.value !== legacyValue) {
+          decl.cloneBefore({ value: legacyValue });
+        }
+      }
+    }
+  };
+}
+
+legacyDeclarationFallbackPlugin.postcss = true;
+
+function unsupportedSelectorFallbackPlugin() {
+  return {
+    postcssPlugin: "nuvio-unsupported-selector-fallbacks",
+    Rule(rule) {
+      if (!rule.selector || !rule.selectors?.length) {
+        return;
+      }
+
+      const safeSelectors = rule.selectors.filter(
+        (selector) => !selector.includes(":focus-visible") && !selector.includes(":has(")
+      );
+      if (!safeSelectors.length || safeSelectors.length === rule.selectors.length) {
+        return;
+      }
+
+      const fallback = rule.clone({ selectors: safeSelectors });
+      rule.before(fallback);
+    }
+  };
+}
+
+unsupportedSelectorFallbackPlugin.postcss = true;
+
+function gridFallbackPlugin() {
+  return {
+    postcssPlugin: "nuvio-grid-fallback",
+    Rule(rule) {
+      if (!rule.selector) {
+        return;
+      }
+
+      let displayGrid = false;
+      let rowGap = null;
+      let columnGap = null;
+
+      rule.walkDecls((decl) => {
+        const prop = decl.prop.toLowerCase();
+        if (prop === "display" && /\bgrid\b/.test(decl.value)) {
+          displayGrid = true;
+          return;
+        }
+        if (prop === "gap") {
+          const values = splitTopLevelSpaces(decl.value).map(toLegacyLengthValue);
+          rowGap = values[0] || "0";
+          columnGap = values[1] || rowGap;
+          return;
+        }
+        if (prop === "row-gap") {
+          rowGap = toLegacyLengthValue(decl.value);
+          return;
+        }
+        if (prop === "column-gap") {
+          columnGap = toLegacyLengthValue(decl.value);
+        }
+      });
+
+      if (!displayGrid) {
+        return;
+      }
+
+      rowGap ||= "0";
+      columnGap ||= "0";
+      const scopedSelectors = rule.selectors.map((selector) => `html.no-css-grid ${selector}`);
+      const fallback = postcss.rule({ selectors: scopedSelectors });
+      fallback.append({ prop: "display", value: "flex" });
+      fallback.append({ prop: "flex-wrap", value: "wrap" });
+
+      const childFallback = postcss.rule({
+        selectors: scopedSelectors.map((selector) => `${selector} > *`)
+      });
+      childFallback.append({ prop: "margin-right", value: columnGap });
+      childFallback.append({ prop: "margin-bottom", value: rowGap });
+
+      rule.after(childFallback);
+      rule.after(fallback);
+    }
+  };
+}
+
+gridFallbackPlugin.postcss = true;
+
+function flexGapFallbackPlugin() {
+  return {
+    postcssPlugin: "nuvio-flex-gap-fallback",
+    Rule(rule) {
+      if (!rule.selector || rule.parent?.type === "atrule" && /keyframes$/i.test(rule.parent.name)) {
+        return;
+      }
+
+      let displayFlex = false;
+      let rowGap = null;
+      let columnGap = null;
+      let flexDirection = "row";
+      let flexWrap = "nowrap";
+
+      rule.walkDecls((decl) => {
+        const prop = decl.prop.toLowerCase();
+        if (prop === "display" && /\b(?:inline-)?flex\b/.test(decl.value)) {
+          displayFlex = true;
+          return;
+        }
+
+        if (prop === "flex-direction") {
+          flexDirection = decl.value.toLowerCase();
+          return;
+        }
+
+        if (prop === "flex-wrap") {
+          flexWrap = decl.value.toLowerCase();
+          return;
+        }
+
+        if (prop === "flex-flow") {
+          const value = decl.value.toLowerCase();
+          if (value.includes("column")) {
+            flexDirection = "column";
+          }
+          if (value.includes("wrap")) {
+            flexWrap = "wrap";
+          }
+          return;
+        }
+
+        if (prop === "gap") {
+          const values = splitTopLevelSpaces(decl.value).map(toLegacyLengthValue);
+          rowGap = values[0] || "0";
+          columnGap = values[1] || rowGap;
+          return;
+        }
+
+        if (prop === "row-gap") {
+          rowGap = toLegacyLengthValue(decl.value);
+          return;
+        }
+
+        if (prop === "column-gap") {
+          columnGap = toLegacyLengthValue(decl.value);
+        }
+      });
+
+      if (!displayFlex || (!rowGap && !columnGap)) {
+        return;
+      }
+
+      rowGap ||= "0";
+      columnGap ||= "0";
+
+      const scopedSelectors = rule.selectors.map((selector) => `html.no-flex-gap ${selector}`);
+      const isColumnDirection = flexDirection.includes("column");
+      const wraps = flexWrap.includes("wrap");
+      const childFallback = postcss.rule({
+        selectors: scopedSelectors.map((selector) => `${selector} > * + *`)
+      });
+
+      if (isColumnDirection) {
+        childFallback.append({ prop: "margin-top", value: rowGap });
+      } else if (wraps) {
+        childFallback.selectors = scopedSelectors.map((selector) => `${selector} > *`);
+        childFallback.append({ prop: "margin-right", value: columnGap });
+        childFallback.append({ prop: "margin-bottom", value: rowGap });
+      } else {
+        childFallback.append({ prop: "margin-left", value: columnGap });
+      }
+
+      rule.after(childFallback);
+    }
+  };
+}
+
+flexGapFallbackPlugin.postcss = true;
 
 async function buildCSS() {
   console.log("processing CSS with PostCSS (legacy support)...");
@@ -36,6 +444,10 @@ async function buildCSS() {
       postcssGlobalData({ files: [path.join(cssDir, "base.css")] }),
       postcssCustomProperties({ preserve: true }),
       autoprefixer({ overrideBrowserslist: ["Chrome 38"], grid: "autoplace" }),
+      legacyDeclarationFallbackPlugin(),
+      unsupportedSelectorFallbackPlugin(),
+      gridFallbackPlugin(),
+      flexGapFallbackPlugin(),
       cssnano()
     ]).process(css, { from: cssPath, to: outPath });
 

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -407,7 +407,7 @@ function flexGapFallbackPlugin() {
 
       const scopedSelectors = rule.selectors.map((selector) => `html.no-flex-gap ${selector}`);
       const isColumnDirection = flexDirection.includes("column");
-      const wraps = flexWrap.includes("wrap");
+      const wraps = flexWrap.includes("wrap") && !flexWrap.includes("nowrap");
       const childFallback = postcss.rule({
         selectors: scopedSelectors.map((selector) => `${selector} > * + *`)
       });

--- a/scripts/package-tizen.mjs
+++ b/scripts/package-tizen.mjs
@@ -21,6 +21,56 @@ const defaultTizenAppId = "NuvioTV001.NuvioTV";
 const defaultWidgetUri = "https://nuvio.tv";
 const tizenEngineFsServiceRelativePath = "services/tizen/enginefs-service.js";
 const tizenEngineFsRuntimeDirRelativePath = "services/tizen/runtime";
+const flexGapDetectionScript = `  <script>
+    (function detectLegacyFeatureSupport() {
+      var root = document.documentElement;
+      function removeClass(name) {
+        root.className = (" " + root.className + " ")
+          .replace(new RegExp(" " + name + " ", "g"), " ")
+          .replace(/^\\s+|\\s+$/g, "");
+      }
+      function supports(prop, value) {
+        var css = window.CSS;
+        return Boolean(css && typeof css.supports === "function" && css.supports(prop, value));
+      }
+      try {
+        var test = document.createElement("div");
+        var child = document.createElement("div");
+        test.style.position = "absolute";
+        test.style.left = "-9999px";
+        test.style.top = "-9999px";
+        test.style.display = "flex";
+        test.style.flexDirection = "column";
+        test.style.rowGap = "1px";
+        child.style.height = "1px";
+        test.appendChild(child.cloneNode());
+        test.appendChild(child.cloneNode());
+        root.appendChild(test);
+        if (test.scrollHeight === 3) {
+          removeClass("no-flex-gap");
+        }
+        root.removeChild(test);
+      } catch (error) {
+        removeClass("no-flex-gap");
+      }
+      if (supports("display", "grid")) {
+        removeClass("no-css-grid");
+      }
+      if (supports("--nuvio-probe", "0")) {
+        removeClass("no-css-vars");
+      }
+      if (supports("font-size", "clamp(1px, 2px, 3px)")) {
+        removeClass("no-css-math");
+      }
+      if (supports("aspect-ratio", "1 / 1")) {
+        removeClass("no-aspect-ratio");
+      }
+      if (supports("backdrop-filter", "blur(1px)") || supports("-webkit-backdrop-filter", "blur(1px)")) {
+        removeClass("no-backdrop-filter");
+      }
+    })();
+  </script>
+`;
 
 function normalizeVersion(version) {
   const parts = String(version || "0.0.0")
@@ -80,13 +130,13 @@ function buildConfigXml({ appId, packageId, version }) {
 
 function buildIndexHtml() {
   return `<!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="no-flex-gap no-css-grid no-css-vars no-css-math no-backdrop-filter no-aspect-ratio">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=1920, height=1080, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <title>${appName}</title>
-  <link rel="stylesheet" href="css/base.css" />
+${flexGapDetectionScript}  <link rel="stylesheet" href="css/base.css" />
   <link rel="stylesheet" href="css/layout.css" />
   <link rel="stylesheet" href="css/components.css" />
   <link rel="stylesheet" href="css/themes.css" />
@@ -125,6 +175,7 @@ if (tvInput && typeof tvInput.registerKey === "function") {
 
 function loadScript(src) {
   var script = document.createElement("script");
+  script.async = false;
   script.src = src;
   script.defer = false;
   document.body.appendChild(script);

--- a/scripts/package-webos.mjs
+++ b/scripts/package-webos.mjs
@@ -43,6 +43,56 @@ const webOsLegacyPreloadScript = `  <script>
       };
     }
   </script>`;
+const flexGapDetectionScript = `  <script>
+    (function detectLegacyFeatureSupport() {
+      var root = document.documentElement;
+      function removeClass(name) {
+        root.className = (" " + root.className + " ")
+          .replace(new RegExp(" " + name + " ", "g"), " ")
+          .replace(/^\\s+|\\s+$/g, "");
+      }
+      function supports(prop, value) {
+        var css = window.CSS;
+        return Boolean(css && typeof css.supports === "function" && css.supports(prop, value));
+      }
+      try {
+        var test = document.createElement("div");
+        var child = document.createElement("div");
+        test.style.position = "absolute";
+        test.style.left = "-9999px";
+        test.style.top = "-9999px";
+        test.style.display = "flex";
+        test.style.flexDirection = "column";
+        test.style.rowGap = "1px";
+        child.style.height = "1px";
+        test.appendChild(child.cloneNode());
+        test.appendChild(child.cloneNode());
+        root.appendChild(test);
+        if (test.scrollHeight === 3) {
+          removeClass("no-flex-gap");
+        }
+        root.removeChild(test);
+      } catch (error) {
+        removeClass("no-flex-gap");
+      }
+      if (supports("display", "grid")) {
+        removeClass("no-css-grid");
+      }
+      if (supports("--nuvio-probe", "0")) {
+        removeClass("no-css-vars");
+      }
+      if (supports("font-size", "clamp(1px, 2px, 3px)")) {
+        removeClass("no-css-math");
+      }
+      if (supports("aspect-ratio", "1 / 1")) {
+        removeClass("no-aspect-ratio");
+      }
+      if (supports("backdrop-filter", "blur(1px)") || supports("-webkit-backdrop-filter", "blur(1px)")) {
+        removeClass("no-backdrop-filter");
+      }
+    })();
+  </script>
+`;
 
 async function assertDistExists() {
   try {
@@ -75,13 +125,13 @@ function buildWebOsIndexHtml({ webOsScriptPath = "" } = {}) {
   const webOsScriptTag = webOsScriptPath ? `  <script src="${webOsScriptPath}"></script>\n` : "";
 
   return `<!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="no-flex-gap no-css-grid no-css-vars no-css-math no-backdrop-filter no-aspect-ratio">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <title>${appName}</title>
-  <link rel="stylesheet" href="css/base.css" />
+${flexGapDetectionScript}  <link rel="stylesheet" href="css/base.css" />
   <link rel="stylesheet" href="css/layout.css" />
   <link rel="stylesheet" href="css/components.css" />
   <link rel="stylesheet" href="css/themes.css" />

--- a/scripts/serve.mjs
+++ b/scripts/serve.mjs
@@ -8,6 +8,7 @@ import { buildRuntimeEnvScript, readEnvProperties } from "./envProperties.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, "..");
+const distDir = path.join(rootDir, "dist");
 const host = process.env.HOST || "0.0.0.0";
 const port = Number(process.env.PORT || 4173);
 const mediaRuntimePath = path.join(rootDir, "services", "webos", "runtime", "media-http.cjs");
@@ -60,6 +61,35 @@ function resolveRequestPath(urlPathname) {
   }
   const normalized = path.normalize(pathname).replace(/^(\.\.[/\\])+/, "");
   return path.join(rootDir, normalized);
+}
+
+function resolveDistPathForRootFile(rootFilePath) {
+  const relativePath = path.relative(rootDir, rootFilePath);
+  if (!relativePath || relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
+    return "";
+  }
+  return path.join(distDir, relativePath);
+}
+
+async function resolveRequestFile(pathname) {
+  const rootPath = resolveRequestPath(pathname);
+  const rootStat = await stat(rootPath).catch(() => null);
+
+  if (!String(pathname || "").startsWith("/css/")) {
+    return { filePath: rootPath, fileStat: rootStat };
+  }
+
+  const distPath = resolveDistPathForRootFile(rootPath);
+  const distStat = distPath ? await stat(distPath).catch(() => null) : null;
+  if (!distStat?.isFile()) {
+    return { filePath: rootPath, fileStat: rootStat };
+  }
+
+  if (!rootStat?.isFile() || distStat.mtimeMs >= rootStat.mtimeMs) {
+    return { filePath: distPath, fileStat: distStat };
+  }
+
+  return { filePath: rootPath, fileStat: rootStat };
 }
 
 function requestLocalMediaPath(
@@ -189,8 +219,7 @@ const server = http.createServer(async (request, response) => {
       return;
     }
 
-    let filePath = resolveRequestPath(requestUrl.pathname);
-    let fileStat = await stat(filePath).catch(() => null);
+    let { filePath, fileStat } = await resolveRequestFile(requestUrl.pathname);
 
     if (fileStat?.isDirectory()) {
       filePath = path.join(filePath, "index.html");

--- a/scripts/sync-tizenbrew.mjs
+++ b/scripts/sync-tizenbrew.mjs
@@ -9,6 +9,56 @@ const rootDir = path.resolve(__dirname, "..");
 const distDir = path.join(rootDir, "dist");
 const appName = "Nuvio TV";
 const tizenIconSource = path.join(rootDir, "assets", "images", "tizenIcon.png");
+const flexGapDetectionScript = `  <script>
+    (function detectLegacyFeatureSupport() {
+      var root = document.documentElement;
+      function removeClass(name) {
+        root.className = (" " + root.className + " ")
+          .replace(new RegExp(" " + name + " ", "g"), " ")
+          .replace(/^\\s+|\\s+$/g, "");
+      }
+      function supports(prop, value) {
+        var css = window.CSS;
+        return Boolean(css && typeof css.supports === "function" && css.supports(prop, value));
+      }
+      try {
+        var test = document.createElement("div");
+        var child = document.createElement("div");
+        test.style.position = "absolute";
+        test.style.left = "-9999px";
+        test.style.top = "-9999px";
+        test.style.display = "flex";
+        test.style.flexDirection = "column";
+        test.style.rowGap = "1px";
+        child.style.height = "1px";
+        test.appendChild(child.cloneNode());
+        test.appendChild(child.cloneNode());
+        root.appendChild(test);
+        if (test.scrollHeight === 3) {
+          removeClass("no-flex-gap");
+        }
+        root.removeChild(test);
+      } catch (error) {
+        removeClass("no-flex-gap");
+      }
+      if (supports("display", "grid")) {
+        removeClass("no-css-grid");
+      }
+      if (supports("--nuvio-probe", "0")) {
+        removeClass("no-css-vars");
+      }
+      if (supports("font-size", "clamp(1px, 2px, 3px)")) {
+        removeClass("no-css-math");
+      }
+      if (supports("aspect-ratio", "1 / 1")) {
+        removeClass("no-aspect-ratio");
+      }
+      if (supports("backdrop-filter", "blur(1px)") || supports("-webkit-backdrop-filter", "blur(1px)")) {
+        removeClass("no-backdrop-filter");
+      }
+    })();
+  </script>
+`;
 
 function fail(message) {
   throw new Error(
@@ -81,12 +131,22 @@ async function syncFolder(targetDir, folderName) {
   await cp(path.join(distDir, folderName), path.join(targetDir, folderName), { recursive: true });
 }
 
+async function syncOptionalFolder(targetDir, folderName) {
+  try {
+    await access(path.join(distDir, folderName), fsConstants.R_OK);
+  } catch {
+    await rm(path.join(targetDir, folderName), { recursive: true, force: true });
+    return;
+  }
+  await syncFolder(targetDir, folderName);
+}
+
 async function syncBuild(targetAppDir, envSourcePath) {
   await mkdir(targetAppDir, { recursive: true });
   await Promise.all([
     syncFolder(targetAppDir, "assets"),
     syncFolder(targetAppDir, "css"),
-    syncFolder(targetAppDir, "js"),
+    syncOptionalFolder(targetAppDir, "js"),
     syncFolder(targetAppDir, "res")
   ]);
 
@@ -111,13 +171,13 @@ async function syncBuild(targetAppDir, envSourcePath) {
 
 function buildIndexHtml() {
   return `<!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="no-flex-gap no-css-grid no-css-vars no-css-math no-backdrop-filter no-aspect-ratio">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=1920, height=1080, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <title>${appName}</title>
-  <link rel="stylesheet" href="css/base.css" />
+${flexGapDetectionScript}  <link rel="stylesheet" href="css/base.css" />
   <link rel="stylesheet" href="css/layout.css" />
   <link rel="stylesheet" href="css/components.css" />
   <link rel="stylesheet" href="css/themes.css" />
@@ -154,6 +214,7 @@ if (tvInput && typeof tvInput.registerKey === "function") {
 
 function loadScript(src) {
   var script = document.createElement("script");
+  script.async = false;
   script.src = src;
   script.defer = false;
   document.body.appendChild(script);

--- a/scripts/sync-wrapper.mjs
+++ b/scripts/sync-wrapper.mjs
@@ -39,6 +39,56 @@ const webOsLegacyPreloadScript = `  <script>
       };
     }
   </script>`;
+const flexGapDetectionScript = `  <script>
+    (function detectLegacyFeatureSupport() {
+      var root = document.documentElement;
+      function removeClass(name) {
+        root.className = (" " + root.className + " ")
+          .replace(new RegExp(" " + name + " ", "g"), " ")
+          .replace(/^\\s+|\\s+$/g, "");
+      }
+      function supports(prop, value) {
+        var css = window.CSS;
+        return Boolean(css && typeof css.supports === "function" && css.supports(prop, value));
+      }
+      try {
+        var test = document.createElement("div");
+        var child = document.createElement("div");
+        test.style.position = "absolute";
+        test.style.left = "-9999px";
+        test.style.top = "-9999px";
+        test.style.display = "flex";
+        test.style.flexDirection = "column";
+        test.style.rowGap = "1px";
+        child.style.height = "1px";
+        test.appendChild(child.cloneNode());
+        test.appendChild(child.cloneNode());
+        root.appendChild(test);
+        if (test.scrollHeight === 3) {
+          removeClass("no-flex-gap");
+        }
+        root.removeChild(test);
+      } catch (error) {
+        removeClass("no-flex-gap");
+      }
+      if (supports("display", "grid")) {
+        removeClass("no-css-grid");
+      }
+      if (supports("--nuvio-probe", "0")) {
+        removeClass("no-css-vars");
+      }
+      if (supports("font-size", "clamp(1px, 2px, 3px)")) {
+        removeClass("no-css-math");
+      }
+      if (supports("aspect-ratio", "1 / 1")) {
+        removeClass("no-aspect-ratio");
+      }
+      if (supports("backdrop-filter", "blur(1px)") || supports("-webkit-backdrop-filter", "blur(1px)")) {
+        removeClass("no-backdrop-filter");
+      }
+    })();
+  </script>
+`;
 const wrapperIconFiles = {
   webosIcon: {
     source: path.join(rootDir, "assets", "images", "icon.png"),
@@ -206,13 +256,13 @@ function buildWebOsIndexHtml({ webOsScriptPath = "" } = {}) {
   const webOsScriptTag = webOsScriptPath ? `  <script src="${webOsScriptPath}"></script>\n` : "";
 
   return `<!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="no-flex-gap no-css-grid no-css-vars no-css-math no-backdrop-filter no-aspect-ratio">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <title>${appName}</title>
-  <link rel="stylesheet" href="css/base.css" />
+${flexGapDetectionScript}  <link rel="stylesheet" href="css/base.css" />
   <link rel="stylesheet" href="css/layout.css" />
   <link rel="stylesheet" href="css/components.css" />
   <link rel="stylesheet" href="css/themes.css" />
@@ -230,13 +280,13 @@ ${webOsScriptTag}  <script defer src="app.bundle.js"></script>
 
 function buildTizenIndexHtml() {
   return `<!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="no-flex-gap no-css-grid no-css-vars no-css-math no-backdrop-filter no-aspect-ratio">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=1920, height=1080, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <title>${appName}</title>
-  <link rel="stylesheet" href="css/base.css" />
+${flexGapDetectionScript}  <link rel="stylesheet" href="css/base.css" />
   <link rel="stylesheet" href="css/layout.css" />
   <link rel="stylesheet" href="css/components.css" />
   <link rel="stylesheet" href="css/themes.css" />


### PR DESCRIPTION
## Summary
- add early feature detection classes for legacy TV webviews across the app, Tizen packaging, webOS packaging, and wrapper sync flows
- generate legacy CSS fallbacks for unsupported selectors, CSS math/color syntax, grid layouts, flex gap, inset, backdrop filters, CSS variables, and aspect ratio behavior
- add runtime polyfills and imports for older Chromium engines, including URL/URLSearchParams, Element.remove, Node.isConnected, and scrollIntoView options fallback
- keep sidebar layout state mirrored with explicit classes so older engines do not depend on modern selector support like :has()

## Why
Older Tizen and webOS browser engines can miss or partially implement modern web platform features that the app now uses. That causes broken layout, missing spacing, unsupported CSS declarations/selectors, and runtime API failures on legacy TV devices.

## Impact
This keeps the modern code path intact for capable browsers while giving legacy TV runtimes deterministic fallbacks during local builds, packaged Tizen builds, packaged webOS builds, and wrapper sync output.