### PR TITLE
Allow hold to manage profile on webOS

### DIFF
--- a/js/core/profile/profileSelectionScreen.js
+++ b/js/core/profile/profileSelectionScreen.js
@@ -1321,7 +1321,6 @@ export const ProfileSelectionScreen = {
   canHoldManageProfile(node) {
     return (
       !this.isManagementMode &&
-      !Platform.isWebOS() &&
       Boolean(node?.matches?.(".profile-card.focused, .profile-card")) &&
       String(node?.dataset?.profileId || "") !== "add"
     );


### PR DESCRIPTION
Closes #314

On the profile select screen the hint says to hold a profile to open its manage menu (Edit, Set PIN, etc). On webOS this was turned off, so holding a profile just opened it like a normal press, even though the hint still tells you to hold.

The hold detection was gated behind a check that excluded webOS. The profile card is a div, so holding OK does not cause any native click double action, and the hold timer already opens the menu on its own. Removed the webOS exclusion so the hold works there too.

Verified in the browser with a webOS user agent:
- Hold OK on a profile: the manage menu opens, the profile is not selected.
- Short press OK: the profile is selected as before.
- Also tested with simulated key auto repeat (held key): the menu opens once and stays open, no accidental selection.