### PR TITLE
Align empty cast and reviews placeholders on TV

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -15031,6 +15031,13 @@ button:focus-visible {
   box-sizing: border-box;
 }
 
+.series-insight-empty {
+  padding-left: var(--tv-safe-gutter-wide);
+  padding-right: var(--tv-safe-gutter-wide);
+  box-sizing: border-box;
+  font-size: clamp(20px, 1.35vw, 26px);
+}
+
 .series-season-row {
   margin-bottom: 0;
   gap: clamp(12px, 1vw, 18px);


### PR DESCRIPTION
Closes #324

On the details screen, when there is no cast or no Trakt reviews, the placeholder text ("No cast information.", "No Trakt comments yet.") had no side padding and a smaller font than the rest of the section. On TVs that made it sit at the very left edge (slightly off screen) and look tiny.

Both placeholders use the .series-insight-empty class. On the TV layout it now gets the same safe side gutter the cast and comments rows use, plus a font size that matches the section, so the text lines up with the content and is readable.

Verified in the browser at a TV viewport with a cast-less title: the placeholder padding-left now matches the cast row gutter (about 46px) and the font is 20px instead of 18px, where before it had no padding and sat at the edge.