### PR TITLE
Include anime catalogs in search and discover

### DIFF
--- a/js/ui/screens/search/searchScreen.js
+++ b/js/ui/screens/search/searchScreen.js
@@ -131,7 +131,12 @@ function isSearchableCatalogType(type) {
   const normalized = String(type || "")
     .trim()
     .toLowerCase();
-  return normalized === "movie" || normalized === "series" || normalized === "tv";
+  return (
+    normalized === "movie" ||
+    normalized === "series" ||
+    normalized === "tv" ||
+    normalized === "anime"
+  );
 }
 
 function buildSearchTargets(addons = []) {


### PR DESCRIPTION
Related to #355

Search and Discover only treated `movie`, `series` and `tv` catalogs as searchable. Any catalog with a different type was skipped even when it declared search support, so `anime` catalogs (common with AIOMetadata) were never queried and returned nothing.

Added `anime` to the searchable catalog types so those catalogs are searched and appear in Discover like the others.

Verified in the browser with a mock addon that exposes a series search catalog and an anime search catalog:
- Before: only the series catalog was requested; the anime catalog was never queried.
- After: both are requested and their results show (series + anime).

This likely fixes #355 for AIOMetadata setups whose search catalogs are anime-typed. It does not change how the search request itself is built, so setups that were already returning results are unaffected.