### PR TITLE
fix(tizen): snap profile picker background on TV platforms

### DIFF
--- a/js/core/profile/profileSelectionScreen.js
+++ b/js/core/profile/profileSelectionScreen.js
@@ -14,6 +14,7 @@ import { ThemeManager } from "../../ui/theme/themeManager.js";
 import { I18n } from "../../i18n/index.js";
 import { NuvioDialog } from "../../ui/components/nuvioDialog.js";
 import { detailWatchedEnrichmentService } from "../../data/repository/detailWatchedEnrichmentService.js";
+import { Platform } from "../../platform/index.js";
 
 const PINNED_AVATAR_CATEGORIES = ["anime", "animation", "tv", "movie", "gaming"];
 const DEFAULT_PROFILE_COLOR = "#f5f5f5";
@@ -1247,6 +1248,16 @@ export const ProfileSelectionScreen = {
     if (this._bgAnimRaf) {
       cancelAnimationFrame(this._bgAnimRaf);
       this._bgAnimRaf = null;
+    }
+
+    if (
+      Platform.isTizen() ||
+      Platform.isWebOS() ||
+      globalThis.document?.body?.classList?.contains("performance-constrained")
+    ) {
+      this._bgCurrentColor = targetColor;
+      screen.style.background = this.buildBackgroundStyleFromColor(targetColor, themeColors);
+      return;
     }
 
     const fromColor = this._bgCurrentColor || targetColor;


### PR DESCRIPTION
## Summary

Skip the 520ms RAF gradient background tween on profile picker navigation for Tizen, webOS, and other performance-constrained TV runtimes.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix
- [ ] Approved feature/change

## Affected area

- [x] Shared web app
- [x] Samsung Tizen
- [x] LG webOS
- [ ] Browser development mode
- [ ] Playback
- [ ] Audio tracks
- [ ] Subtitles
- [x] Focus / Remote navigation
- [x] UI / Layout
- [ ] Resume / Watch progress
- [ ] Continue Watching
- [ ] Next Episode / Auto-play
- [ ] Packaging / Build
- [ ] Nuvio WebTV Installer compatibility
- [ ] TizenBrew wrapper
- [ ] webOS Homebrew wrapper
- [ ] Documentation
- [ ] Other

## Why

Issue #391 reports profile picker lag on TV when moving between profiles. `updateBackground()` runs a 520ms requestAnimationFrame loop (~31 full-screen gradient repaints per profile move) and does not respect performance-constrained runtimes, while other screens already snap on TV.

## Issue or approval

Fixes #391

## Reproduction steps

1. Create two or more profiles in Nuvio.
2. Open the app on a Samsung Tizen TV (or LG webOS TV).
3. On the profile picker screen, move left/right between profiles using the remote.
4. Observe visible stutter and lag during the background gradient animation.

## Old behavior

Every profile focus change triggered a 520ms RAF gradient tween with ~31 full-screen repaints, regardless of platform performance constraints.

## New behavior

On Tizen, webOS, and performance-constrained runtimes, the background snaps immediately to the target profile color. Browser and non-constrained platforms keep the existing tween.

## Platform impact

- Samsung Tizen: Background snaps instantly on profile navigation — eliminates gradient repaint stutter.
- LG webOS: Same snap behavior applied.
- Browser development mode: Unchanged — gradient tween still runs on capable platforms.
- Installer / packaging: No changes.
- Wrapper repositories: No changes.

## UI / behavior / playback impact

- [x] No UI change
- [ ] No behavior change
- [ ] No playback change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] Playback changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval
- [ ] Playback change has explicit maintainer approval

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact
- [ ] Tizen `.wgt` packaging changed
- [ ] webOS `.ipk` packaging changed
- [ ] App identifiers or metadata changed
- [ ] `local.properties` / environment handling changed
- [ ] `sync:tizen` changed
- [ ] `sync:webos` changed
- [ ] Nuvio WebTV Installer compatibility changed
- [ ] TizenBrew wrapper support changed
- [ ] webOS Homebrew metadata support changed

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I included a linked issue, reproduction steps, and testing notes if this is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Early-return snap in `updateBackground()` only. Does not change profile selection logic, focus management, or profile data handling.

## Testing

Verified via build pipeline. TV platform gating uses existing `Platform.isTizen()`, `Platform.isWebOS()`, and `performance-constrained` checks.

### Devices / platforms tested

Build verification on Linux (Node.js v22). No physical TV sideload performed by contributor.

### Commands tested

```sh
npm run build
```

## Manual test flow

Build compiles without errors. Code review confirms snap path sets background to target color immediately and returns before the RAF loop on TV platforms.

## Screenshots / Video

Not a UI change

## Logs

Not applicable

## Regression risk

Low. Only affects profile picker background animation on TV platforms. Final background color is identical — only the transition is instant instead of animated. Browser behavior unchanged.

## Breaking changes

None.

## Linked issues

Fixes #391
