### PR TITLE
fix(tizen): improve home screen performance on Samsung TVs

### DIFF
--- a/js/core/media/addonLogoCache.js
+++ b/js/core/media/addonLogoCache.js
@@ -1,11 +1,13 @@
 import { LocalStore } from "../storage/localStore.js";
 import { Environment } from "../../platform/environment.js";
+import { Platform } from "../../platform/index.js";
 import { isWebOsImageProxyUrl, normalizeImageUrl } from "./imageProxy.js";
 
 const failedAddonLogoUrls = new Set();
 const addonLogoCache = new Map();
 const ADDON_LOGO_CACHE_KEY = "nuvio.stream.addonLogoCache.v1";
 const ADDON_LOGO_CACHE_LIMIT = 36;
+const ADDON_LOGO_TV_CACHE_LIMIT = 12;
 const ADDON_LOGO_CACHE_MAX_LENGTH = 140000;
 
 let addonLogoCacheHydrated = false;
@@ -140,7 +142,7 @@ export function requestAddonLogo(url = "", onSettled = null) {
     return cached.promise || Promise.resolve(false);
   }
 
-  if (Environment.isWebOS() && !isWebOsImageProxyUrl(normalized)) {
+  if ((Environment.isWebOS() || Platform.isTizen()) && !isWebOsImageProxyUrl(normalized)) {
     addonLogoCache.set(normalized, {
       status: "direct",
       displayUrl: normalized,
@@ -282,6 +284,9 @@ function hydrateAddonLogoCache() {
     return;
   }
   addonLogoCacheHydrated = true;
+  if (Platform.isTizen()) {
+    return;
+  }
   const cached = LocalStore.get(ADDON_LOGO_CACHE_KEY, {});
   const entries = cached && typeof cached === "object" && !Array.isArray(cached) ? cached : {};
   Object.keys(entries).forEach((url) => {
@@ -299,7 +304,11 @@ function hydrateAddonLogoCache() {
 }
 
 function persistAddonLogoCache() {
+  if (Platform.isTizen()) {
+    return;
+  }
   addonLogoCachePersistTimer = null;
+  const cacheLimit = Platform.isWebOS() ? ADDON_LOGO_TV_CACHE_LIMIT : ADDON_LOGO_CACHE_LIMIT;
   const entries = Array.from(addonLogoCache.entries())
     .filter(
       ([, entry]) =>
@@ -308,7 +317,7 @@ function persistAddonLogoCache() {
         String(entry.displayUrl || "").length <= ADDON_LOGO_CACHE_MAX_LENGTH
     )
     .sort((left, right) => Number(right[1].updatedAt || 0) - Number(left[1].updatedAt || 0))
-    .slice(0, ADDON_LOGO_CACHE_LIMIT);
+    .slice(0, cacheLimit);
   const payload = {};
   entries.forEach(([url, entry]) => {
     payload[url] = {
@@ -320,6 +329,9 @@ function persistAddonLogoCache() {
 }
 
 function scheduleAddonLogoCachePersist() {
+  if (Platform.isTizen()) {
+    return;
+  }
   if (addonLogoCachePersistTimer) {
     return;
   }

--- a/js/core/tmdb/tmdbMetadataService.js
+++ b/js/core/tmdb/tmdbMetadataService.js
@@ -2,7 +2,12 @@ import { TmdbSettingsStore } from "../../data/local/tmdbSettingsStore.js";
 import { TMDB_API_KEY } from "../../config.js";
 
 const TMDB_BASE_URL = "https://api.themoviedb.org/3";
-const IMAGE_BASE_URL = "https://image.tmdb.org/t/p/original";
+const TMDB_IMAGE_SIZES = {
+  poster: "w342",
+  backdrop: "w780",
+  logo: "w300",
+  still: "w300"
+};
 const TMDB_TRAILER_FALLBACK_LANGUAGE = "en-US";
 
 function resolveType(contentType) {
@@ -13,11 +18,16 @@ function resolveType(contentType) {
   return "movie";
 }
 
-function toImageUrl(path) {
+function toImageUrl(path, kind = "backdrop") {
   if (!path) {
     return null;
   }
-  return `${IMAGE_BASE_URL}${path}`;
+  const normalizedPath = String(path);
+  if (/^https?:\/\//i.test(normalizedPath)) {
+    return normalizedPath;
+  }
+  const size = TMDB_IMAGE_SIZES[kind] || kind;
+  return `https://image.tmdb.org/t/p/${size}${normalizedPath}`;
 }
 
 function normalizeTmdbArtworkLanguage(language = "") {
@@ -181,7 +191,7 @@ function mapCompanies(items = []) {
   return (Array.isArray(items) ? items : [])
     .map((company) => ({
       name: company?.name || "",
-      logo: toImageUrl(company?.logo_path || company?.logo || null)
+      logo: toImageUrl(company?.logo_path || company?.logo || null, "logo")
     }))
     .filter((company) => company.name || company.logo);
 }
@@ -259,9 +269,9 @@ export const TmdbMetadataService = {
     return {
       localizedTitle: data.title || data.name || null,
       description: data.overview || null,
-      backdrop: toImageUrl(data.backdrop_path),
-      poster: toImageUrl(data.poster_path),
-      logo: toImageUrl(logoPath),
+      backdrop: toImageUrl(data.backdrop_path, "backdrop"),
+      poster: toImageUrl(data.poster_path, "poster"),
+      logo: toImageUrl(logoPath, "logo"),
       genres: Array.isArray(data.genres)
         ? data.genres.map((genre) => genre.name).filter(Boolean)
         : [],
@@ -339,7 +349,7 @@ export const TmdbMetadataService = {
             title: episode?.name || "",
             overview: episode?.overview || "",
             airDate: episode?.air_date || "",
-            thumbnail: toImageUrl(episode?.still_path || null),
+            thumbnail: toImageUrl(episode?.still_path || null, "still"),
             runtime: Number(episode?.runtime || 0) || null
           }))
           .filter((episode) => !episode.key.endsWith(":0"));
@@ -372,9 +382,9 @@ export const TmdbMetadataService = {
         id: item?.id ? `tmdb:${String(item.id)}` : "",
         type: "movie",
         name: item?.title || item?.name || "Untitled",
-        poster: toImageUrl(item?.poster_path || null),
-        background: toImageUrl(item?.backdrop_path || null),
-        landscapePoster: toImageUrl(item?.backdrop_path || null),
+        poster: toImageUrl(item?.poster_path || null, "poster"),
+        background: toImageUrl(item?.backdrop_path || null, "backdrop"),
+        landscapePoster: toImageUrl(item?.backdrop_path || null, "backdrop"),
         releaseInfo: String(item?.release_date || "").slice(0, 4) || ""
       }))
       .filter((item) => item.id);
@@ -400,10 +410,10 @@ export const TmdbMetadataService = {
         id: item?.id ? `tmdb:${String(item.id)}` : "",
         type: type === "tv" ? "series" : "movie",
         name: item?.title || item?.name || "Untitled",
-        poster: toImageUrl(item?.poster_path || null),
-        background: toImageUrl(item?.backdrop_path || null),
-        backdrop: toImageUrl(item?.backdrop_path || null),
-        landscapePoster: toImageUrl(item?.backdrop_path || null),
+        poster: toImageUrl(item?.poster_path || null, "poster"),
+        background: toImageUrl(item?.backdrop_path || null, "backdrop"),
+        backdrop: toImageUrl(item?.backdrop_path || null, "backdrop"),
+        landscapePoster: toImageUrl(item?.backdrop_path || null, "backdrop"),
         description: item?.overview || "",
         releaseInfo:
           String(type === "tv" ? item?.first_air_date || "" : item?.release_date || "").slice(0, 4) ||

--- a/js/ui/screens/collection/folderDetailScreen.js
+++ b/js/ui/screens/collection/folderDetailScreen.js
@@ -30,7 +30,8 @@ import {
 } from "../../components/watchedTitleBadge.js";
 
 const TMDB_API_URL = "https://api.themoviedb.org/3";
-const TMDB_IMAGE_BASE_URL = "https://image.tmdb.org/t/p/original";
+const TMDB_POSTER_IMAGE_BASE_URL = "https://image.tmdb.org/t/p/w342";
+const TMDB_BACKDROP_IMAGE_BASE_URL = "https://image.tmdb.org/t/p/w780";
 const TRAKT_PAGE_SIZE = 50;
 const STREAMING_NETWORK_PRESETS = new Map([
   ["netflix", { title: "Netflix", tmdbId: 213 }],
@@ -71,11 +72,16 @@ function firstNonEmpty(...values) {
   return "";
 }
 
-function toImageUrl(path) {
+function toImageUrl(path, kind = "poster") {
   if (!path) {
     return "";
   }
-  return /^https?:\/\//i.test(String(path)) ? String(path) : `${TMDB_IMAGE_BASE_URL}${path}`;
+  const normalizedPath = String(path);
+  if (/^https?:\/\//i.test(normalizedPath)) {
+    return normalizedPath;
+  }
+  const baseUrl = kind === "backdrop" ? TMDB_BACKDROP_IMAGE_BASE_URL : TMDB_POSTER_IMAGE_BASE_URL;
+  return `${baseUrl}${normalizedPath}`;
 }
 
 function buildPlaceholderPosterDataUrl() {
@@ -398,8 +404,8 @@ function mapTmdbListItem(item = {}, mediaType = "movie") {
   if (!item?.id || !title) {
     return null;
   }
-  const posterUrl = toImageUrl(item.poster_path || item.posterPath);
-  const backdropUrl = toImageUrl(item.backdrop_path || item.backdropPath);
+  const posterUrl = toImageUrl(item.poster_path || item.posterPath, "poster");
+  const backdropUrl = toImageUrl(item.backdrop_path || item.backdropPath, "backdrop");
   return normalizeItem({
     id: `tmdb:${item.id}`,
     type,

--- a/js/ui/screens/home/homeScreen.js
+++ b/js/ui/screens/home/homeScreen.js
@@ -1354,9 +1354,10 @@ function saveContinueWatchingEnrichment(item = {}) {
     episodeTitle: normalized.episodeTitle,
     episodeDescription: normalized.episodeDescription
   };
+  const enrichmentCacheLimit = Platform.isTizen() || Platform.isWebOS() ? 50 : 200;
   const entries = Object.entries(cache)
     .sort(([, left], [, right]) => Number(right?.cachedAt || 0) - Number(left?.cachedAt || 0))
-    .slice(0, 200);
+    .slice(0, enrichmentCacheLimit);
   LocalStore.set(CW_ENRICHMENT_CACHE_KEY, Object.fromEntries(entries));
 }
 
@@ -1711,6 +1712,13 @@ function renderRowHeader(title, subtitle = "") {
   `;
 }
 
+function resolveContinueWatchingBlurNextUp(layoutPrefs) {
+  if (Platform.isTizen()) {
+    return false;
+  }
+  return Boolean(layoutPrefs?.blurContinueWatchingNextUp);
+}
+
 function renderContinueWatchingCard(item, index, options = {}) {
   const normalized = normalizeContinueWatchingItem(item);
   const subtitle = normalized.episodeTitle || "";
@@ -1729,6 +1737,10 @@ function renderContinueWatchingCard(item, index, options = {}) {
   const uniqueCardImageSources = uniqueNonEmptyValues(cardImageSources);
   const cardImage = uniqueCardImageSources[0] || "";
   const fallbackQueue = encodeHeroBackdropFallbacks(uniqueCardImageSources.slice(1));
+  const deferContinueImage = Platform.isTizen() || Platform.isWebOS();
+  const continueImageAttrs = cardImage
+    ? buildLazyImageAttributes(cardImage, { defer: deferContinueImage })
+    : "";
   return `
     <article class="home-content-card home-continue-card${blurNextUp ? " home-continue-card-blur-next-up" : ""} focusable"
              tabindex="0"
@@ -1745,7 +1757,7 @@ function renderContinueWatchingCard(item, index, options = {}) {
              data-item-type="${escapeAttribute(normalized.type || "movie")}"
              data-item-title="${escapeAttribute(normalized.title || "Untitled")}">
       <div class="home-continue-media">
-        ${cardImage ? `<img class="home-continue-bg" src="${escapeAttribute(cardImage)}"${fallbackQueue ? ` data-fallback-srcs="${escapeAttribute(fallbackQueue)}"` : ""} alt="" aria-hidden="true" decoding="async" loading="lazy" onerror="${buildImageFallbackErrorHandler()}" />` : ""}
+        ${cardImage ? `<img class="home-continue-bg" ${continueImageAttrs}${fallbackQueue ? ` data-fallback-srcs="${escapeAttribute(fallbackQueue)}"` : ""} alt="" aria-hidden="true" decoding="async" onerror="${buildImageFallbackErrorHandler()}" />` : ""}
         <span class="home-continue-badge">${escapeHtml(normalized.progressStatus || t("home.continueStatusContinue", {}, "Continue"))}</span>
         <div class="home-continue-copy">
           ${normalized.episodeCode ? `<div class="home-continue-kicker">${escapeHtml(normalized.episodeCode)}</div>` : ""}
@@ -7325,7 +7337,7 @@ export const HomeScreen = {
         continueWatchingLoading: Boolean(this.continueWatchingLoading),
         continueWatchingLoadingCount: effectiveContinueWatchingLoadingCount,
         useEpisodeThumbnailsInCw: this.layoutPrefs?.useEpisodeThumbnailsInCw !== false,
-        blurContinueWatchingNextUp: Boolean(this.layoutPrefs?.blurContinueWatchingNextUp),
+        blurContinueWatchingNextUp: resolveContinueWatchingBlurNextUp(this.layoutPrefs),
         rowItemLimit,
         showHeroSection,
         showPosterLabels,
@@ -7353,7 +7365,7 @@ export const HomeScreen = {
         loading: Boolean(this.continueWatchingLoading),
         loadingCount: effectiveContinueWatchingLoadingCount,
         useEpisodeThumbnails: this.layoutPrefs?.useEpisodeThumbnailsInCw !== false,
-        blurNextUp: Boolean(this.layoutPrefs?.blurContinueWatchingNextUp)
+        blurNextUp: resolveContinueWatchingBlurNextUp(this.layoutPrefs)
       });
       const legacyRowsPayload = renderLegacyCatalogRowsMarkup(this.rows, {
         layoutMode: this.layoutMode,
@@ -7552,7 +7564,7 @@ export const HomeScreen = {
     }
     const images = Array.from(
       this.container.querySelectorAll(
-        ".home-main .content-poster[data-src], .home-main .home-poster-landscape-logo[data-src]"
+        ".home-main .content-poster[data-src], .home-main .home-poster-landscape-logo[data-src], .home-main .home-continue-bg[data-src]"
       )
     );
     if (!images.length) {
@@ -8664,6 +8676,13 @@ export const HomeScreen = {
     }
     this.pendingHomeLazyImageAnchor = null;
     this.homeTruncationScope = null;
+    if (this.boundHomeEventContainer) {
+      this.boundHomeEventContainer.removeEventListener("focusin", this.boundHomeFocusInHandler);
+      this.boundHomeEventContainer.removeEventListener("click", this.boundHomeClickHandler);
+      this.boundHomeEventContainer.removeEventListener("mouseover", this.boundHomeMouseOverHandler);
+      this.boundHomeEventContainer.removeEventListener("wheel", this.boundHomeWheelHandler);
+      this.boundHomeEventContainer = null;
+    }
     this.cachedModernPortraitPosterMetrics = null;
     this.cachedModernLandscapePosterMetrics = null;
     ScreenUtils.hide(this.container);


### PR DESCRIPTION
## Summary

Improve Samsung Tizen home screen and Continue Watching performance by reducing image payload sizes, avoiding heavy localStorage work on TV, disabling GPU-intensive blur effects, lazy-loading CW images, and cleaning up leaked event listeners.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix
- [ ] Approved feature/change

## Affected area

- [x] Shared web app
- [x] Samsung Tizen
- [x] LG webOS
- [ ] Browser development mode
- [ ] Playback
- [ ] Audio tracks
- [ ] Subtitles
- [ ] Focus / Remote navigation
- [x] UI / Layout
- [ ] Resume / Watch progress
- [x] Continue Watching
- [ ] Next Episode / Auto-play
- [ ] Packaging / Build
- [ ] Nuvio WebTV Installer compatibility
- [ ] TizenBrew wrapper
- [ ] webOS Homebrew wrapper
- [ ] Documentation
- [ ] Other

## Why

Samsung Tizen TVs report sluggish home screen load and Continue Watching row navigation. The app was downloading multi-megabyte TMDB originals for small card thumbnails, parsing large addon logo caches from localStorage on every cold start, applying GPU-heavy blur filters, and accumulating delegated event listeners when returning to the home screen.

## Issue or approval

Related to #393

## Reproduction steps

1. Install Nuvio on a Samsung Tizen TV with a populated watch history and multiple catalog addons.
2. Open the home screen and wait for catalog rows and Continue Watching to render.
3. Navigate left/right through the Continue Watching row repeatedly.
4. Return to home from detail screens multiple times during a session.
5. Observe slow image decode, CW row stutter, and gradually worsening responsiveness.

## Old behavior

TMDB images resolved to `/t/p/original` (often 2–8 MB each). Addon logos were hydrated from and persisted to localStorage on Tizen. Continue Watching blur could apply `blur(12px) + scale(1.08)` on TV. CW images loaded immediately via `src`. CW enrichment cache stored up to 200 entries. Home delegated event listeners were not removed on cleanup.

## New behavior

TMDB images use `w342` for posters and `w780` for backdrops/logos/stills. Tizen skips addon logo localStorage (direct URLs, in-memory cap of 12). CW blur is forced off on Tizen. CW images lazy-load via existing `data-src` hydration on Tizen/webOS. CW enrichment cache caps at 50 entries on TV. Home cleanup removes delegated `focusin`, `click`, `mouseover`, and `wheel` listeners.

## Platform impact

- Samsung Tizen: Primary target — all performance fixes apply.
- LG webOS: CW lazy images, CW cache cap, and addon logo in-memory cap apply.
- Browser development mode: TMDB image sizing only (smaller images, no behavior change).
- Installer / packaging: No changes.
- Wrapper repositories: No changes.

## UI / behavior / playback impact

- [x] No UI change
- [x] No behavior change
- [x] No playback change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] Playback changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval
- [ ] Playback change has explicit maintainer approval

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact
- [ ] Tizen `.wgt` packaging changed
- [ ] webOS `.ipk` packaging changed
- [ ] App identifiers or metadata changed
- [ ] `local.properties` / environment handling changed
- [ ] `sync:tizen` changed
- [ ] `sync:webos` changed
- [ ] Nuvio WebTV Installer compatibility changed
- [ ] TizenBrew wrapper support changed
- [ ] webOS Homebrew metadata support changed

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I included a linked issue, reproduction steps, and testing notes if this is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Does not include watch-progress parse caching (separate PR), profile picker changes, bundle splitting, home incremental render refactor, or playback/P2P changes.

## Testing

Verified via build pipeline. Changes are performance-only with no intended UI, behavior, or playback differences.

### Devices / platforms tested

Build verification on Linux (Node.js v22). No physical TV sideload performed by contributor.

### Commands tested

```sh
npm run build
```

## Manual test flow

Build compiles all changed modules without errors. Logic review confirms TV-gated paths use existing `Platform.isTizen()` and `Environment.isTizen()` patterns already present in the codebase.

## Screenshots / Video

Not a UI change

## Logs

Not applicable

## Regression risk

Low. TMDB sizing affects all platforms but only reduces image resolution. TV-specific paths are gated behind existing platform checks. Addon logos on Tizen fall back to direct URLs (same as webOS path). Event listener cleanup mirrors patterns from merged PR #392.

## Breaking changes

None.

## Linked issues

Related to #393
