### PR TITLE
fix(tizen): disconnect episode thumbnail IntersectionObserver on cleanup

### DIFF
--- a/js/ui/screens/detail/metaDetailsScreen.js
+++ b/js/ui/screens/detail/metaDetailsScreen.js
@@ -8807,6 +8807,10 @@ export const MetaDetailsScreen = {
     }
     this.stopEpisodeHoldRepeat();
     this.episodeThumbnailPrefetchCache = new Set();
+    if (this.episodeThumbObserver) {
+      try { this.episodeThumbObserver.disconnect(); } catch (_) {}
+      this.episodeThumbObserver = null;
+    }
     this.selectedSeasonEpisodeState = null;
     if (this.episodeTrackScrollNode && this.episodeTrackScrollHandler) {
       this.episodeTrackScrollNode.removeEventListener("scroll", this.episodeTrackScrollHandler);


### PR DESCRIPTION
## Summary

Disconnect the episode thumbnail IntersectionObserver in MetaDetailsScreen cleanup to prevent observer accumulation during repeated detail screen visits on Samsung Tizen.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix
- [ ] Approved feature/change

## Affected area

- [x] Shared web app
- [x] Samsung Tizen
- [ ] LG webOS
- [ ] Browser development mode
- [ ] Playback
- [ ] Audio tracks
- [ ] Subtitles
- [ ] Focus / Remote navigation
- [ ] UI / Layout
- [ ] Resume / Watch progress
- [ ] Continue Watching
- [ ] Next Episode / Auto-play
- [ ] Packaging / Build
- [ ] Nuvio WebTV Installer compatibility
- [ ] TizenBrew wrapper
- [ ] webOS Homebrew wrapper
- [ ] Documentation
- [ ] Other

## Why

MetaDetailsScreen creates an IntersectionObserver for lazy episode thumbnail loading but never disconnects it in cleanup(). Each detail → back → detail cycle leaves a live observer and callback registered. Over a long TV session this degrades performance, matching the class of memory/handler leaks fixed in PR #392.

## Issue or approval

Related to #393 (performance degradation during extended TV sessions). No separate issue filed for this specific observer leak.

## Reproduction steps

1. Open Nuvio on a Samsung Tizen TV.
2. Navigate to a series detail screen with multiple seasons/episodes.
3. Press Back to return to the previous screen.
4. Re-enter the same detail screen.
5. Repeat steps 3–4 ten or more times during a single session.
6. Observe gradually increasing lag when scrolling episodes and navigating the app.

## Old behavior

`episodeThumbObserver` was created in `mount()` but never `disconnect()`'d in `cleanup()`. Each revisit added another live IntersectionObserver.

## New behavior

`cleanup()` disconnects and nulls `episodeThumbObserver`, matching the teardown pattern used for other handlers in the same function.

## Platform impact

- Samsung Tizen: Primary beneficiary — extended sessions no longer accumulate observers.
- LG webOS: Same shared code path benefits from the fix.
- Browser development mode: Same shared code path; no platform-specific changes.
- Installer / packaging: No changes.
- Wrapper repositories: No changes.

## UI / behavior / playback impact

- [x] No UI change
- [x] No behavior change
- [x] No playback change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] Playback changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval
- [ ] Playback change has explicit maintainer approval

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact
- [ ] Tizen `.wgt` packaging changed
- [ ] webOS `.ipk` packaging changed
- [ ] App identifiers or metadata changed
- [ ] `local.properties` / environment handling changed
- [ ] `sync:tizen` changed
- [ ] `sync:webos` changed
- [ ] Nuvio WebTV Installer compatibility changed
- [ ] TizenBrew wrapper support changed
- [ ] webOS Homebrew metadata support changed

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I included a linked issue, reproduction steps, and testing notes if this is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Four-line cleanup addition only. No changes to observer creation logic, episode rendering, focus management, or other screens.

## Testing

Verified via build pipeline. Change is teardown-only with no first-visit behavior difference.

### Devices / platforms tested

Build verification on Linux (Node.js v22). No physical TV sideload performed by contributor.

### Commands tested

```sh
npm run build
```

## Manual test flow

Build compiles without errors. Code review confirms `disconnect()` is called in the existing `cleanup()` function alongside other handler teardown.

## Screenshots / Video

Not a UI change

## Logs

Not applicable

## Regression risk

Very low. Only adds missing teardown for an existing observer. First visit to detail screen is unchanged. Same pattern as merged PR #392.

## Breaking changes

None.

## Linked issues

Related to #393
