### PR TITLE
Add Reduce Animations toggle

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -17744,16 +17744,30 @@ html.legacy-webos .debug-console-log-frame {
   -webkit-backdrop-filter: none !important;
 }
 
-.no-backdrop-filter .modern-sidebar-shell.blur-enabled .modern-sidebar-panel {
+.no-backdrop-filter .modern-sidebar-shell.blur-enabled .modern-sidebar-panel,
+.reduce-animations .modern-sidebar-shell.blur-enabled .modern-sidebar-panel {
   background:
     linear-gradient(180deg, rgb(var(--bg-elevated-rgb) / 0.96), rgb(var(--bg-elevated-rgb) / 0.96)),
     var(--bg-elevated);
 }
 
-.no-backdrop-filter .modern-sidebar-shell.blur-enabled .modern-sidebar-pill-chip {
+.no-backdrop-filter .modern-sidebar-shell.blur-enabled .modern-sidebar-pill-chip,
+.reduce-animations .modern-sidebar-shell.blur-enabled .modern-sidebar-pill-chip {
   background:
     linear-gradient(180deg, rgb(var(--bg-elevated-rgb) / 0.92), rgb(var(--bg-elevated-rgb) / 0.92)),
     var(--bg-elevated);
+}
+
+/* Reduce Animations (opt-in): make transitions effectively instant and drop
+   backdrop blur so lower-end TVs stop dropping frames. Keyframe animations
+   (loading spinners) are left alone so they still spin. */
+.reduce-animations *,
+.reduce-animations *::before,
+.reduce-animations *::after {
+  transition-duration: 0.01ms !important;
+  transition-delay: 0ms !important;
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
 }
 
 html.no-css-grid .qr-layout,

--- a/js/data/local/themeStore.js
+++ b/js/data/local/themeStore.js
@@ -9,7 +9,8 @@ const DEFAULT_THEME = {
   fontFamily: "INTER",
   language: null,
   amoledMode: false,
-  amoledSurfacesMode: false
+  amoledSurfacesMode: false,
+  reduceAnimations: false
 };
 
 const THEME_BY_ACCENT = new Map([
@@ -54,7 +55,8 @@ function normalizeTheme(settings = {}) {
     ...DEFAULT_THEME,
     ...settings,
     themeName,
-    accentColor: normalizedAccent
+    accentColor: normalizedAccent,
+    reduceAnimations: Boolean(settings?.reduceAnimations)
   };
 }
 

--- a/js/ui/screens/settings/settingsScreen.js
+++ b/js/ui/screens/settings/settingsScreen.js
@@ -2979,6 +2979,10 @@ export const SettingsScreen = {
       ThemeStore.set({ amoledSurfacesMode: !ThemeStore.get().amoledSurfacesMode });
       ThemeManager.apply();
     });
+    this.actionMap.set("appearance:reduceAnimations", () => {
+      ThemeStore.set({ reduceAnimations: !ThemeStore.get().reduceAnimations });
+      ThemeManager.apply();
+    });
 
     return `
       ${this.renderSectionHeader(SECTION_META.find((item) => item.id === "appearance"))}
@@ -3019,6 +3023,16 @@ export const SettingsScreen = {
               })
             : ""
         }
+        ${this.renderToggleRow({
+          focusKey: "appearance:reduceAnimations",
+          title: t("appearance_reduce_animations", {}, "Reduce Animations"),
+          subtitle: t(
+            "appearance_reduce_animations_subtitle",
+            {},
+            "Turn off motion and background blur for smoother performance on slower TVs"
+          ),
+          checked: Boolean(model.theme.reduceAnimations)
+        })}
       </div>
       <div class="settings-group-card settings-appearance-group-card">
         <div class="settings-group-heading">

--- a/js/ui/theme/themeManager.js
+++ b/js/ui/theme/themeManager.js
@@ -161,6 +161,14 @@ export const ThemeManager = {
     );
     document.documentElement.style.setProperty("color-scheme", "dark");
 
+    // Reduce animations / transparency for lower-end TVs that lag on the
+    // regular transitions and backdrop blur (opt-in from settings).
+    const reduceAnimations = Boolean(theme.reduceAnimations);
+    document.documentElement.classList.toggle("reduce-animations", reduceAnimations);
+    if (document.body) {
+      document.body.classList.toggle("reduce-animations", reduceAnimations);
+    }
+
     if (!SUPPORTS_CSS_VARS) {
       const colorMap = {
         bg: colors["--bg-color"],


### PR DESCRIPTION
Closes #390

Several users report the app lagging badly on their TVs from the UI transitions and background blur, with newer webOS in particular called "virtually unusable". This adds an opt-in way to turn that off.

Adds a Reduce Animations toggle under Settings > Appearance. When on, it makes transitions effectively instant and removes backdrop blur (reusing the existing no-blur solid-background fallbacks so panels stay readable). Loading spinners are left running so nothing looks frozen. Off by default, so there is no change unless you enable it.

It is wired through the existing theme store / ThemeManager, so it applies at startup and immediately on toggle, and is stored per profile like the other appearance settings.

Verified in the browser: toggling it adds the reduce-animations class, drops sample transition durations from ~0.18s to ~0, persists, and reverses cleanly when turned back off.