### PR TITLE
Fix double action on catalog reorder buttons

### DIFF
--- a/js/ui/screens/plugin/catalogOrderScreen.js
+++ b/js/ui/screens/plugin/catalogOrderScreen.js
@@ -259,6 +259,10 @@ export const CatalogOrderScreen = {
     }
 
     if (code === 13) {
+      // Prevent the focused button's native click from also firing, otherwise
+      // the action runs twice and rows jump two slots at a time.
+      event?.preventDefault?.();
+      event?.stopPropagation?.();
       await this.activateFocused();
     }
   },


### PR DESCRIPTION
Fixes the row skipping and disable toggle parts of #299

On the Reorder and hide catalogs screen, pressing OK on a row button ran the action twice: once from the screen key handler and once from the focused button's own native click on Enter. That caused two reported problems:

- Moving a row with the up or down button jumped two slots at a time instead of one.
- Toggling a catalog to disabled immediately toggled it back, so it looked like the change did not save.

The Enter handler now calls preventDefault (like the arrow keys already do), so the native button click no longer fires too and each press runs the action once.

Verified in the browser: focused a row's down button and pressed OK once, the row moved exactly one slot (before it moved two). Pressed OK on the disable button once and the catalog stayed disabled (before it flipped straight back).

Note: the reordering sync persistence point in #299 looks separate and is not part of this change.