### PR TITLE
Fix memory leaks in player cleanup

### DIFF
--- a/js/core/player/playerController.js
+++ b/js/core/player/playerController.js
@@ -3859,6 +3859,7 @@ export const PlayerController = {
     this.playbackEngine = "none";
     this.lastPlaybackErrorCode = 0;
     this.clearPlaybackEngineAttempts();
+    this.avplayFallbackAttempts.clear();
 
     if (this.progressSaveTimer) {
       clearInterval(this.progressSaveTimer);

--- a/js/ui/screens/player/playerScreen.js
+++ b/js/ui/screens/player/playerScreen.js
@@ -15521,6 +15521,9 @@ export const PlayerScreen = {
     this.nextEpisodeTransitionMeta = null;
     this.streamCandidatesByVideoId?.clear?.();
     this.streamCandidatesLoadPromises?.clear?.();
+    this.hlsManifestSubtitlePromotionUrls?.clear?.();
+    this.failedPlaybackUrls?.clear?.();
+    this.failedPlaybackStreamIds?.clear?.();
     this.skipIntervalsRequestToken = Number(this.skipIntervalsRequestToken || 0) + 1;
     this.subtitleLoadToken = (this.subtitleLoadToken || 0) + 1;
     this.manifestLoadToken = (this.manifestLoadToken || 0) + 1;


### PR DESCRIPTION
## Problem
Three Sets in the player grew indefinitely across playback sessions, causing memory leaks on long-running TV sessions (especially problematic on low-RAM devices):

- `hlsManifestSubtitlePromotionUrls` - tracks HLS subtitle URLs for promotion
- `failedPlaybackUrls` - tracks URLs that failed to play
- `failedPlaybackStreamIds` - tracks stream IDs that failed to play
- `avplayFallbackAttempts` - tracks AVPlay fallback attempts

These Sets are populated during playback but never cleared in `cleanup()` or `stop()`, leading to unbounded memory growth.

## Solution
Clear these Sets in the appropriate cleanup methods:
- Clear `hlsManifestSubtitlePromotionUrls`, `failedPlaybackUrls`, and `failedPlaybackStreamIds` in `playerScreen.js` `cleanup()` method
- Clear `avplayFallbackAttempts` in `playerController.js` `stop()` method

## Impact
- Prevents memory leaks on long-running TV sessions
- No functional changes - these Sets are only used for tracking state during active playback
- Safe to clear on cleanup since they're re-initialized on next playback session