### PR TITLE
fix(tizen): snap profile picker background on Samsung TVs

### DIFF
--- a/js/core/profile/profileSelectionScreen.js
+++ b/js/core/profile/profileSelectionScreen.js
@@ -14,6 +14,7 @@ import { ThemeManager } from "../../ui/theme/themeManager.js";
 import { I18n } from "../../i18n/index.js";
 import { NuvioDialog } from "../../ui/components/nuvioDialog.js";
 import { detailWatchedEnrichmentService } from "../../data/repository/detailWatchedEnrichmentService.js";
+import { Platform } from "../../platform/index.js";
 
 const PINNED_AVATAR_CATEGORIES = ["anime", "animation", "tv", "movie", "gaming"];
 const DEFAULT_PROFILE_COLOR = "#f5f5f5";
@@ -1247,6 +1248,16 @@ export const ProfileSelectionScreen = {
     if (this._bgAnimRaf) {
       cancelAnimationFrame(this._bgAnimRaf);
       this._bgAnimRaf = null;
+    }
+
+    if (
+      Platform.isTizen() ||
+      Platform.isWebOS() ||
+      globalThis.document?.body?.classList?.contains("performance-constrained")
+    ) {
+      this._bgCurrentColor = targetColor;
+      screen.style.background = this.buildBackgroundStyleFromColor(targetColor, themeColors);
+      return;
     }
 
     const fromColor = this._bgCurrentColor || targetColor;


### PR DESCRIPTION
## Summary

- Skip the 520ms requestAnimationFrame gradient tween when switching profiles on Tizen, webOS, and performance-constrained runtimes
- Snap directly to the target profile color instead of animating ~31 frames per profile move

Fixes #391

## Problem

`ProfileSelectionScreen.updateBackground()` runs a 520ms eased gradient animation on every profile focus change. On Samsung Tizen this repaints the full-screen background each frame and causes visible stutter when navigating between profiles with the remote.

## Why this is safe

- Visual-only change on TV platforms; desktop/browser keeps the existing animation
- Same pattern used elsewhere (home/detail already treat Tizen as performance-constrained)
- No API or data changes

## Test plan

- [x] `npm run build` passes
- [ ] Profile picker with 2+ profiles: left/right navigation feels instant on Samsung Tizen
- [ ] Desktop/browser profile picker still animates smoothly

## Device notes

Target: Samsung Tizen. Also applies to LG webOS (#391 reported webOS stutter).

Made with [Cursor](https://cursor.com)