### PR TITLE
fix(tizen): disconnect episode thumbnail IntersectionObserver on cleanup

### DIFF
--- a/js/ui/screens/detail/metaDetailsScreen.js
+++ b/js/ui/screens/detail/metaDetailsScreen.js
@@ -8807,6 +8807,10 @@ export const MetaDetailsScreen = {
     }
     this.stopEpisodeHoldRepeat();
     this.episodeThumbnailPrefetchCache = new Set();
+    if (this.episodeThumbObserver) {
+      try { this.episodeThumbObserver.disconnect(); } catch (_) {}
+      this.episodeThumbObserver = null;
+    }
     this.selectedSeasonEpisodeState = null;
     if (this.episodeTrackScrollNode && this.episodeTrackScrollHandler) {
       this.episodeTrackScrollNode.removeEventListener("scroll", this.episodeTrackScrollHandler);


### PR DESCRIPTION
## Summary

- Disconnect `episodeThumbObserver` in `MetaDetailsScreen.cleanup()` when leaving the detail screen
- Prevents IntersectionObserver instances and their callbacks from accumulating across repeated detail visits on TV platforms (especially Samsung Tizen long sessions)

## Problem

`observeEpisodeThumbnails()` creates a reusable `IntersectionObserver` (line ~3646) and observes episode thumb elements. On screen cleanup, scroll/focus/click handlers are removed, but the observer was never disconnected. Each detail → back → detail cycle leaves a live observer referencing stale DOM nodes.

This is a sustained-performance regression (not first-load speed). It compounds over a TV viewing session, similar in nature to the unbounded Set leaks fixed in #392.

## Fix

4 lines in `cleanup()`, matching existing teardown patterns (`try/catch`, null assignment):

```js
if (this.episodeThumbObserver) {
  try { this.episodeThumbObserver.disconnect(); } catch (_) {}
  this.episodeThumbObserver = null;
}
```

## Test plan

- [x] `npm run build` passes
- [x] Diff is 4 lines only (no line-ending churn in `metaDetailsScreen.js`)
- [ ] On Samsung Tizen: open a series detail → back to home → repeat 10× → confirm no progressive lag when scrolling episode list
- [ ] Verify episode thumbnails still lazy-load on first detail open after fix

## Related

- Follow-up to performance work in #397 (home screen speed)
- Same class of fix as #392 (resource cleanup on screen teardown)


Made with [Cursor](https://cursor.com)