### PR TITLE
fix(streams): skip metadata-only addons during stream discovery

### DIFF
--- a/js/data/repository/streamRepository.js
+++ b/js/data/repository/streamRepository.js
@@ -112,7 +112,16 @@ class StreamRepository {
       try {
         const canStream = supportsStreamType(addon);
         const canMeta = supportsMetaType(addon);
-        if (!canStream && !canMeta) {
+        // Meta-only stream discovery is a compatibility path for debrid cloud
+        // items, which are exposed through the `other` type. Regular movie/series
+        // metadata addons must not be queried as stream sources.
+        const shouldTryInlineMetaStreams =
+          canMeta &&
+          (canStream ||
+            String(type || "")
+              .trim()
+              .toLowerCase() === "other");
+        if (!canStream && !shouldTryInlineMetaStreams) {
           return null;
         }
         const orderIndex = Number(addon.orderIndex ?? Number.MAX_SAFE_INTEGER);
@@ -127,7 +136,7 @@ class StreamRepository {
         // Some addons (e.g. debrid cloud catalogs) deliver the playable stream
         // inline in the meta's videos[].streams[] and only expose a meta resource
         // for the content type, not a stream resource. Fall back to that here.
-        if (addonStreams.length === 0 && canMeta) {
+        if (addonStreams.length === 0 && shouldTryInlineMetaStreams) {
           addonStreams = await this.fetchInlineStreamsFromMeta(addon, type, videoId);
         }
         if (addonStreams.length === 0) {


### PR DESCRIPTION
## Summary

Prevent metadata-only addons from being treated as loading stream sources for regular movie and series requests.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix
- [ ] Approved feature/change

## Affected area

- [x] Shared web app
- [x] Samsung Tizen
- [x] LG webOS
- [x] Browser development mode
- [ ] Playback
- [ ] Audio tracks
- [ ] Subtitles
- [ ] Focus / Remote navigation
- [ ] UI / Layout
- [ ] Resume / Watch progress
- [ ] Continue Watching
- [ ] Next Episode / Auto-play
- [ ] Packaging / Build
- [ ] Nuvio WebTV Installer compatibility
- [ ] TizenBrew wrapper
- [ ] webOS Homebrew wrapper
- [ ] Documentation
- [x] Other - stream source discovery

## Why

The inline-meta stream compatibility path considered every compatible `meta` resource a possible stream source. Metadata-only addons such as AIOMetadata were therefore announced as loading sources and queried during stream discovery, delaying real stream results until the metadata request returned without streams.

## Issue or approval

Fixes #394

## Reproduction steps

1. Install a metadata-only addon such as AIOMetadata alongside one or more stream addons.
2. Open any movie or series and request its streams.
3. Observe that AIOMetadata appears as a loading source even though it does not advertise a stream resource.
4. Wait for its request to finish and observe that it disappears before the real stream addons remain.

## Old behavior

Any addon with a compatible `meta` resource was treated as a possible stream source. Metadata-only addons appeared in the loading source list and were queried for inline streams during ordinary movie and series discovery.

## New behavior

Metadata-only addons are skipped for ordinary movie and series stream discovery. Inline streams from metadata remain supported for the special `other` content type used by debrid-cloud catalogs, and addons that advertise a real stream resource retain the existing metadata fallback when their stream response is empty.

## Platform impact

- Samsung Tizen: Shared stream discovery no longer announces or queries metadata-only addons; no Tizen-specific APIs changed.
- LG webOS: Receives the same shared-code fix; no webOS-specific APIs changed.
- Browser development mode: Used for post-fix manual validation with the affected addon combination.
- Installer / packaging: No impact.
- Wrapper repositories: No impact.

## UI / behavior / playback impact

- [x] No UI change
- [ ] No behavior change
- [x] No playback change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] Playback changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval
- [ ] Playback change has explicit maintainer approval

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact
- [ ] Tizen `.wgt` packaging changed
- [ ] webOS `.ipk` packaging changed
- [ ] App identifiers or metadata changed
- [ ] `local.properties` / environment handling changed
- [ ] `sync:tizen` changed
- [ ] `sync:webos` changed
- [ ] Nuvio WebTV Installer compatibility changed
- [ ] TizenBrew wrapper support changed
- [ ] webOS Homebrew metadata support changed

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I included a linked issue, reproduction steps, and testing notes if this is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

This change only narrows eligibility for the existing inline-meta stream fallback. It does not change addon manifests, metadata loading elsewhere, stream response mapping, playback, UI styling, packaging, dependencies, or platform adapters. The debrid-cloud `other` compatibility path remains supported.

## Testing

### Devices / platforms tested

- Chrome on macOS using browser development mode: post-fix behavior manually verified.
- Samsung QN90C / Tizen 9.0: affected device from issue #394; post-fix device test not performed.
- LG webOS: independently reported affected in issue #394; post-fix device test not performed.

### Commands tested

```sh
npm ci
npm run build
npm run lint
npx eslint js/data/repository/streamRepository.js
node --check js/data/repository/streamRepository.js
npm run package:tizen
```

The repository-layer regression check used mocked manifests and verified both boundaries: metadata-only movie addons receive no request or loading callback, while a metadata-only `other` addon still returns an inline playable stream.

`npm run format:check` also reports an existing formatting issue in `js/ui/screens/home/homeUtils.js`, which is outside this PR and was left unchanged per the one-issue policy.

## Manual test flow

1. Run the local browser build.
2. Install Cinemeta and AIOMetadata alongside AIOStreams, Torrentio, Comet, and other stream addons.
3. Open content and load its sources.
4. Confirm Cinemeta and AIOMetadata do not appear as loading stream sources.
5. Confirm AIOStreams, Torrentio, Comet, and the other genuine stream addons still appear and return streams.

## Screenshots / Video

Not a UI change. Issue #394 contains the original visible loading-state evidence; the corrected source list was manually verified in browser development mode.

## Logs

Not applicable. This changes addon eligibility before requests are made and does not modify playback or platform APIs.

## Regression risk

The main risk is excluding an addon that intentionally embeds streams in metadata without advertising a stream resource. The fallback remains enabled for the `other` type used by the debrid-cloud case that introduced this compatibility behavior. A targeted regression check confirmed that path still returns inline streams.

## Breaking changes

None.

## Linked issues

Fixes #394
