### PR TITLE
Stop trailer up/down from toggling mute

### DIFF
--- a/js/ui/screens/detail/metaDetailsScreen.js
+++ b/js/ui/screens/detail/metaDetailsScreen.js
@@ -8130,7 +8130,12 @@ export const MetaDetailsScreen = {
       }
       if (direction === "up" || direction === "down") {
         event?.preventDefault?.();
-        this.setTrailerMutedState(!this.trailerMuted);
+        if (direction === "down") {
+          this.stopTrailerControlsTimer();
+          this.setTrailerControlsVisible(false);
+        } else {
+          this.restartTrailerControlsTimer();
+        }
         return;
       }
     } else if (!this.isTrailerPlaying) {


### PR DESCRIPTION
Closes #322

In the full screen trailer, pressing Up or Down toggled mute. That is surprising because Up is also meant to show the timeline, so trying to peek at the timeline accidentally muted the sound.

Up now shows the trailer controls (timeline) and Down hides them, matching what the report expects. Mute is unchanged and still available from the mute button in the controls overlay (it is a focusable, clickable button).

The change is limited to the up/down branch of the manual trailer key handler; left/right seek and OK play/pause are untouched.