### PR TITLE
fix(detail): keep season buttons from collapsing on shows with many seasons

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -19672,9 +19672,14 @@ html.no-css-grid .cast-detail-meta {
 
 .series-season-btn {
   min-height: 80px;
+  height: auto;
+  flex: 0 0 auto;
+  width: auto;
+  max-width: none;
   padding: 20px 40px;
   border-radius: 40px;
   font-size: 32px;
+  box-sizing: border-box;
 }
 
 .series-episode-track {


### PR DESCRIPTION
## Summary

In the season selector the season buttons collapse and overlap when a show has many seasons, so the "Season N" label spills out and is unreadable. This pins each button to its content size so labels stay readable and the row scrolls instead.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix
- [ ] Approved feature/change

## Affected area

- [x] Shared web app
- [x] Samsung Tizen
- [x] UI / Layout

## Why

The season buttons are flex items in `.series-season-row` with no explicit `flex`, so `flex-shrink: 1` collapses them below their content when there are many seasons (e.g. Doraemon, 33 seasons). The labels then overflow/overlap and become unreadable.

## Issue or approval

Fixes #336

## Reproduction steps

1. Open NuvioTV Web on Samsung Tizen.
2. Open a series with many seasons (e.g. Doraemon).
3. Look at the season selector row.
4. Observe the overlapping/overflowing "Season N" labels.

## Old behavior

Buttons shrank below their content; labels overlapped and overflowed.

## New behavior

Each button keeps its content size (`flex: 0 0 auto; width: auto; max-width: none`); labels stay readable and the row scrolls horizontally.

## Platform impact

- Samsung Tizen: fixed (where it was observed).
- LG webOS: shared CSS, same fix.
- Browser development mode: same, reproducible with many seasons.
- Installer / packaging: none.
- Wrapper repositories: none.

## UI / behavior / playback impact

- [x] UI changed only to fix a documented glitch/bug

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I included a linked issue, reproduction steps, and testing notes if this is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

One CSS rule on `.series-season-btn`. No other UI/behavior changes.

## Testing

### Devices / platforms tested

Samsung UE55NU8075 (Tizen 4.0) and Chrome (browser dev build), using Doraemon (33 seasons).

### Commands tested

```sh
npm run build
```

## Manual test flow

Open Doraemon, scroll to the season selector, confirm every "Season N" label is fully readable and the row scrolls horizontally.

## Screenshots / Video

**Before:**
![before](https://raw.githubusercontent.com/Krlooo/NuvioWeb/pr-assets/docs/pr-screenshots/season-buttons-before.png)

**After:**
![after](https://raw.githubusercontent.com/Krlooo/NuvioWeb/pr-assets/docs/pr-screenshots/season-buttons-after.png)

## Logs

Not applicable.

## Regression risk

Very low. CSS-only change scoped to the season buttons.

## Breaking changes

None.

## Linked issues

Fixes #336
