### PR TITLE
fix(player): don't get stuck in the player when cleanup throws on Tizen

### DIFF
--- a/js/ui/screens/player/playerScreen.js
+++ b/js/ui/screens/player/playerScreen.js
@@ -14305,6 +14305,7 @@ export const PlayerScreen = {
   },
 
   cleanup() {
+    try {
     this.playerRouteActive = false;
     this.playerMountToken = Number(this.playerMountToken || 0) + 1;
     this.unbindVideoEvents();
@@ -14392,16 +14393,24 @@ export const PlayerScreen = {
     this.clearMediaSessionHandlers();
 
     this.releaseStartupAudioGate({ resume: false });
-    PlayerController.stop();
-
-    if (this.container) {
-      this.container.style.display = "none";
-      this.container.querySelector("#playerUiRoot")?.remove();
-      this.container.querySelector("#episodeSidePanel")?.remove();
+    } catch (error) {
+      try { console.warn("Player cleanup error suppressed to keep navigation working", error); } catch (e) {}
+    } finally {
+      // Always stop playback and hide the player surface, even if the teardown
+      // above threw, so the user is never left stuck in the player with the
+      // video still playing (seen on Samsung Tizen when the EngineFS release
+      // throws during cleanup and aborts the route navigation).
+      try { PlayerController.stop(); } catch (e) {}
+      try {
+        if (this.container) {
+          this.container.style.display = "none";
+          this.container.querySelector("#playerUiRoot")?.remove();
+          this.container.querySelector("#episodeSidePanel")?.remove();
+        }
+      } catch (e) {}
+      this.uiRefs = null;
+      this.lastUiTickState = null;
     }
-    this.uiRefs = null;
-    this.lastUiTickState = null;
-
   }
 
 };


### PR DESCRIPTION
## Summary

Pressing Back in the player could leave you stuck on a rendered player with no way out (you had to power-cycle the TV). The player `cleanup()` could throw partway through teardown, which aborted the navigation back to the detail screen. This wraps the teardown so navigation always completes even if a teardown step fails.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix
- [ ] Approved feature/change

## Affected area

- [x] Shared web app
- [x] Samsung Tizen
- [x] Playback
- [x] Focus / Remote navigation
- [ ] UI / Layout

## Why

On Samsung Tizen, pressing Back while playing could throw inside `cleanup()` (a teardown step failing), so the route change never finished and the player stayed on screen, unresponsive — the only way out was to turn the TV off.

## Issue or approval

Fixes #318

## Reproduction steps

1. Open NuvioTV Web on Samsung Tizen.
2. Play any title.
3. Press Back on the remote.
4. Observe the player stays rendered and input is stuck.

## Old behavior

A failing teardown step in `cleanup()` aborted navigation, leaving the player on screen with no way back.

## New behavior

Teardown is wrapped so a failing step is logged and suppressed, the player is always hidden/removed, and navigation back to details always completes.

## Platform impact

- Samsung Tizen: where the freeze was observed; fixed.
- LG webOS: shared code path, same safety applies.
- Browser development mode: no change in normal flow.
- Installer / packaging: none.
- Wrapper repositories: none.

## UI / behavior / playback impact

- [x] Behavior changed only to fix a documented bug/regression

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I included a linked issue, reproduction steps, and testing notes if this is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Only the player teardown path is touched. No new behavior, no UI polish, no playback changes.

## Testing

### Devices / platforms tested

Samsung UE55NU8075 (Tizen 4.0), manual `.wgt` install. Also `npm run build` in browser dev mode.

### Commands tested

```sh
npm run build
npm run package:tizen
```

## Manual test flow

Play a title, press Back, confirm it returns to the detail screen reliably; repeated several times and across episodes.

## Screenshots / Video

Not a UI change.

## Logs

Not applicable (the only addition is a defensive `console.warn` if a teardown step is suppressed).

## Regression risk

Low. Teardown is only made more defensive; the happy path is unchanged.

## Breaking changes

None.

## Linked issues

Fixes #318
