### PR TITLE
fix(detail): recenter episode row on cross-section focus

### DIFF
--- a/js/ui/screens/detail/metaDetailsScreen.js
+++ b/js/ui/screens/detail/metaDetailsScreen.js
@@ -7751,7 +7751,11 @@ export const MetaDetailsScreen = {
         );
       if (direction === "up") {
         if (seasons.length) {
-          return this.focusInList(seasons, this.getSelectedSeasonIndex(seasons)) || true;
+          return (
+            this.focusInList(seasons, this.getSelectedSeasonIndex(seasons), {
+              preserveVerticalScroll: true
+            }) || true
+          );
         }
         if (actions.length) {
           return (

--- a/js/ui/screens/detail/metaDetailsScreen.js
+++ b/js/ui/screens/detail/metaDetailsScreen.js
@@ -7646,7 +7646,7 @@ export const MetaDetailsScreen = {
         return this.focusInList(insightTabs, this.getActiveInsightTabIndex(insightTabs));
       if (episodes.length)
         return this.focusEpisodeByIndex(this.getRememberedEpisodeIndex(episodes), {
-          preserveVerticalScroll: true
+          preserveVerticalScroll: false
         });
       return false;
     };
@@ -7674,7 +7674,7 @@ export const MetaDetailsScreen = {
     const focusSeriesSectionAboveInsights = (index = 0) => {
       if (episodes.length) {
         return this.focusEpisodeByIndex(this.getRememberedEpisodeIndex(episodes), {
-          preserveVerticalScroll: true
+          preserveVerticalScroll: false
         });
       }
       if (seasons.length) {
@@ -7701,7 +7701,7 @@ export const MetaDetailsScreen = {
         if (episodes.length) {
           return (
             this.focusEpisodeByIndex(this.getRememberedEpisodeIndex(episodes), {
-              preserveVerticalScroll: true
+              preserveVerticalScroll: false
             }) || true
           );
         }
@@ -7725,7 +7725,7 @@ export const MetaDetailsScreen = {
         if (episodes.length) {
           return (
             this.focusEpisodeByIndex(this.getRememberedEpisodeIndex(episodes), {
-              preserveVerticalScroll: true
+              preserveVerticalScroll: false
             }) || true
           );
         }
@@ -7826,7 +7826,7 @@ export const MetaDetailsScreen = {
         if (episodes.length) {
           return (
             this.focusEpisodeByIndex(this.getRememberedEpisodeIndex(episodes), {
-              preserveVerticalScroll: true
+              preserveVerticalScroll: false
             }) || true
           );
         }
@@ -7858,7 +7858,7 @@ export const MetaDetailsScreen = {
         if (episodes.length) {
           return (
             this.focusEpisodeByIndex(this.getRememberedEpisodeIndex(episodes), {
-              preserveVerticalScroll: true
+              preserveVerticalScroll: false
             }) || true
           );
         }
@@ -7894,7 +7894,7 @@ export const MetaDetailsScreen = {
         if (episodes.length) {
           return (
             this.focusEpisodeByIndex(this.getRememberedEpisodeIndex(episodes), {
-              preserveVerticalScroll: true
+              preserveVerticalScroll: false
             }) || true
           );
         }
@@ -7970,7 +7970,7 @@ export const MetaDetailsScreen = {
         if (episodes.length) {
           return (
             this.focusEpisodeByIndex(this.getRememberedEpisodeIndex(episodes), {
-              preserveVerticalScroll: true
+              preserveVerticalScroll: false
             }) || true
           );
         }
@@ -8021,7 +8021,7 @@ export const MetaDetailsScreen = {
         if (episodes.length) {
           return (
             this.focusEpisodeByIndex(this.getRememberedEpisodeIndex(episodes), {
-              preserveVerticalScroll: true
+              preserveVerticalScroll: false
             }) || true
           );
         }


### PR DESCRIPTION
## Summary
Recenter the series-detail episode row on focus so it always lands at a single consistent vertical position, matching NuvioTV. Previously the row inherited the neighboring section's scroll and only ever settled in one of two positions.

## PR type
- [x] Critical bug fix

## Affected area
- [x] Shared web app
- [x] Focus / Remote navigation
- [x] UI / Layout

## Why
Focusing the episode row from an adjacent section forced `preserveVerticalScroll`, so the row never recentered — it kept whatever scroll the neighbor left behind, producing two inconsistent positions instead of the NuvioTV framing.

## Issue or approval
Fixes #420

## Reproduction steps
1. Open a series detail page (e.g. *House of the Dragon*).
2. Focus an episode card in the episode row.
3. Press **Down** into *Creator and Cast*.
4. Press **Up** back to the episode row.
5. Observe: before this fix the row does not recenter; if a season selector is present, entering from it lands the row in a different ("upper") position.

## Old behavior
The episode row inherited the neighboring section's scroll, settling in one of two positions and never recentering the focused episode.

## New behavior
Entering the episode row from any adjacent section (up from cast/tabs/ratings/comments, down from season selector/actions) recenters it to `DETAIL_ROW_FOCUS_TARGET`. Horizontal in-row navigation and moving up to the season selector keep their existing framing.

## Platform impact
- Samsung Tizen: shared focus/scroll logic, benefits from fix
- LG webOS: shared focus/scroll logic, benefits from fix
- Browser development mode: fix visible here
- Installer / packaging: none
- Wrapper repositories: none

## UI / behavior / playback impact
- [x] Behavior changed only to fix a documented bug/regression
- [x] UI changed only to fix a documented glitch/bug
- [x] No playback change

## Installer, packaging, or wrapper impact
- [x] No installer, packaging, or wrapper impact

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I included a linked issue, reproduction steps, and testing notes if this is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries
Only the vertical-scroll preservation on cross-section entry into the episode row (9 call sites). Horizontal navigation and season-focus framing are unchanged.

## Testing
### Devices / platforms tested
Chrome on macOS (browser development mode)

### Commands tested
```sh
npm run build
```

## Manual test flow
Built the bundle and exercised focus moving between the episode row and Creator and Cast / season selector, confirming the row recenters consistently.

## Screenshots / Video
**Before** (episode row not recentered after returning up from Creator and Cast):

<img src="https://github.com/user-attachments/assets/43196089-eb43-4e47-9f2e-fe14021a790b" width="300" />

**After**
<img width="300" alt="IMG_9535" src="https://github.com/user-attachments/assets/dbbcaf1e-2354-4fa6-bc04-faec8cdf93e8" />

## Logs
Not applicable.

## Regression risk
Low — scoped to `preserveVerticalScroll` on episode-row entry; same-track detection still preserves scroll for horizontal navigation.

## Breaking changes
None.

## Linked issues
Fixes #420
