### PR TITLE
feat(player): show buffered media progress

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -11380,6 +11380,7 @@ html.legacy-webos .debug-console-log-frame {
 }
 
 .player-progress-track {
+  position: relative;
   width: 100%;
   height: 6px;
   border-radius: 3px;
@@ -11395,10 +11396,32 @@ html.legacy-webos .debug-console-log-frame {
   background: rgba(255, 255, 255, 0.45);
 }
 
+.player-progress-buffered,
 .player-progress-fill {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
   width: 0%;
   height: 100%;
   border-radius: 3px;
+}
+
+.player-progress-buffered {
+  z-index: 1;
+  background: var(--player-secondary);
+  opacity: 0;
+  transition:
+    width 250ms linear,
+    opacity 120ms ease;
+}
+
+.player-progress-buffered.is-visible {
+  opacity: 0.4;
+}
+
+.player-progress-fill {
+  z-index: 2;
   background: var(--player-secondary);
   transition: width 150ms linear;
 }

--- a/js/core/player/playerController.js
+++ b/js/core/player/playerController.js
@@ -2161,6 +2161,48 @@ export const PlayerController = {
     return Math.max(0, Number(this.video?.duration || 0));
   },
 
+  getBufferedTimeSeconds() {
+    // AVPlay reports buffering-operation progress, not a buffered media
+    // timestamp. Returning no value prevents the UI from presenting that
+    // percentage as playable time.
+    if (this.isUsingAvPlay()) {
+      return null;
+    }
+
+    const video = this.video;
+    const durationSeconds = Number(video?.duration || 0);
+    const currentSeconds = Number(video?.currentTime || 0);
+    const ranges = video?.buffered;
+    if (
+      !ranges
+      || !Number.isFinite(durationSeconds)
+      || durationSeconds <= 0
+      || !Number.isFinite(currentSeconds)
+      || currentSeconds < 0
+    ) {
+      return null;
+    }
+
+    try {
+      for (let index = 0; index < Number(ranges.length || 0); index += 1) {
+        const startSeconds = Number(ranges.start(index));
+        const endSeconds = Number(ranges.end(index));
+        if (
+          Number.isFinite(startSeconds)
+          && Number.isFinite(endSeconds)
+          && startSeconds <= currentSeconds + 0.25
+          && endSeconds >= currentSeconds - 0.25
+        ) {
+          return Math.max(0, Math.min(endSeconds, durationSeconds));
+        }
+      }
+    } catch (_) {
+      // TimeRanges can change while it is being read on older TV engines.
+    }
+
+    return null;
+  },
+
   seekToSeconds(targetSeconds) {
     const seconds = Number(targetSeconds || 0);
     if (!Number.isFinite(seconds) || seconds < 0) {

--- a/js/ui/screens/player/playerScreen.js
+++ b/js/ui/screens/player/playerScreen.js
@@ -4324,6 +4324,7 @@ export const PlayerScreen = {
             <div class="player-controls-bar">
               <div id="playerProgressShell" class="player-progress-shell focusable" tabindex="-1" data-player-pointer-action="progress">
                 <div class="player-progress-track">
+                  <div id="playerProgressBuffered" class="player-progress-buffered"></div>
                   <div id="playerProgressFill" class="player-progress-fill"></div>
                 </div>
               </div>
@@ -4395,12 +4396,15 @@ export const PlayerScreen = {
       progressShell: uiRoot.querySelector("#playerProgressShell"),
       clock: uiRoot.querySelector("#playerClock"),
       endsAt: uiRoot.querySelector("#playerEndsAt"),
+      progressBuffered: uiRoot.querySelector("#playerProgressBuffered"),
       progressFill: uiRoot.querySelector("#playerProgressFill"),
       controlButtons: uiRoot.querySelector("#playerControlButtons"),
       timeLabel: uiRoot.querySelector("#playerTimeLabel"),
       startupErrorButton: uiRoot.querySelector("#playerStartupErrorOverlay .player-startup-error-button")
     } : null;
     this.lastUiTickState = {
+      bufferedVisible: false,
+      bufferedWidth: "",
       progressWidth: "",
       clockText: "",
       clockMinuteKey: "",
@@ -7085,6 +7089,10 @@ export const PlayerScreen = {
       this.updateUiTick();
     };
 
+    const onProgress = () => {
+      this.updateUiTick();
+    };
+
     const onLoadedMetadata = () => {
       if (this.isStartupErrorVisible()) {
         return;
@@ -7389,6 +7397,7 @@ export const PlayerScreen = {
       ["playing", onPlaying],
       ["error", onError],
       ["pause", onPause],
+      ["progress", onProgress],
       ["timeupdate", onTimeUpdate],
       ["loadedmetadata", onLoadedMetadata],
       ["loadeddata", onPlayable],
@@ -7956,6 +7965,14 @@ export const PlayerScreen = {
     return Number(PlayerController.video?.duration || 0);
   },
 
+  getPlaybackBufferedSeconds() {
+    if (typeof PlayerController.getBufferedTimeSeconds !== "function") {
+      return null;
+    }
+    const bufferedSeconds = PlayerController.getBufferedTimeSeconds();
+    return bufferedSeconds == null ? null : Number(bufferedSeconds);
+  },
+
   getPlaybackSpeed() {
     if (typeof PlayerController.getPlaybackRate === "function") {
       return Number(PlayerController.getPlaybackRate() || 1);
@@ -8257,6 +8274,25 @@ export const PlayerScreen = {
     const progress = duration > 0 ? clamp(effectiveProgressSeconds / duration, 0, 1) : 0;
     const uiRefs = this.uiRefs || {};
     const uiState = this.lastUiTickState || (this.lastUiTickState = {});
+    const progressBuffered = uiRefs.progressBuffered;
+    if (progressBuffered) {
+      const bufferedSeconds = this.getPlaybackBufferedSeconds();
+      const bufferedVisible = Number.isFinite(bufferedSeconds)
+        && duration > 0
+        && bufferedSeconds > current + 0.25;
+      const bufferedProgress = bufferedVisible
+        ? clamp(bufferedSeconds / duration, 0, 1)
+        : 0;
+      const nextBufferedWidth = `${Math.round(bufferedProgress * 10000) / 100}%`;
+      if (uiState.bufferedWidth !== nextBufferedWidth) {
+        progressBuffered.style.width = nextBufferedWidth;
+        uiState.bufferedWidth = nextBufferedWidth;
+      }
+      if (uiState.bufferedVisible !== bufferedVisible) {
+        progressBuffered.classList.toggle("is-visible", bufferedVisible);
+        uiState.bufferedVisible = bufferedVisible;
+      }
+    }
     const progressFill = uiRefs.progressFill;
     if (progressFill) {
       const nextWidth = `${Math.round(progress * 10000) / 100}%`;


### PR DESCRIPTION
## Summary

Adds a lower-opacity buffered-media layer beneath the played fill on the player progress bar. The layer uses reliable playable-media time only and hides when the active engine cannot report a meaningful buffered range.

## PR type

Approval is pending in #416, so this draft intentionally does not claim an approved PR type yet.

- [ ] Translation/localization only
- [ ] Critical bug fix
- [ ] Approved feature/change

## Affected area

- [x] Shared web app
- [x] Samsung Tizen
- [x] LG webOS
- [x] Browser development mode
- [x] Playback
- [ ] Audio tracks
- [ ] Subtitles
- [ ] Focus / Remote navigation
- [x] UI / Layout
- [ ] Resume / Watch progress
- [ ] Continue Watching
- [ ] Next Episode / Auto-play
- [ ] Packaging / Build
- [ ] Nuvio WebTV Installer compatibility
- [ ] TizenBrew wrapper
- [ ] webOS Homebrew wrapper
- [ ] Documentation
- [ ] Other

## Why

NuvioWeb currently shows only playback position. NuvioTV on Android also shows the buffered playable position as a translucent accent section, helping users understand how much media is ready ahead of the playhead.

## Issue or approval

Feature request #416. Explicit maintainer approval is still pending; this PR is a draft and must not be marked ready before approval.

## Reproduction steps

1. Play media that reports a finite duration and buffered media ranges.
2. Open the player controls.
3. Observe that current main shows only the solid played fill and the remaining track.
4. Compare with NuvioTV, which shows a translucent buffered section ahead of the played fill.

## Old behavior

The progress bar contained one track and one played fill. No active engine buffered timestamp was read or displayed.

## New behavior

The controller reads the HTML media TimeRanges entry containing the current playhead. The player renders its endpoint as a lower-opacity accent layer beneath the played fill, updates it on media progress events and normal UI ticks, and hides it for unknown durations, empty/discontinuous ranges, or unsupported engines such as Samsung AVPlay.

Torrent download bytes and completion percentage are not used.

## Platform impact

- Samsung Tizen: Shared UI support is included. Manually validated on Samsung QN90C / Tizen 9.0 with the native-file HTML engine. AVPlay remains unchanged and reports no buffered layer because it has no buffered timestamp API.
- LG webOS: Uses the shared HTML media element and is expected to report TimeRanges where supported. Physical-device validation is pending.
- Browser development mode: Manually validated; buffered progress appears for streams exposing video.buffered.
- Installer / packaging: No implementation changes. Production WGT packaging succeeds.
- Wrapper repositories: No changes.

## UI / behavior / playback impact

- [ ] No UI change
- [x] No behavior change
- [x] No playback change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] Playback changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval
- [ ] Playback change has explicit maintainer approval

The UI approval box remains unchecked until a maintainer approves #416.

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact
- [ ] Tizen `.wgt` packaging changed
- [ ] webOS `.ipk` packaging changed
- [ ] App identifiers or metadata changed
- [ ] `local.properties` / environment handling changed
- [ ] `sync:tizen` changed
- [ ] `sync:webos` changed
- [ ] Nuvio WebTV Installer compatibility changed
- [ ] TizenBrew wrapper support changed
- [ ] webOS Homebrew metadata support changed

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [ ] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [ ] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I included a linked issue, reproduction steps, and testing notes if this is a critical bug fix.
- [x] I listed the testing performed below.

The two approval-dependent boxes remain unchecked while this PR is a draft.

## Scope boundaries

No engine-selection changes, buffering-policy changes, torrent-progress mapping, seeking changes, dependencies, packaging changes, refactors, or unrelated player UI changes. The temporary Samsung engine override and diagnostic text used during device validation are not included.

## Testing

### Devices / platforms tested

- Samsung QN90C, Tizen 9.0, custom WGT: buffered section confirmed with native-file HTML playback for tested 1080p and multiple 4K streams exposing TimeRanges.
- Browser development mode on macOS: buffered section confirmed for streams exposing TimeRanges.
- LG webOS physical device: not available; shared HTML-media behavior only.

### Commands tested

```sh
npm run build
npm run package:tizen
```

A focused runtime check also covered active range selection, discontinuous-range hiding, duration clamping, and AVPlay suppression.

## Manual test flow

1. Build and install the custom WGT.
2. Start playback with an HTML media engine/source.
3. Open player controls and confirm the translucent accent section extends beyond the solid played section.
4. Pause and resume playback and confirm updates continue.
5. Test sources that expose no usable range and confirm the buffered layer hides.
6. Confirm the ordinary playback position, seeking, audio, and subtitles continue to work.

## Screenshots / Video

Samsung Tizen after:

<img width="900" alt="Buffered progress working on Samsung Tizen" src="https://github.com/user-attachments/assets/744843bb-51f7-407a-94fd-feeaf86e23e6" />

NuvioWeb before:

<img width="900" alt="NuvioWeb before buffered progress" src="https://github.com/user-attachments/assets/801571ec-2f82-4ab1-bd35-ea7ff23f7970" />

NuvioTV reference:

<img width="900" alt="NuvioTV buffered progress reference" src="https://github.com/user-attachments/assets/a4387da8-cd3a-4fa6-8b79-07fb2ece0219" />

## Logs

No crash, blank screen, playback failure, or platform API error was observed. No error logs are relevant to this visual telemetry change.

## Regression risk

Low and limited to progress-bar presentation. Older TV engines can return empty, changing, or discontinuous TimeRanges; reads are guarded, clamped to duration, restricted to the range containing the playhead, and hidden when unreliable. Played progress remains layered above buffered progress.

## Breaking changes

None.

## Linked issues

Feature request #416 — awaiting explicit maintainer approval.
