### PR TITLE
perf(detail): lazy-load episode thumbnails to avoid stall on season switch

### DIFF
--- a/js/ui/screens/detail/metaDetailsScreen.js
+++ b/js/ui/screens/detail/metaDetailsScreen.js
@@ -3414,7 +3414,7 @@ export const MetaDetailsScreen = {
             data-action="openEpisodeStreams"
             data-video-id="${escapeHtml(episode.id)}"
             data-episode-index="${absoluteIndex}">
-        <div class="series-episode-thumb"${episode.thumbnail ? ` style="background-image:url('${episode.thumbnail.replace(/'/g, "%27")}')"` : ""}>
+        <div class="series-episode-thumb"${episode.thumbnail ? ` data-thumb="${escapeHtml(episode.thumbnail)}"` : ""}>
           <div class="series-episode-overlay"></div>
           ${isWatched ? `<div class="series-episode-status complete">${renderWatchedBadgeGlyph()}</div>` : progressRatio < 0.02 ? `<div class="series-episode-status idle"></div>` : ""}
           ${isUnavailable ? `<div class="series-episode-unavailable">${escapeHtml(t("episodes_unavailable", {}, "Unavailable").toUpperCase())}</div>` : ""}
@@ -3430,25 +3430,48 @@ export const MetaDetailsScreen = {
     `;
   },
 
-  warmEpisodeThumbnails(episodes = [], startIndex = 0, endIndex = 0) {
-    if (!Array.isArray(episodes) || !episodes.length) {
-      return;
-    }
-    const from = Math.max(0, Math.min(episodes.length - 1, Number(startIndex || 0)));
-    const to = Math.max(from, Math.min(episodes.length - 1, Number(endIndex || 0)));
-    const prefetchStart = Math.max(0, from - EPISODE_VIRTUALIZATION_OVERSCAN);
-    const prefetchEnd = Math.min(episodes.length - 1, to + EPISODE_VIRTUALIZATION_OVERSCAN);
-    for (let index = prefetchStart; index <= prefetchEnd; index += 1) {
-      const thumbnail = String(episodes[index]?.thumbnail || "").trim();
-      if (!thumbnail || this.episodeThumbnailPrefetchCache.has(thumbnail)) {
-        continue;
+  warmEpisodeThumbnails() {
+    // Eager prefetch removed: episode thumbnails are now lazy-loaded on demand via
+    // IntersectionObserver (see observeEpisodeThumbnails). Eagerly decoding a whole
+    // season's thumbnails at once stalled low-end TVs when switching seasons.
+  },
+
+  applyEpisodeThumb(el) {
+    try {
+      if (!el) return;
+      const url = el.getAttribute("data-thumb");
+      if (!url) return;
+      el.style.backgroundImage = "url('" + String(url).replace(/'/g, "%27") + "')";
+      el.removeAttribute("data-thumb");
+    } catch (e) {}
+  },
+
+  observeEpisodeThumbnails() {
+    try {
+      const root = this.container;
+      if (!root) return;
+      const thumbs = Array.from(root.querySelectorAll(".series-episode-thumb[data-thumb]"));
+      if (!thumbs.length) return;
+      // Fallback for engines without IntersectionObserver: just load them all.
+      if (typeof IntersectionObserver !== "function") {
+        thumbs.forEach((el) => this.applyEpisodeThumb(el));
+        return;
       }
-      this.episodeThumbnailPrefetchCache.add(thumbnail);
-      const image = new Image();
-      image.decoding = "async";
-      image.loading = "eager";
-      image.src = thumbnail;
-    }
+      if (!this.episodeThumbObserver) {
+        this.episodeThumbObserver = new IntersectionObserver(
+          (entries) => {
+            entries.forEach((entry) => {
+              if (entry.isIntersecting) {
+                this.applyEpisodeThumb(entry.target);
+                try { this.episodeThumbObserver.unobserve(entry.target); } catch (e) {}
+              }
+            });
+          },
+          { root: null, rootMargin: "300px", threshold: 0.01 }
+        );
+      }
+      thumbs.forEach((el) => this.episodeThumbObserver.observe(el));
+    } catch (e) {}
   },
 
   renderEpisodeCards(preferredIndex = null) {
@@ -5082,6 +5105,7 @@ export const MetaDetailsScreen = {
   },
 
   bindDetailChrome() {
+    this.observeEpisodeThumbnails();
     const content = this.container?.querySelector(".series-detail-content");
     if (!content) {
       return;


### PR DESCRIPTION
## Summary

Episode thumbnails were rendered as an inline `background-image` and additionally eager-prefetched via `new Image()` across the whole virtual window. Switching season on a show with many episodes decoded a batch of images at once and stalled low-end TVs. This lazy-loads each thumbnail on demand with `IntersectionObserver` and drops the eager prefetch.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix
- [ ] Approved feature/change

## Affected area

- [x] Shared web app
- [x] Samsung Tizen
- [x] UI / Layout

## Why

On a series with many episodes (e.g. Doraemon, 2000+ episodes) changing season decoded a whole window of thumbnails up front, blocking the UI thread and causing a visible stall on low-end TVs.

## Issue or approval

Fixes #340

## Reproduction steps

1. Open NuvioTV Web on Samsung Tizen.
2. Open a series with many episodes (e.g. Doraemon).
3. Switch between seasons.
4. Observe the stall while the episode list re-renders.

## Old behavior

All episode thumbnails for the window were eagerly decoded on season switch (inline `background-image` + `new Image()` prefetch), stalling the UI.

## New behavior

Thumbnails are stored in `data-thumb` and loaded on demand by an `IntersectionObserver` (`rootMargin: 300px`) that sets the `background-image` only as a card approaches the viewport, then unobserves it. Falls back to load-all where `IntersectionObserver` is missing. The eager prefetch is removed.

## Platform impact

- Samsung Tizen: fixed (where the stall was observed).
- LG webOS: shared code path, same benefit.
- Browser development mode: same behavior, no visual change.
- Installer / packaging: none.
- Wrapper repositories: none.

## UI / behavior / playback impact

- [x] No UI change
- [x] No playback change
- [x] Behavior changed only to fix a documented bug/regression

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I included a linked issue, reproduction steps, and testing notes if this is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Only the episode thumbnail loading path in the detail screen is touched. The visual result is unchanged; only when images decode changes.

## Testing

### Devices / platforms tested

Samsung UE55NU8075 (Tizen 4.0) and Chrome (browser dev build), using Doraemon (33 seasons).

### Commands tested

```sh
npm run build
```

## Manual test flow

Open Doraemon, switch seasons repeatedly, confirm the stall is gone and thumbnails appear as the list scrolls.

## Screenshots / Video

Not a UI change (the thumbnails look identical; only when they decode changes).

## Logs

Not applicable.

## Regression risk

Low. Falls back to load-all where `IntersectionObserver` is unavailable, so thumbnails always appear.

## Breaking changes

None.

## Linked issues

Fixes #340
