### PR TITLE
fix(detail): strengthen readability scrim over light backdrops

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -13879,12 +13879,17 @@ button:focus-visible {
   background:
     linear-gradient(
       90deg,
-      rgba(4, 7, 11, 0.94) 0%,
-      rgba(8, 12, 17, 0.72) 45%,
-      rgba(8, 12, 17, 0.36) 68%,
-      rgba(8, 12, 17, 0.2) 100%
+      rgba(6, 9, 14, 0.96) 0%,
+      rgba(6, 9, 14, 0.86) 45%,
+      rgba(6, 9, 14, 0.66) 72%,
+      rgba(6, 9, 14, 0.5) 100%
     ),
-    linear-gradient(180deg, rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.85));
+    linear-gradient(
+      180deg,
+      rgba(0, 0, 0, 0.4) 0%,
+      rgba(0, 0, 0, 0.18) 38%,
+      rgba(0, 0, 0, 0.9) 100%
+    );
 }
 
 .movie-detail-content {
@@ -14554,20 +14559,22 @@ button:focus-visible {
   left: 0;
   inset: 0;
   z-index: 0;
-  /* Android TV BackdropLayer leftGradient: fadeWidth = 78% of screen. */
-  background: linear-gradient(
-    90deg,
-    rgb(var(--bg-color-rgb) / 1) 0%,
-    rgb(var(--bg-color-rgb) / 0.95) 7.8%,
-    rgb(var(--bg-color-rgb) / 0.84) 17.16%,
-    rgb(var(--bg-color-rgb) / 0.7) 28.08%,
-    rgb(var(--bg-color-rgb) / 0.52) 40.56%,
-    rgb(var(--bg-color-rgb) / 0.34) 51.48%,
-    rgb(var(--bg-color-rgb) / 0.18) 60.84%,
-    rgb(var(--bg-color-rgb) / 0.07) 70.2%,
-    rgb(var(--bg-color-rgb) / 0) 78%,
-    rgb(var(--bg-color-rgb) / 0) 100%
-  );
+  /* Stronger scrim that never fully fades, so detail info/genres stay readable
+     over light backdrops. Classic rgba() for old Tizen/webOS browsers. */
+  background:
+    linear-gradient(
+      90deg,
+      rgba(6, 9, 14, 0.96) 0%,
+      rgba(6, 9, 14, 0.86) 45%,
+      rgba(6, 9, 14, 0.66) 72%,
+      rgba(6, 9, 14, 0.5) 100%
+    ),
+    linear-gradient(
+      180deg,
+      rgba(0, 0, 0, 0.4) 0%,
+      rgba(0, 0, 0, 0.18) 38%,
+      rgba(0, 0, 0, 0.9) 100%
+    );
   transition: opacity 800ms cubic-bezier(0.4, 0, 0.2, 1);
 }
 
@@ -15693,12 +15700,17 @@ button:focus-visible {
   background:
     linear-gradient(
       90deg,
-      rgba(5, 9, 14, 0.9) 0%,
-      rgba(7, 11, 16, 0.72) 44%,
-      rgba(7, 11, 16, 0.44) 70%,
-      rgba(7, 11, 16, 0.3) 100%
+      rgba(6, 9, 14, 0.96) 0%,
+      rgba(6, 9, 14, 0.86) 45%,
+      rgba(6, 9, 14, 0.66) 72%,
+      rgba(6, 9, 14, 0.5) 100%
     ),
-    linear-gradient(180deg, rgba(0, 0, 0, 0.26), rgba(0, 0, 0, 0.72));
+    linear-gradient(
+      180deg,
+      rgba(0, 0, 0, 0.4) 0%,
+      rgba(0, 0, 0, 0.2) 40%,
+      rgba(0, 0, 0, 0.82) 100%
+    );
 }
 
 .stream-screen-panel {


### PR DESCRIPTION
## Summary

The detail/stream backdrop scrim faded to fully transparent on the right half, so over light backdrops the info (writer/year/synopsis) and the genres washed out and were hard to read. This strengthens the scrim so it never fully fades, and switches the series scrim to classic `rgba()` (the modern `rgb(R G B / a)` syntax is unreliable on old Tizen/webOS Chromium).

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix
- [ ] Approved feature/change

## Affected area

- [x] Shared web app
- [x] Samsung Tizen
- [x] LG webOS
- [x] UI / Layout

## Why

Over light backdrops the text was hard or impossible to read because the scrim fell to 0 alpha on the right. Additionally the series scrim used `rgb(R G B / a)`, which can fail entirely on the old Chromium in Tizen 4 / older webOS, removing the scrim there.

## Issue or approval

Fixes #338

## Reproduction steps

1. Open NuvioTV Web on Samsung Tizen.
2. Open a title with a light/bright backdrop (or its stream/links page).
3. Try to read the left-side info and the right-side genres.
4. Observe the text washing out.

## Old behavior

Scrim faded to transparent on the right; text washed out over light backdrops; series scrim could fail to apply on old TV browsers.

## New behavior

Scrim keeps ~0.5 alpha on the right plus a bottom gradient, using `rgba()` for old-browser safety. Applied consistently to the series, movie and stream (links) scrims; text stays readable over any backdrop.

## Platform impact

- Samsung Tizen: fixed (old Chromium safe `rgba()`).
- LG webOS: same shared CSS, same benefit.
- Browser development mode: improved contrast, reproducible.
- Installer / packaging: none.
- Wrapper repositories: none.

## UI / behavior / playback impact

- [x] UI changed only to fix a documented glitch/bug

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I included a linked issue, reproduction steps, and testing notes if this is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Only the three detail/stream scrim gradients are changed. No layout, behavior or playback changes.

## Testing

### Devices / platforms tested

Samsung UE55NU8075 (Tizen 4.0) and Chrome (browser dev build).

### Commands tested

```sh
npm run build
```

## Manual test flow

Open titles with light and dark backdrops, plus a stream/links page; confirm info and genres stay readable in all cases.

## Screenshots / Video

**Before:**
![before](https://raw.githubusercontent.com/Krlooo/NuvioWeb/pr-assets/docs/pr-screenshots/readability-before.png)

**After:**
![after](https://raw.githubusercontent.com/Krlooo/NuvioWeb/pr-assets/docs/pr-screenshots/readability-after.png)

## Logs

Not applicable.

## Regression risk

Low. CSS-only change to the scrim gradients; darker scrim only improves contrast.

## Breaking changes

None.

## Linked issues

Fixes #338
