### PR TITLE
perf(library): reduce navigation layout work

### DIFF
--- a/js/data/repository/libraryRepository.js
+++ b/js/data/repository/libraryRepository.js
@@ -301,6 +301,7 @@ async function hydrateEntries(entries, { onBatch = null, shouldContinue = null }
     listKeys: [...entry.listKeys],
     listMeta: { ...(entry.listMeta || {}) }
   }));
+  let hasPendingChanges = false;
 
   for (let index = 0; index < nextEntries.length; index += META_BATCH_SIZE) {
     if (shouldContinue && !shouldContinue()) {
@@ -363,8 +364,13 @@ async function hydrateEntries(entries, { onBatch = null, shouldContinue = null }
             ]);
       })
     );
-    if (didChange && (!shouldContinue || shouldContinue())) {
+    hasPendingChanges = hasPendingChanges || didChange;
+    const processedCount = Math.min(index + META_BATCH_SIZE, nextEntries.length);
+    const shouldNotify =
+      processedCount === nextEntries.length || processedCount % (META_BATCH_SIZE * 4) === 0;
+    if (hasPendingChanges && shouldNotify && (!shouldContinue || shouldContinue())) {
       onBatch?.(nextEntries);
+      hasPendingChanges = false;
     }
   }
 

--- a/js/ui/screens/library/libraryScreen.js
+++ b/js/ui/screens/library/libraryScreen.js
@@ -233,6 +233,7 @@ export const LibraryScreen = {
     this.pendingPosterOptionsFocusKey = "";
     this.pendingPosterHoldTarget = null;
     this.pendingPosterHoldTimer = null;
+    this.gridRows = [];
     this.lastPrivacyFocus = "private";
     this.partialContentRefresh = null;
 
@@ -528,6 +529,7 @@ export const LibraryScreen = {
       contentMount.outerHTML = this.renderLibraryContentArea(state);
     }
 
+    this.buildGridRows();
     ScreenUtils.indexFocusables(this.container);
     bindRootSidebarEvents(this.container, {
       currentRoute: "library",
@@ -810,6 +812,7 @@ export const LibraryScreen = {
     `;
     this.libraryRouteEnterPending = false;
 
+    this.buildGridRows();
     ScreenUtils.indexFocusables(this.container);
     bindRootSidebarEvents(this.container, {
       currentRoute: "library",
@@ -1126,17 +1129,18 @@ export const LibraryScreen = {
     return remembered || findNearestNodeByCenterX(referenceNode, cards) || cards[0] || null;
   },
 
+  buildGridRows() {
+    const cards = Array.from(
+      this.container?.querySelectorAll(".library-grid-card.focusable") || []
+    );
+    this.gridRows = cards.length ? groupNodesByRow(cards) : [];
+  },
+
   resolveRelativeGridNode(current, direction) {
     if (!current || !current.matches?.(".library-grid-card.focusable")) {
       return null;
     }
-    const cards = Array.from(
-      this.container?.querySelectorAll(".library-grid-card.focusable") || []
-    );
-    if (!cards.length) {
-      return null;
-    }
-    const rows = groupNodesByRow(cards);
+    const rows = this.gridRows || [];
     if (!rows.length) {
       return null;
     }
@@ -1184,14 +1188,7 @@ export const LibraryScreen = {
     if (!node?.matches?.(".library-grid-card.focusable")) {
       return false;
     }
-    const cards = Array.from(
-      this.container?.querySelectorAll(".library-grid-card.focusable") || []
-    );
-    if (!cards.length) {
-      return false;
-    }
-    const rows = groupNodesByRow(cards);
-    return Boolean(rows[0]?.nodes?.includes(node));
+    return Boolean(this.gridRows?.[0]?.nodes?.includes(node));
   },
 
   handleActionsRowNavigation(event, current) {
@@ -1237,7 +1234,7 @@ export const LibraryScreen = {
   },
 
   handleContentRowMemoryNavigation(event, current) {
-    const state = this.controller.getState();
+    const state = this.controller.state;
     if (state.sourceMode !== "trakt" || state.expandedPicker || !current) {
       return false;
     }
@@ -1757,7 +1754,7 @@ export const LibraryScreen = {
       return;
     }
 
-    const state = this.controller.getState();
+    const state = this.controller.state;
     const code = Number(event?.keyCode || 0);
     if (this.suppressHoldMenuEnterUntilKeyUp && code === 13) {
       event?.preventDefault?.();
@@ -1888,6 +1885,7 @@ export const LibraryScreen = {
     this.posterOptionsController = null;
     this.pendingPosterOptionsFocusKey = "";
     this.suppressHoldMenuEnterUntilKeyUp = false;
+    this.gridRows = [];
     this.controller?.dispose?.();
     this.controller = null;
     ScreenUtils.hide(this.container);


### PR DESCRIPTION
## Summary

Reduce Library lag during D-pad navigation and metadata loading on LG webOS without changing the UI.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix
- [ ] Approved feature/change

## Affected area

- [x] Shared web app
- [ ] Samsung Tizen
- [x] LG webOS
- [x] Browser development mode
- [ ] Playback
- [ ] Audio tracks
- [ ] Subtitles
- [x] Focus / Remote navigation
- [ ] UI / Layout
- [ ] Resume / Watch progress
- [ ] Continue Watching
- [ ] Next Episode / Auto-play
- [ ] Packaging / Build
- [ ] Nuvio WebTV Installer compatibility
- [ ] TizenBrew wrapper
- [ ] webOS Homebrew wrapper
- [ ] Documentation
- [ ] Other

## Why

The Library showed noticeable lag on an LG C2 running webOS 25, especially while repeatedly moving focus and while metadata filled in. Each D-pad move measured every card to rebuild the row map, and metadata enrichment repeatedly rebuilt the full grid.

## Issue or approval

Fixes #470.

## Reproduction steps

1. Open Library on an LG C2 running webOS 25.
2. Use a Library containing roughly 100-300 titles.
3. Hold or repeatedly press the D-pad across poster rows.
4. Observe extra stutter while metadata fills in.

## Old behavior

With 170 cards, each D-pad move performed about 578 layout reads. Metadata hydration could also request up to 29 full grid refreshes, repeatedly recreating posters and focusable elements.

## New behavior

The grid row map is built once after rendering and reused during navigation. Key handling reads existing controller state without cloning large collections, and four metadata batches are combined before refreshing the grid.

## Platform impact

- Samsung Tizen: Shared code is touched but no Tizen-specific behavior changes.
- LG webOS: Reduces Library navigation and metadata-loading work reported on LG C2 webOS 25.
- Browser development mode: Used for repeatable benchmarking and navigation smoke testing.
- Installer / packaging: No impact.
- Wrapper repositories: No impact.

## UI / behavior / playback impact

- [x] No UI change
- [ ] No behavior change
- [x] No playback change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] Playback changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval
- [ ] Playback change has explicit maintainer approval

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact
- [ ] Tizen `.wgt` packaging changed
- [ ] webOS `.ipk` packaging changed
- [ ] App identifiers or metadata changed
- [ ] `local.properties` / environment handling changed
- [ ] `sync:tizen` changed
- [ ] `sync:webos` changed
- [ ] Nuvio WebTV Installer compatibility changed
- [ ] TizenBrew wrapper support changed
- [ ] webOS Homebrew metadata support changed

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I included a linked issue, reproduction steps, and testing notes if this is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

No UI, poster loading, virtualization, playback, packaging, or platform API changes. This only caches grid navigation data, avoids hot-path state cloning, and coalesces metadata refreshes.

## Testing

Benchmarked and smoke tested a 170-card Library at 1920x1080 in browser development mode. The original lag was observed on an LG C2 running webOS 25.

### Devices / platforms tested

- LG C2, webOS 25: original lag observed
- Browser development mode, 1920x1080: benchmark and navigation smoke test

### Commands tested

```sh
npm run build
```

## Manual test flow

1. Open Library with 170 cards.
2. Move focus horizontally and vertically across poster rows.
3. Repeat 100 alternating horizontal moves.
4. Confirm focus movement and final-row clamping remain correct.
5. Observe metadata hydration refresh behavior.

## Screenshots / Video

Screenshot attached below. The Library visuals are unchanged by this performance-only fix.

## Logs

Not applicable. This issue does not involve crashes, playback, packaging, or platform API errors.

## Regression risk

Low. A stale cached row map could affect focus movement if the grid changes without a render; the cache is rebuilt after full and partial Library content renders and cleared during cleanup.

## Breaking changes

None.

## Linked issues

Fixes #470.

## Benchmark findings

170 cards at 1920x1080:

- Layout reads per D-pad move: approximately 578 to 2, a 99.65% reduction.
- Layout reads over 100 moves: 57,800 to 200.
- Maximum metadata hydration grid rebuilds: 29 to 8, a 72.4% reduction.

The remaining major cost is poster loading: only 10 of 170 cards were visible in the browser measurement, while all 170 poster backgrounds were activated. Deferred poster activation is intentionally outside this PR.
