### PR TITLE
fix(supporters): restore back navigation on Supporters screen

### DIFF
--- a/js/ui/screens/supporters/supportersContributorsScreen.js
+++ b/js/ui/screens/supporters/supportersContributorsScreen.js
@@ -734,6 +734,9 @@ export const SupportersContributorsScreen = {
   },
 
   consumeBackRequest() {
+    if (!this.dialog && !this.showDonateQr) {
+      return false;
+    }
     void this.handleBack();
     return true;
   },


### PR DESCRIPTION
## Summary

Fix the back/return button being completely dead on the Supporters screen: `consumeBackRequest()` now follows the router's consume contract (return `true` only when it actually consumed the press by closing an open dialog/QR overlay), so `Router.back()` can navigate away from the screen again.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix
- [ ] Approved feature/change

## Affected area

- [x] Shared web app
- [x] Samsung Tizen
- [x] LG webOS
- [x] Browser development mode
- [ ] Playback
- [ ] Audio tracks
- [ ] Subtitles
- [x] Focus / Remote navigation
- [ ] UI / Layout
- [ ] Resume / Watch progress
- [ ] Continue Watching
- [ ] Next Episode / Auto-play
- [ ] Packaging / Build
- [ ] Nuvio WebTV Installer compatibility
- [ ] TizenBrew wrapper
- [ ] webOS Homebrew wrapper
- [ ] Documentation
- [ ] Other

## Why

Users cannot leave the Supporters screen with the remote at all — every back press is silently swallowed and the only way out is closing the app. Root cause: `consumeBackRequest()` on this screen unconditionally returns `true` while its `handleBack()` re-enters `Router.back()`. `Router.back()` returns without navigating whenever `consumeBackRequest()` is truthy, so the two functions hand the back press to each other in a synchronous re-entry loop and navigation never happens (the same consume gate swallows the `popstate` path too). Every other screen implements the contract correctly (`traktScreen.js` returns `false` with no dialog open; `settingsScreen.js` returns `true` only for its open dialogs), which is why back works everywhere else.

## Issue or approval

Fixes #450

## Reproduction steps

1. Open Nuvio 0.3.13 (release `.wgt`) on a Samsung TV.
2. Go to Settings and open the Supporters screen.
3. Press Return/Back on the remote any number of times — nothing happens; the screen cannot be left. (Browser development mode: same trap via Escape on the same screen.)

## Old behavior

Back/Return (and Escape in browser development mode) did nothing on the Supporters screen — with no dialog open, the press was consumed by the `consumeBackRequest()`/`handleBack()` re-entry loop and `Router.back()` never navigated. Users were trapped and had to close the app.

## New behavior

With nothing open, back navigates to the previous route exactly as on every other screen. With the supporter/sponsor detail dialog or the donate QR overlay open, back still closes the overlay first and does not leave the screen (unchanged).

## Platform impact

- Samsung Tizen: affected (bug reproduced on real hardware); fixed by this change.
- LG webOS: affected (shared code, same handler); fixed by this change.
- Browser development mode: affected via Escape (same code path); fixed by this change.
- Installer / packaging: no impact.
- Wrapper repositories: no impact.

## UI / behavior / playback impact

- [x] No UI change
- [ ] No behavior change
- [x] No playback change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] Playback changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval
- [ ] Playback change has explicit maintainer approval

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact
- [ ] Tizen `.wgt` packaging changed
- [ ] webOS `.ipk` packaging changed
- [ ] App identifiers or metadata changed
- [ ] `local.properties` / environment handling changed
- [ ] `sync:tizen` changed
- [ ] `sync:webos` changed
- [ ] Nuvio WebTV Installer compatibility changed
- [ ] TizenBrew wrapper support changed
- [ ] webOS Homebrew metadata support changed

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I included a linked issue, reproduction steps, and testing notes if this is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Only `consumeBackRequest()` in `supportersContributorsScreen.js` changes (3 added lines). Intentionally NOT changed: `handleBack()` itself, dialog/QR close behavior, focus handling, tab behavior, any other screen, and the router — the router's consume contract is left as-is and this screen is brought into compliance with it, matching the existing pattern in `traktScreen.js` and `settingsScreen.js`. No UI polish, no formatting changes.

## Testing

Bug reproduced on real hardware; fix verified in a browser harness that runs the real screen module against a router stub whose `back()` replicates the real consume gate line-for-line, comparing upstream `main` vs this branch side by side.

### Devices / platforms tested

- Samsung UN58TU700DFXZA, Tizen 5.5, Nuvio 0.3.13 installed via Nuvio WebTV Installer — bug reproduction (back press trapped, 100% reproducible).
- Firefox 152 (browser development mode code path) — automated before/after verification of the fix (details below).

### Commands tested

```sh
# Static server over the repo root + harness page driving the real
# supportersContributorsScreen.js module with import-mapped stubs:
python3 -m http.server  # serve repo root
# then load the harness page in Firefox (headless run used for CI-style output)
```

## Manual test flow

Harness mounts the real screen module and dispatches the exact remote back event (`keyCode` 10009) three times per version:

1. Nothing open → upstream `main`: navigation never fires and `consumeBackRequest` re-enters itself hundreds of times (loop guard trips at 400 re-entries); this branch: navigates back exactly once, `consumeBackRequest` called exactly once.
2. Supporter detail dialog open → dialog closes, no navigation (identical before/after — behavior preserved).
3. Donate QR overlay open → overlay closes, no navigation (identical before/after — behavior preserved).

All 8 checks pass on this branch; upstream `main` fails check 1 exactly as reported in #450.

## Screenshots / Video

Not a UI change — navigation-only fix; no pixels differ. (Harness verdict output available on request.)

## Logs

Not applicable — no crash or platform API error; the bug is a silent navigation swallow, demonstrated by the re-entry counts in the harness output.

## Regression risk

Low. The change only makes this screen return `false` from `consumeBackRequest()` when no dialog/QR is open — the same contract every other screen already follows. Risk surface: back handling on this one screen across Tizen/webOS/browser; the dialog-open and QR-open paths are explicitly covered by the before/after harness checks and unchanged. No shared/router code touched.

## Breaking changes

None.

## Linked issues

Fixes #450
