### PR TITLE
fix(detail): align episode card layout and sizing with NuvioTV

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -20428,48 +20428,56 @@ html.no-css-grid .cast-detail-meta {
 }
 
 .series-episode-track {
-  gap: 40px;
-  padding: 36px var(--detail-episode-safe-x);
+  gap: 28px;
+  padding: 28px 64px;
 }
 
 .series-episode-card {
-  flex-basis: 800px;
-  width: 800px;
-  border-radius: 40px;
+  flex-basis: 560px;
+  width: 560px;
+  border-radius: 32px;
 }
 
 .series-episode-thumb {
-  height: 526px;
-  border-radius: 40px;
+  height: 358px;
+  border-radius: 32px;
 }
 
 .series-episode-copy {
-  padding: 40px 40px 48px;
+  padding: 28px 28px 32px;
   gap: 12px;
 }
 
 .series-episode-badge {
-  padding: 10px 20px;
-  border-radius: 16px;
+  padding: 6px 14px;
+  border-radius: 10px;
   font-size: 20px;
   line-height: 28px;
-  letter-spacing: 2px;
+  letter-spacing: 1.6px;
 }
 
 .series-episode-title {
-  min-height: 56px;
+  display: block;
+  min-height: 38px;
   font-size: 32px;
-  line-height: 56px;
+  line-height: 38px;
+  -webkit-line-clamp: 1;
+  line-clamp: 1;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .series-episode-overview {
   font-size: 28px;
-  line-height: 44px;
+  line-height: 32px;
+  max-height: 96px;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
 }
 
 .series-episode-meta {
   gap: 24px;
-  min-height: 32px;
+  min-height: 28px;
   font-size: 20px;
   line-height: 28px;
 }
@@ -20479,8 +20487,8 @@ html.no-css-grid .cast-detail-meta {
 }
 
 .series-episode-runtime-icon {
-  width: 32px;
-  height: 32px;
+  width: 26px;
+  height: 26px;
 }
 
 .series-episode-meta .series-imdb-badge {
@@ -20488,39 +20496,282 @@ html.no-css-grid .cast-detail-meta {
 }
 
 .series-episode-meta .series-imdb-badge img {
-  width: 56px;
-  height: 28px;
+  width: 44px;
+  height: 22px;
 }
 
 .series-episode-progress {
-  margin-top: 4px;
+  position: absolute;
+  right: 28px;
+  bottom: 14px;
+  left: 28px;
+  width: auto;
   height: 8px;
+  margin-top: 0;
 }
 
 .series-episode-status {
-  top: 32px;
-  left: 32px;
-  width: 64px;
-  height: 64px;
+  top: 20px;
+  left: 20px;
+  width: 44px;
+  height: 44px;
 }
 
 .series-episode-status.complete {
-  font-size: 40px;
+  font-size: 28px;
 }
 
 .series-watched-badge-svg {
-  width: 40px;
-  height: 40px;
+  width: 28px;
+  height: 28px;
 }
 
 .series-episode-unavailable {
-  top: 32px;
-  right: 32px;
-  padding: 10px 20px;
-  border-radius: 16px;
+  top: 20px;
+  right: 20px;
+  padding: 6px 14px;
+  border-radius: 10px;
   font-size: 20px;
   line-height: 28px;
-  letter-spacing: 2px;
+  letter-spacing: 1.6px;
+}
+
+/* Mirror the responsive card tiers in NuvioTV EpisodesSection.kt. The Web
+   detail port uses a 2x Android dp-to-CSS-pixel mapping. */
+@media (min-width: 1520px) {
+  .series-episode-track {
+    gap: 32px;
+    padding: 32px 96px;
+  }
+
+  .series-episode-card {
+    flex-basis: 640px;
+    width: 640px;
+  }
+
+  .series-episode-thumb {
+    height: 414px;
+  }
+
+  .series-episode-copy {
+    padding: 32px 32px 40px;
+  }
+
+  .series-episode-badge {
+    padding: 8px 16px;
+    border-radius: 12px;
+    letter-spacing: 1.8px;
+  }
+
+  .series-episode-title {
+    min-height: 44px;
+    line-height: 44px;
+  }
+
+  .series-episode-overview {
+    line-height: 36px;
+    max-height: 108px;
+  }
+
+  .series-episode-runtime-icon {
+    width: 28px;
+    height: 28px;
+  }
+
+  .series-episode-meta .series-imdb-badge img {
+    width: 48px;
+    height: 24px;
+  }
+
+  .series-episode-progress {
+    right: 32px;
+    bottom: 16px;
+    left: 32px;
+  }
+
+  .series-episode-status {
+    top: 24px;
+    left: 24px;
+    width: 48px;
+    height: 48px;
+  }
+
+  .series-episode-status.complete {
+    font-size: 32px;
+  }
+
+  .series-watched-badge-svg {
+    width: 32px;
+    height: 32px;
+  }
+
+  .series-episode-unavailable {
+    top: 24px;
+    right: 24px;
+    padding: 8px 16px;
+    border-radius: 12px;
+    letter-spacing: 1.8px;
+  }
+}
+
+@media (min-width: 2000px) {
+  .series-episode-track {
+    gap: 36px;
+    padding: 36px 104px;
+  }
+
+  .series-episode-card {
+    flex-basis: 720px;
+    width: 720px;
+    border-radius: 36px;
+  }
+
+  .series-episode-thumb {
+    height: 470px;
+    border-radius: 36px;
+  }
+
+  .series-episode-copy {
+    padding: 36px 36px 44px;
+  }
+
+  .series-episode-badge {
+    padding: 8px 18px;
+    border-radius: 14px;
+  }
+
+  .series-episode-title {
+    min-height: 50px;
+    line-height: 50px;
+  }
+
+  .series-episode-overview {
+    line-height: 40px;
+    max-height: 160px;
+    -webkit-line-clamp: 4;
+    line-clamp: 4;
+  }
+
+  .series-episode-runtime-icon {
+    width: 30px;
+    height: 30px;
+  }
+
+  .series-episode-meta .series-imdb-badge img {
+    width: 52px;
+    height: 26px;
+  }
+
+  .series-episode-progress {
+    right: 36px;
+    bottom: 18px;
+    left: 36px;
+  }
+
+  .series-episode-status {
+    top: 28px;
+    left: 28px;
+    width: 56px;
+    height: 56px;
+  }
+
+  .series-episode-status.complete {
+    font-size: 36px;
+  }
+
+  .series-watched-badge-svg {
+    width: 36px;
+    height: 36px;
+  }
+
+  .series-episode-unavailable {
+    top: 28px;
+    right: 28px;
+    padding: 8px 18px;
+    border-radius: 14px;
+  }
+}
+
+@media (min-width: 2600px) {
+  .series-episode-track {
+    gap: 40px;
+    padding: 36px 112px;
+  }
+
+  .series-episode-card {
+    flex-basis: 800px;
+    width: 800px;
+    border-radius: 40px;
+  }
+
+  .series-episode-thumb {
+    height: 526px;
+    border-radius: 40px;
+  }
+
+  .series-episode-copy {
+    padding: 40px 40px 48px;
+  }
+
+  .series-episode-badge {
+    padding: 10px 20px;
+    border-radius: 16px;
+    letter-spacing: 2px;
+  }
+
+  .series-episode-title {
+    min-height: 56px;
+    line-height: 56px;
+  }
+
+  .series-episode-overview {
+    line-height: 44px;
+    max-height: 176px;
+  }
+
+  .series-episode-meta {
+    min-height: 32px;
+  }
+
+  .series-episode-runtime-icon {
+    width: 32px;
+    height: 32px;
+  }
+
+  .series-episode-meta .series-imdb-badge img {
+    width: 56px;
+    height: 28px;
+  }
+
+  .series-episode-progress {
+    right: 40px;
+    bottom: 20px;
+    left: 40px;
+  }
+
+  .series-episode-status {
+    top: 32px;
+    left: 32px;
+    width: 64px;
+    height: 64px;
+  }
+
+  .series-episode-status.complete {
+    font-size: 40px;
+  }
+
+  .series-watched-badge-svg {
+    width: 40px;
+    height: 40px;
+  }
+
+  .series-episode-unavailable {
+    top: 32px;
+    right: 32px;
+    padding: 10px 20px;
+    border-radius: 16px;
+    letter-spacing: 2px;
+  }
 }
 
 .series-insight-tabs {

--- a/js/ui/screens/detail/metaDetailsScreen.js
+++ b/js/ui/screens/detail/metaDetailsScreen.js
@@ -3633,8 +3633,8 @@ export const MetaDetailsScreen = {
             <div class="series-episode-title">${escapeHtml(normalizeEpisodeTitle(episode.title, episode.episode))}</div>
             <div class="series-episode-overview">${escapeHtml(episode.overview || t("episodes_episode", {}, "Episode"))}</div>
             ${metaParts ? `<div class="series-episode-meta">${metaParts}</div>` : ""}
-            ${progressRatio > 0.02 && progressRatio < 0.98 ? `<div class="series-episode-progress"><span style="width:${Math.round(progressRatio * 100)}%"></span></div>` : ""}
           </div>
+          ${progressRatio > 0.02 && progressRatio < 0.98 ? `<div class="series-episode-progress"><span style="width:${Math.round(progressRatio * 100)}%"></span></div>` : ""}
         </div>
       </article>
     `;
@@ -3890,12 +3890,12 @@ export const MetaDetailsScreen = {
       statusNode.remove();
     }
 
-    let progressNode = copy.querySelector(".series-episode-progress");
+    let progressNode = thumb.querySelector(".series-episode-progress");
     if (progressRatio > 0.02 && progressRatio < 0.98) {
       if (!(progressNode instanceof HTMLElement)) {
         progressNode = document.createElement("div");
         progressNode.className = "series-episode-progress";
-        copy.appendChild(progressNode);
+        thumb.appendChild(progressNode);
       }
       progressNode.innerHTML = `<span style="width:${Math.round(progressRatio * 100)}%"></span>`;
     } else if (progressNode instanceof HTMLElement) {


### PR DESCRIPTION
## Summary
Align the series-detail episode card layout and sizing with the NuvioTV (Android TV) reference: fix the card copy/progress markup so the progress bar sits on the thumbnail (not inside the copy block) and the title/overview/meta spacing matches, and bring the card sizing back in line at TV scale.

## PR type
- [x] Critical bug fix

## Affected area
- [x] Shared web app
- [x] UI / Layout

## Why
Episode cards rendered oversized and with divergent markup vs NuvioTV, breaking parity on the 10-foot detail screen.

## Issue or approval
Fixes #420

## Reproduction steps
1. Open a series detail page (e.g. *House of the Dragon*).
2. Scroll to the episode row.
3. Observe the oversized cards and progress-bar/copy placement that differs from NuvioTV.

## Old behavior
Episode cards were oversized; the progress bar lived inside the copy block and title/overview/meta spacing diverged from NuvioTV.

## New behavior
Card markup and sizing match NuvioTV — progress bar on the thumbnail, consistent copy spacing.

## Platform impact
- Samsung Tizen: shared web UI, unaffected beyond layout
- LG webOS: shared web UI, unaffected beyond layout
- Browser development mode: layout fix visible here
- Installer / packaging: none
- Wrapper repositories: none

## UI / behavior / playback impact
- [x] UI changed only to fix a documented glitch/bug
- [x] No playback change

## Installer, packaging, or wrapper impact
- [x] No installer, packaging, or wrapper impact

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I included a linked issue, reproduction steps, and testing notes if this is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries
Layout/markup for episode cards only. No behavior, focus, or playback changes.

## Testing
### Devices / platforms tested
Chrome on macOS (browser development mode)

### Commands tested
```sh
npm run build
```

## Manual test flow
Built the bundle and reviewed the series detail episode row against the NuvioTV layout.

## Screenshots / Video
**Before** (oversized cards):

<img src="https://github.com/user-attachments/assets/a918e6cb-245e-4085-bdb5-81baf6eda903" width="300" />

**After**
<img width="300" alt="IMG_9535" src="https://github.com/user-attachments/assets/5fade73a-1990-4b22-9c97-e19ece0b7fb3" />

## Logs
Not applicable.

## Regression risk
Low — scoped to episode card markup/CSS.

## Breaking changes
None.

## Linked issues
Fixes #420
