### PR TITLE
fix(tizen): cache watch progress listAll() to reduce Continue Watching lag

### DIFF
--- a/js/data/local/watchProgressStore.js
+++ b/js/data/local/watchProgressStore.js
@@ -105,9 +105,47 @@ function dedupeAndSort(items = []) {
   );
 }
 
+let listAllCacheRaw = null;
+let listAllCacheValue = null;
+
+function readStoredProgressRaw() {
+  try {
+    return localStorage.getItem(WATCH_PROGRESS_KEY);
+  } catch (_) {
+    return null;
+  }
+}
+
+function loadProgressItems() {
+  const raw = readStoredProgressRaw();
+  if (raw === listAllCacheRaw && Array.isArray(listAllCacheValue)) {
+    return listAllCacheValue;
+  }
+
+  let parsed = [];
+  if (raw !== null) {
+    try {
+      parsed = JSON.parse(raw);
+    } catch (_) {
+      parsed = [];
+    }
+  }
+
+  const items = dedupeAndSort(Array.isArray(parsed) ? parsed : []);
+  listAllCacheRaw = raw;
+  listAllCacheValue = items;
+  return items;
+}
+
+function persistProgressItems(items) {
+  LocalStore.set(WATCH_PROGRESS_KEY, items);
+  listAllCacheRaw = readStoredProgressRaw();
+  listAllCacheValue = items;
+}
+
 export const WatchProgressStore = {
   listAll() {
-    return dedupeAndSort(LocalStore.get(WATCH_PROGRESS_KEY, []));
+    return loadProgressItems();
   },
 
   listForProfile(profileId) {
@@ -127,7 +165,7 @@ export const WatchProgressStore = {
       normalized,
       ...items.filter((item) => progressKey(item) !== key)
     ]).slice(0, 5000);
-    LocalStore.set(WATCH_PROGRESS_KEY, next);
+    persistProgressItems(next);
   },
 
   findByContentId(contentId, profileId) {
@@ -151,7 +189,7 @@ export const WatchProgressStore = {
       }
       return String(item.videoId || "") !== wantedVideoId;
     });
-    LocalStore.set(WATCH_PROGRESS_KEY, next);
+    persistProgressItems(next);
   },
 
   replaceForProfile(profileId, items = []) {
@@ -163,6 +201,6 @@ export const WatchProgressStore = {
       .map((item) => normalizeProgress(item, pid))
       .filter((item) => Boolean(item.contentId));
     const next = dedupeAndSort([...normalized, ...keepOtherProfiles]).slice(0, 5000);
-    LocalStore.set(WATCH_PROGRESS_KEY, next);
+    persistProgressItems(next);
   }
 };


### PR DESCRIPTION
## Summary

- Cache parsed watch progress in memory, keyed on the raw `localStorage` string
- Skip repeated `JSON.parse` + dedupe on every `listAll()` call during home load, CW navigation, and detail screen resume lookups
- Refresh cache only when `upsert`, `remove`, or `replaceForProfile` mutates storage

Fixes #393

## Problem

`WatchProgressStore.listAll()` was re-parsing and re-deduplicating the entire watch history from localStorage on every call. Home screen Continue Watching, detail resume lookups, and progress saves each hit this path multiple times per navigation. Community reports on Tizen/webOS tied clearing watch history to the whole app feeling smooth again.

## Why this is safe

- No behavior change — same dedupe/sort output as before
- All writes still go through `WatchProgressStore`; cache updates on every mutation
- Small, isolated diff in one store file

## Test plan

- [x] `npm run build` passes
- [ ] Home Continue Watching row loads without stutter on Samsung Tizen with large watch history
- [ ] Saving/removing progress still updates CW row correctly
- [ ] Detail screen resume position still accurate after playback

## Device notes

Target: Samsung Tizen (all versions). Same code path affects webOS Continue Watching lag (#393).

Made with [Cursor](https://cursor.com)