### PR TITLE
Add addon logo display setting

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -13109,6 +13109,11 @@ html.legacy-webos .debug-console-log-frame {
   gap: 12px;
 }
 
+.player-source-card.no-side {
+  grid-template-columns: 1fr;
+  gap: 0;
+}
+
 .player-source-card.focused {
   border-color: var(--player-focus-ring);
   background: var(--player-focus-background);

--- a/css/components.css
+++ b/css/components.css
@@ -13128,6 +13128,21 @@ html.legacy-webos .debug-console-log-frame {
   min-width: 0;
 }
 
+.player-source-title-row {
+  display: flex;
+  align-items: center;
+}
+
+.player-source-title-row .player-source-title {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.player-source-title-row .player-source-playing {
+  flex: 0 0 auto;
+  margin-left: 8px;
+}
+
 .player-source-title {
   font-size: 20px;
   font-weight: 700;

--- a/js/core/profile/profileSettingsSyncService.js
+++ b/js/core/profile/profileSettingsSyncService.js
@@ -1473,6 +1473,7 @@ const FEATURE_ADAPTERS = {
       return {
         stream_badge_rules: rules.imports.length ? JSON.stringify(rules) : "",
         show_file_size_badges: settings.showFileSizeBadges !== false,
+        show_addon_logo: settings.showAddonLogo !== false,
         stream_badge_placement: settings.badgePlacement === "TOP" ? "TOP" : "BOTTOM"
       };
     },
@@ -1481,6 +1482,7 @@ const FEATURE_ADAPTERS = {
       const projected = {};
       projected.stream_badge_rules = String(raw.stream_badge_rules || "").trim();
       projected.show_file_size_badges = booleanFromAnyKey(raw, ["show_file_size_badges"]) ?? true;
+      projected.show_addon_logo = booleanFromAnyKey(raw, ["show_addon_logo"]) ?? true;
       projected.stream_badge_placement =
         String(raw.stream_badge_placement || raw.badge_placement || raw.badgePlacement || "")
           .trim()
@@ -1501,6 +1503,9 @@ const FEATURE_ADAPTERS = {
       }
       if (booleanOrNull(raw.show_file_size_badges) != null) {
         partial.showFileSizeBadges = Boolean(raw.show_file_size_badges);
+      }
+      if (booleanOrNull(raw.show_addon_logo) != null) {
+        partial.showAddonLogo = Boolean(raw.show_addon_logo);
       }
       const badgePlacement = String(
         raw.stream_badge_placement ?? raw.badge_placement ?? raw.badgePlacement ?? ""

--- a/js/data/local/streamBadgeSettingsStore.js
+++ b/js/data/local/streamBadgeSettingsStore.js
@@ -11,7 +11,7 @@ const LEGACY_DEBRID_KEY = "debridSettings";
 const DEFAULT_STREAM_BADGE_SETTINGS = {
   rules: { imports: [] },
   showFileSizeBadges: true,
-  showAddonLogo: false,
+  showAddonLogo: true,
   badgePlacement: "BOTTOM"
 };
 
@@ -41,7 +41,7 @@ function normalizeStreamBadgeSettings(value = {}) {
   return {
     rules: normalizeStreamBadgeRules(rulesSource),
     showFileSizeBadges: showFileSizeBadges !== false,
-    showAddonLogo: showAddonLogo === true,
+    showAddonLogo: showAddonLogo !== false,
     badgePlacement: normalizeBadgePlacement(badgePlacement)
   };
 }

--- a/js/data/local/streamBadgeSettingsStore.js
+++ b/js/data/local/streamBadgeSettingsStore.js
@@ -11,6 +11,7 @@ const LEGACY_DEBRID_KEY = "debridSettings";
 const DEFAULT_STREAM_BADGE_SETTINGS = {
   rules: { imports: [] },
   showFileSizeBadges: true,
+  showAddonLogo: false,
   badgePlacement: "BOTTOM"
 };
 
@@ -31,6 +32,7 @@ function normalizeStreamBadgeSettings(value = {}) {
     source.payload ??
     null;
   const showFileSizeBadges = source.showFileSizeBadges ?? source.show_file_size_badges;
+  const showAddonLogo = source.showAddonLogo ?? source.show_addon_logo;
   const badgePlacement =
     source.badgePlacement ??
     source.badge_placement ??
@@ -39,6 +41,7 @@ function normalizeStreamBadgeSettings(value = {}) {
   return {
     rules: normalizeStreamBadgeRules(rulesSource),
     showFileSizeBadges: showFileSizeBadges !== false,
+    showAddonLogo: showAddonLogo === true,
     badgePlacement: normalizeBadgePlacement(badgePlacement)
   };
 }
@@ -195,6 +198,10 @@ export const StreamBadgeSettingsStore = {
 
   setShowFileSizeBadges(enabled) {
     store.set({ showFileSizeBadges: Boolean(enabled) });
+  },
+
+  setShowAddonLogo(enabled) {
+    store.set({ showAddonLogo: Boolean(enabled) });
   },
 
   setBadgePlacement(placement) {

--- a/js/ui/screens/player/playerScreen.js
+++ b/js/ui/screens/player/playerScreen.js
@@ -14164,18 +14164,25 @@ export const PlayerScreen = {
             const addonLogoUrl = showAddonLogo
               ? getPlayerSourceLogoDisplayUrl(stream.addonLogo, () => this.scheduleSourceLogoRender())
               : "";
-            const sourceSide = showAddonLogo || isCurrent
+            const playingMarker = isCurrent
+              ? `<div class="player-source-playing">${escapeHtml(t("sources_playing", {}, "Playing"))}</div>`
+              : "";
+            const sourceTitle = `<div class="player-source-title">${escapeHtml(stream.label || "Stream")}</div>`;
+            const mainTitle = !showAddonLogo && playingMarker
+              ? `<div class="player-source-title-row">${sourceTitle}${playingMarker}</div>`
+              : sourceTitle;
+            const sourceSide = showAddonLogo
               ? `<div class="player-source-side">
-                  ${showAddonLogo && addonLogoUrl ? `<img class="player-source-logo" src="${escapeAttribute(addonLogoUrl)}" alt="" decoding="async" loading="lazy" referrerpolicy="no-referrer" />` : ""}
-                  ${showAddonLogo ? `<div class="player-source-addon">${escapeHtml(stream.addonName || t("nav_addons", {}, "Addon"))}</div>` : ""}
-                  ${isCurrent ? `<div class="player-source-playing">${escapeHtml(t("sources_playing", {}, "Playing"))}</div>` : ""}
+                  ${addonLogoUrl ? `<img class="player-source-logo" src="${escapeAttribute(addonLogoUrl)}" alt="" decoding="async" loading="lazy" referrerpolicy="no-referrer" />` : ""}
+                  <div class="player-source-addon">${escapeHtml(stream.addonName || t("nav_addons", {}, "Addon"))}</div>
+                  ${playingMarker}
                 </div>`
               : "";
             return `
               <article class="player-source-card${sourceSide ? "" : " no-side"} focusable${focused ? " focused" : ""}${isCurrent ? " selected" : ""}" data-sources-zone="list" data-sources-index="${index}">
                 <div class="player-source-main">
                   ${topBadges}
-                  <div class="player-source-title">${escapeHtml(stream.label || "Stream")}</div>
+                  ${mainTitle}
                   <div class="player-source-desc">${escapeHtml(stream.description || stream.addonName || "")}</div>
                   ${bottomBadges}
                 </div>

--- a/js/ui/screens/player/playerScreen.js
+++ b/js/ui/screens/player/playerScreen.js
@@ -14074,7 +14074,10 @@ export const PlayerScreen = {
   },
 
   async preloadPlayerSourceLogos(streams = this.getFilteredSources()) {
-    if (!Environment.isWebOS()) {
+    if (
+      StreamBadgeSettingsStore.snapshot().showAddonLogo !== true ||
+      !Environment.isWebOS()
+    ) {
       return;
     }
     try {
@@ -14116,6 +14119,7 @@ export const PlayerScreen = {
     const filters = this.getSourceFilters();
     const filtered = this.getFilteredSources();
     const badgeSettings = StreamBadgeSettingsStore.snapshot();
+    const showAddonLogo = badgeSettings.showAddonLogo === true;
     const badgePlacement = resolvePlayerSourceBadgePlacement(badgeSettings);
     this.ensureSourcesFocus();
 
@@ -14157,20 +14161,25 @@ export const PlayerScreen = {
             const badges = renderPlayerSourceBadges(stream, badgeSettings);
             const topBadges = badgePlacement === "TOP" ? badges : "";
             const bottomBadges = badgePlacement === "BOTTOM" ? badges : "";
-            const addonLogoUrl = getPlayerSourceLogoDisplayUrl(stream.addonLogo, () => this.scheduleSourceLogoRender());
+            const addonLogoUrl = showAddonLogo
+              ? getPlayerSourceLogoDisplayUrl(stream.addonLogo, () => this.scheduleSourceLogoRender())
+              : "";
+            const sourceSide = showAddonLogo || isCurrent
+              ? `<div class="player-source-side">
+                  ${showAddonLogo && addonLogoUrl ? `<img class="player-source-logo" src="${escapeAttribute(addonLogoUrl)}" alt="" decoding="async" loading="lazy" referrerpolicy="no-referrer" />` : ""}
+                  ${showAddonLogo ? `<div class="player-source-addon">${escapeHtml(stream.addonName || t("nav_addons", {}, "Addon"))}</div>` : ""}
+                  ${isCurrent ? `<div class="player-source-playing">${escapeHtml(t("sources_playing", {}, "Playing"))}</div>` : ""}
+                </div>`
+              : "";
             return `
-              <article class="player-source-card focusable${focused ? " focused" : ""}${isCurrent ? " selected" : ""}" data-sources-zone="list" data-sources-index="${index}">
+              <article class="player-source-card${sourceSide ? "" : " no-side"} focusable${focused ? " focused" : ""}${isCurrent ? " selected" : ""}" data-sources-zone="list" data-sources-index="${index}">
                 <div class="player-source-main">
                   ${topBadges}
                   <div class="player-source-title">${escapeHtml(stream.label || "Stream")}</div>
                   <div class="player-source-desc">${escapeHtml(stream.description || stream.addonName || "")}</div>
                   ${bottomBadges}
                 </div>
-                <div class="player-source-side">
-                  ${addonLogoUrl ? `<img class="player-source-logo" src="${escapeAttribute(addonLogoUrl)}" alt="" decoding="async" loading="lazy" referrerpolicy="no-referrer" />` : ""}
-                  <div class="player-source-addon">${escapeHtml(stream.addonName || t("nav_addons", {}, "Addon"))}</div>
-                  ${isCurrent ? `<div class="player-source-playing">${escapeHtml(t("sources_playing", {}, "Playing"))}</div>` : ""}
-                </div>
+                ${sourceSide}
               </article>
             `;
           }).join("")}
@@ -15057,6 +15066,7 @@ export const PlayerScreen = {
     const streams = this.getFilteredEpisodePanelStreams();
     const focus = this.episodePanelStreamFocus || { zone: "actions", index: 0 };
     const badgeSettings = StreamBadgeSettingsStore.snapshot();
+    const showAddonLogo = badgeSettings.showAddonLogo === true;
     const badgePlacement = resolvePlayerSourceBadgePlacement(badgeSettings);
     const episodeCode = episodeDisplayCode(selectedEpisode);
     const episodeTitle = String(
@@ -15122,9 +15132,17 @@ export const PlayerScreen = {
                   const badges = renderPlayerSourceBadges(stream, badgeSettings);
                   const topBadges = badgePlacement === "TOP" ? badges : "";
                   const bottomBadges = badgePlacement === "BOTTOM" ? badges : "";
-                  const addonLogoUrl = getPlayerSourceLogoDisplayUrl(stream.addonLogo, () => this.scheduleSourceLogoRender());
+                  const addonLogoUrl = showAddonLogo
+                    ? getPlayerSourceLogoDisplayUrl(stream.addonLogo, () => this.scheduleSourceLogoRender())
+                    : "";
+                  const sourceSide = showAddonLogo
+                    ? `<div class="player-source-side">
+                        ${addonLogoUrl ? `<img class="player-source-logo" src="${escapeAttribute(addonLogoUrl)}" alt="" decoding="async" loading="lazy" referrerpolicy="no-referrer" />` : ""}
+                        <div class="player-source-addon">${escapeHtml(stream.addonName || t("nav_addons", {}, "Addon"))}</div>
+                      </div>`
+                    : "";
                   return `
-                    <article class="player-source-card player-episode-stream-card focusable${focused ? " focused" : ""}"
+                    <article class="player-source-card player-episode-stream-card${sourceSide ? "" : " no-side"} focusable${focused ? " focused" : ""}"
                              data-episode-stream-index="${index}">
                       <div class="player-source-main">
                         ${topBadges}
@@ -15132,10 +15150,7 @@ export const PlayerScreen = {
                         <div class="player-source-desc">${escapeHtml(stream.description || stream.addonName || "")}</div>
                         ${bottomBadges}
                       </div>
-                      <div class="player-source-side">
-                        ${addonLogoUrl ? `<img class="player-source-logo" src="${escapeAttribute(addonLogoUrl)}" alt="" decoding="async" loading="lazy" referrerpolicy="no-referrer" />` : ""}
-                        <div class="player-source-addon">${escapeHtml(stream.addonName || t("nav_addons", {}, "Addon"))}</div>
-                      </div>
+                      ${sourceSide}
                     </article>
                   `;
                 })

--- a/js/ui/screens/settings/settingsScreen.js
+++ b/js/ui/screens/settings/settingsScreen.js
@@ -4540,6 +4540,10 @@ export const SettingsScreen = {
       StreamBadgeSettingsStore.setShowFileSizeBadges(!badgeSettings.showFileSizeBadges);
     });
 
+    this.actionMap.set("streams:toggle:addonLogo", () => {
+      StreamBadgeSettingsStore.setShowAddonLogo(!badgeSettings.showAddonLogo);
+    });
+
     const badgePlacement =
       String(badgeSettings.badgePlacement || "BOTTOM")
         .trim()
@@ -4664,6 +4668,16 @@ export const SettingsScreen = {
               "Show file size badges in stream results and player source panels."
             ),
             checked: badgeSettings.showFileSizeBadges !== false
+          })}
+          ${this.renderToggleRow({
+            focusKey: "streams:toggle:addonLogo",
+            title: t("settings_stream_addon_logo_title", {}, "Addon logo"),
+            subtitle: t(
+              "settings_stream_addon_logo_description",
+              {},
+              "Show addon logo and name next to stream sources."
+            ),
+            checked: badgeSettings.showAddonLogo === true
           })}
           ${this.renderActionRow({
             focusKey: "streams:badgePlacement",

--- a/js/ui/screens/stream/streamScreen.js
+++ b/js/ui/screens/stream/streamScreen.js
@@ -875,6 +875,9 @@ export const StreamScreen = {
   },
 
   areAddonLogosReady(streams = []) {
+    if (StreamBadgeSettingsStore.snapshot().showAddonLogo !== true) {
+      return true;
+    }
     return (streams || []).every((stream) => {
       const addonLogoUrl =
         normalizeAddonLogoUrl(stream?.addonLogo) ||
@@ -887,6 +890,9 @@ export const StreamScreen = {
   },
 
   requestAddonLogoPrerender(streams = []) {
+    if (StreamBadgeSettingsStore.snapshot().showAddonLogo !== true) {
+      return;
+    }
     const urls = Array.from(
       new Set(
         (streams || [])
@@ -1082,7 +1088,8 @@ export const StreamScreen = {
       this.listScrollTop = Number(restored.listScrollTop || 0);
     }
 
-    if (restored && this.streams.length) {
+    const showAddonLogo = StreamBadgeSettingsStore.snapshot().showAddonLogo === true;
+    if (restored && this.streams.length && showAddonLogo) {
       await ensureAddonLogoImageProxyReady();
       if (token !== this.loadToken || Router.getCurrent() !== "stream") {
         return;
@@ -1122,12 +1129,15 @@ export const StreamScreen = {
     if (!this.hasRenderedStreamRouteShell) {
       this.requestRender();
     }
-    await ensureAddonLogoImageProxyReady();
-    if (token !== this.loadToken) {
-      return;
-    }
     const pendingChunkTasks = new Set();
     const badgeSettings = StreamBadgeSettingsStore.snapshot();
+    const showAddonLogo = badgeSettings.showAddonLogo === true;
+    if (showAddonLogo) {
+      await ensureAddonLogoImageProxyReady();
+      if (token !== this.loadToken) {
+        return;
+      }
+    }
 
     const upsertSourceChip = (addon, status = "loading") => {
       const name = String(addon?.displayName || addon?.name || "").trim();
@@ -1215,7 +1225,9 @@ export const StreamScreen = {
       }
       await Promise.all([
         preloadMatchedStreamBadgeImages(chunkStreams, badgeSettings),
-        preloadAddonLogoImages(chunkStreams, this.addonLogoLookup)
+        ...(showAddonLogo
+          ? [preloadAddonLogoImages(chunkStreams, this.addonLogoLookup)]
+          : [])
       ]);
       if (token !== this.loadToken) {
         return;
@@ -1294,7 +1306,9 @@ export const StreamScreen = {
       if (missingStreams.length) {
         await Promise.all([
           preloadMatchedStreamBadgeImages(missingStreams, badgeSettings),
-          preloadAddonLogoImages(missingStreams, this.addonLogoLookup)
+          ...(showAddonLogo
+            ? [preloadAddonLogoImages(missingStreams, this.addonLogoLookup)]
+            : [])
         ]);
         if (token !== this.loadToken) {
           return;
@@ -1303,7 +1317,7 @@ export const StreamScreen = {
       }
       this.scheduleDebridPreparation();
       markSuccessfulSources(this.streams.map((stream) => stream.addonName));
-      if (this.streams.length) {
+      if (this.streams.length && showAddonLogo) {
         await preloadAddonLogoImages(this.streams, this.addonLogoLookup);
       }
       this.sourceChips = this.sourceChips.map((chip) =>
@@ -2099,27 +2113,36 @@ export const StreamScreen = {
     const headline = getStreamHeadline(stream);
     const quality = getStreamQuality(stream);
     const badges = renderStreamBadges(stream, streamBadgesEnabled, badgeSettings);
+    const showAddonLogo = badgeSettings?.showAddonLogo === true;
     const badgePlacement = resolveStreamBadgePlacement(badgeSettings);
     const topBadges = badgePlacement === "TOP" ? badges : "";
     const bottomBadges = badgePlacement === "BOTTOM" ? badges : "";
     const descriptionLines = getStreamDescriptionLines(stream);
-    const addonLogoUrl =
-      normalizeAddonLogoUrl(stream.addonLogo) ||
-      resolveAddonLogo(stream.addonName, this.addonLogoLookup);
-    const cachedAddonLogoUrl = getCachedAddonLogoDisplayUrl(addonLogoUrl);
-    let displayAddonLogoUrl = cachedAddonLogoUrl || "";
-    if (addonLogoUrl && !displayAddonLogoUrl && !hasFailedAddonLogo(addonLogoUrl)) {
-      requestAddonLogo(addonLogoUrl, () => this.requestRender({ delayMs: 160 }));
-      if (Environment.isWebOS()) {
-        displayAddonLogoUrl = getCachedAddonLogoDisplayUrl(addonLogoUrl);
+    let addonIdentity = "";
+    if (showAddonLogo) {
+      const addonLogoUrl =
+        normalizeAddonLogoUrl(stream.addonLogo) ||
+        resolveAddonLogo(stream.addonName, this.addonLogoLookup);
+      const cachedAddonLogoUrl = getCachedAddonLogoDisplayUrl(addonLogoUrl);
+      let displayAddonLogoUrl = cachedAddonLogoUrl || "";
+      if (addonLogoUrl && !displayAddonLogoUrl && !hasFailedAddonLogo(addonLogoUrl)) {
+        requestAddonLogo(addonLogoUrl, () => this.requestRender({ delayMs: 160 }));
+        if (Environment.isWebOS()) {
+          displayAddonLogoUrl = getCachedAddonLogoDisplayUrl(addonLogoUrl);
+        }
       }
+      const addonBadgeLabel = escapeHtml(getAddonBadgeLabel(stream.addonName || ""));
+      const addonLogoLoading = Environment.isWebOS() || Environment.isTizen() ? "eager" : "lazy";
+      const addonLogoDecoding = Environment.isWebOS() || Environment.isTizen() ? "sync" : "async";
+      const addonBadge = displayAddonLogoUrl
+        ? `<img src="${escapeHtml(displayAddonLogoUrl)}" alt="${escapeHtml(stream.addonName || "Addon")}" data-addon-logo="${escapeHtml(addonLogoUrl)}" decoding="${addonLogoDecoding}" loading="${addonLogoLoading}" referrerpolicy="no-referrer" /><span hidden>${addonBadgeLabel}</span>`
+        : `<span>${addonBadgeLabel}</span>`;
+      addonIdentity = `
+          <div class="stream-route-card-side">
+            <div class="stream-route-addon-badge">${addonBadge}</div>
+            <div class="stream-route-addon-name">${escapeHtml(stream.addonName || "Addon")}</div>
+          </div>`;
     }
-    const addonBadgeLabel = escapeHtml(getAddonBadgeLabel(stream.addonName || ""));
-    const addonLogoLoading = Environment.isWebOS() || Environment.isTizen() ? "eager" : "lazy";
-    const addonLogoDecoding = Environment.isWebOS() || Environment.isTizen() ? "sync" : "async";
-    const addonBadge = displayAddonLogoUrl
-      ? `<img src="${escapeHtml(displayAddonLogoUrl)}" alt="${escapeHtml(stream.addonName || "Addon")}" data-addon-logo="${escapeHtml(addonLogoUrl)}" decoding="${addonLogoDecoding}" loading="${addonLogoLoading}" referrerpolicy="no-referrer" /><span hidden>${addonBadgeLabel}</span>`
-      : `<span>${addonBadgeLabel}</span>`;
 
     return `
       <div class="stream-route-card-row" data-stream-row="${index}">
@@ -2135,10 +2158,7 @@ export const StreamScreen = {
             ${descriptionLines.map((line, lineIndex) => `<div class="stream-route-card-line${lineIndex > 0 ? " secondary" : ""}">${escapeHtml(line)}</div>`).join("")}
             ${bottomBadges || ""}
           </div>
-          <div class="stream-route-card-side">
-            <div class="stream-route-addon-badge">${addonBadge}</div>
-            <div class="stream-route-addon-name">${escapeHtml(stream.addonName || "Addon")}</div>
-          </div>
+          ${addonIdentity}
         </article>
       </div>
     `;
@@ -2182,7 +2202,8 @@ export const StreamScreen = {
     const hasAnyStreams = this.streams.length > 0;
     const streamBadgesEnabled = DebridSettingsStore.get().streamBadgesEnabled !== false;
     const badgeSettings = StreamBadgeSettingsStore.snapshot();
-    const addonLogosReady = !filtered.length || this.areAddonLogosReady(filtered);
+    const showAddonLogo = badgeSettings.showAddonLogo === true;
+    const addonLogosReady = !showAddonLogo || !filtered.length || this.areAddonLogosReady(filtered);
 
     let body = "";
     if (filtered.length && addonLogosReady) {
@@ -2194,7 +2215,7 @@ export const StreamScreen = {
       if (hasPendingForFilter) {
         body += this.renderLoadingCards(1);
       }
-    } else if (filtered.length) {
+    } else if (filtered.length && showAddonLogo) {
       this.requestAddonLogoPrerender(filtered);
       body = this.renderLoadingCards(Math.min(3, filtered.length));
     } else if ((this.loading && !hasAnyStreams) || hasPendingForFilter) {

--- a/res/values-ar/strings.xml
+++ b/res/values-ar/strings.xml
@@ -1361,4 +1361,6 @@
     <string name="player.audio.unsupported">غير مدعوم</string>
     <string name="player.audio.unsupportedCodec">برنامج الترميز غير مدعوم على هذا الجهاز</string>
     <string name="player.audio.noSupportedTracks">لا تتوفر مسارات صوتية مدعومة</string>
+    <string name="settings_stream_addon_logo_title">شعار الإضافة</string>
+    <string name="settings_stream_addon_logo_description">عرض شعار الإضافة واسمها بجانب مصادر البث.</string>
 </resources>

--- a/res/values-bs/strings.xml
+++ b/res/values-bs/strings.xml
@@ -1371,4 +1371,6 @@
     <string name="player.audio.unsupported">Nije podržano</string>
     <string name="player.audio.unsupportedCodec">Ovaj uređaj ne podržava kodek</string>
     <string name="player.audio.noSupportedTracks">Nema dostupnih podržanih audio zapisa</string>
+    <string name="settings_stream_addon_logo_title">Logotip dodatka</string>
+    <string name="settings_stream_addon_logo_description">Prikaži logotip i naziv dodatka pored izvora streama.</string>
 </resources>

--- a/res/values-cs/strings.xml
+++ b/res/values-cs/strings.xml
@@ -1807,4 +1807,6 @@
     <string name="player.audio.unsupported">Nepodporováno</string>
     <string name="player.audio.unsupportedCodec">Tento kodek zařízení nepodporuje</string>
     <string name="player.audio.noSupportedTracks">Nejsou k dispozici žádné podporované zvukové stopy</string>
+    <string name="settings_stream_addon_logo_title">Logo doplňku</string>
+    <string name="settings_stream_addon_logo_description">Zobrazovat logo a název doplňku vedle zdrojů streamů.</string>
 </resources>

--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -2084,4 +2084,6 @@
     <string name="player.audio.unsupported">Nicht unterstützt</string>
     <string name="player.audio.unsupportedCodec">Codec wird von diesem Gerät nicht unterstützt</string>
     <string name="player.audio.noSupportedTracks">Keine unterstützten Audiospuren verfügbar</string>
+    <string name="settings_stream_addon_logo_title">Add-on-Logo</string>
+    <string name="settings_stream_addon_logo_description">Zeige das Logo und den Namen des Add-ons neben Stream-Quellen an.</string>
 </resources>

--- a/res/values-el/strings.xml
+++ b/res/values-el/strings.xml
@@ -2234,4 +2234,6 @@
     <string name="player.audio.unsupported">Δεν υποστηρίζεται</string>
     <string name="player.audio.unsupportedCodec">Ο κωδικοποιητής δεν υποστηρίζεται από αυτήν τη συσκευή</string>
     <string name="player.audio.noSupportedTracks">Δεν υπάρχουν διαθέσιμα υποστηριζόμενα κομμάτια ήχου</string>
+    <string name="settings_stream_addon_logo_title">Λογότυπο πρόσθετου</string>
+    <string name="settings_stream_addon_logo_description">Εμφάνιση λογότυπου και ονόματος πρόσθετου δίπλα στις πηγές ροής.</string>
 </resources>

--- a/res/values-es-419/strings.xml
+++ b/res/values-es-419/strings.xml
@@ -2256,4 +2256,6 @@
     <string name="player.audio.unsupported">No compatible</string>
     <string name="player.audio.unsupportedCodec">Códec no compatible con este dispositivo</string>
     <string name="player.audio.noSupportedTracks">No hay pistas de audio compatibles disponibles</string>
+    <string name="settings_stream_addon_logo_title">Logotipo del complemento</string>
+    <string name="settings_stream_addon_logo_description">Muestra el logotipo y el nombre del complemento junto a las fuentes de transmisión.</string>
 </resources>

--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -1086,4 +1086,6 @@
     <string name="player.audio.unsupported">No compatible</string>
     <string name="player.audio.unsupportedCodec">Códec no compatible con este dispositivo</string>
     <string name="player.audio.noSupportedTracks">No hay pistas de audio compatibles disponibles</string>
+    <string name="settings_stream_addon_logo_title">Logotipo del complemento</string>
+    <string name="settings_stream_addon_logo_description">Muestra el logotipo y el nombre del complemento junto a las fuentes de transmisión.</string>
 </resources>

--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -2519,4 +2519,6 @@
     <string name="player.audio.unsupported">Non pris en charge</string>
     <string name="player.audio.unsupportedCodec">Codec non pris en charge par cet appareil</string>
     <string name="player.audio.noSupportedTracks">Aucune piste audio prise en charge disponible</string>
+    <string name="settings_stream_addon_logo_title">Logo de l’addon</string>
+    <string name="settings_stream_addon_logo_description">Affiche le logo et le nom de l’addon à côté des sources de streams.</string>
 </resources>

--- a/res/values-he/strings.xml
+++ b/res/values-he/strings.xml
@@ -950,4 +950,6 @@
     <string name="player.audio.unsupported">לא נתמך</string>
     <string name="player.audio.unsupportedCodec">רכיב ה-Codec אינו נתמך במכשיר זה</string>
     <string name="player.audio.noSupportedTracks">אין רצועות שמע נתמכות זמינות</string>
+    <string name="settings_stream_addon_logo_title">לוגו התוסף</string>
+    <string name="settings_stream_addon_logo_description">הצגת הלוגו ושם התוסף לצד מקורות הסטרימינג.</string>
 </resources>

--- a/res/values-hi/strings.xml
+++ b/res/values-hi/strings.xml
@@ -1043,4 +1043,6 @@
     <string name="player.audio.unsupported">समर्थित नहीं</string>
     <string name="player.audio.unsupportedCodec">यह डिवाइस इस कोडेक का समर्थन नहीं करता</string>
     <string name="player.audio.noSupportedTracks">कोई समर्थित ऑडियो ट्रैक उपलब्ध नहीं है</string>
+    <string name="settings_stream_addon_logo_title">ऐड-ऑन लोगो</string>
+    <string name="settings_stream_addon_logo_description">स्ट्रीम स्रोतों के आगे ऐड-ऑन का लोगो और नाम दिखाएँ।</string>
 </resources>

--- a/res/values-hu/strings.xml
+++ b/res/values-hu/strings.xml
@@ -999,4 +999,6 @@
     <string name="player.audio.unsupported">Nem támogatott</string>
     <string name="player.audio.unsupportedCodec">Ezt a kodeket az eszköz nem támogatja</string>
     <string name="player.audio.noSupportedTracks">Nincs elérhető támogatott hangsáv</string>
+    <string name="settings_stream_addon_logo_title">Kiegészítő logója</string>
+    <string name="settings_stream_addon_logo_description">A kiegészítő logójának és nevének megjelenítése a stream források mellett.</string>
 </resources>

--- a/res/values-id/strings.xml
+++ b/res/values-id/strings.xml
@@ -2256,4 +2256,6 @@
     <string name="player.audio.unsupported">Tidak didukung</string>
     <string name="player.audio.unsupportedCodec">Codec tidak didukung oleh perangkat ini</string>
     <string name="player.audio.noSupportedTracks">Tidak ada trek audio yang didukung</string>
+    <string name="settings_stream_addon_logo_title">Logo addon</string>
+    <string name="settings_stream_addon_logo_description">Tampilkan logo dan nama addon di samping sumber streaming.</string>
 </resources>

--- a/res/values-it/strings.xml
+++ b/res/values-it/strings.xml
@@ -2646,4 +2646,6 @@
     <string name="playback_net_chunk_size">Dimensione chunk</string>
     <string name="playback_net_chunk_size_sub">Dimensione di ogni chunk di download per connessione. Chunk più grandi riducono l\'overhead ma usano più memoria.</string>
     <string name="contributor_role_app_maintainer">Responsabile di questa app</string>
+    <string name="settings_stream_addon_logo_title">Logo Addon</string>
+    <string name="settings_stream_addon_logo_description">Mostra il logo e il nome dell'addon accanto alle sorgenti degli stream.</string>
 </resources>

--- a/res/values-ja/strings.xml
+++ b/res/values-ja/strings.xml
@@ -1223,4 +1223,6 @@
     <string name="player.audio.unsupported">非対応</string>
     <string name="player.audio.unsupportedCodec">このデバイスではコーデックがサポートされていません</string>
     <string name="player.audio.noSupportedTracks">対応している音声トラックがありません</string>
+    <string name="settings_stream_addon_logo_title">アドオンロゴ</string>
+    <string name="settings_stream_addon_logo_description">ストリームソースの横にアドオンのロゴと名前を表示します。</string>
 </resources>

--- a/res/values-lt/strings.xml
+++ b/res/values-lt/strings.xml
@@ -921,4 +921,6 @@ Klaida: Bandomoji simuliuojama klaida — tai nėra tikras gedimas. Šaltinis gr
     <string name="player.audio.unsupported">Nepalaikoma</string>
     <string name="player.audio.unsupportedCodec">Šis įrenginys nepalaiko kodeko</string>
     <string name="player.audio.noSupportedTracks">Nėra palaikomų garso takelių</string>
+    <string name="settings_stream_addon_logo_title">Priedo logotipas</string>
+    <string name="settings_stream_addon_logo_description">Rodyti priedo logotipą ir pavadinimą šalia srauto šaltinių.</string>
 </resources>

--- a/res/values-nl/strings.xml
+++ b/res/values-nl/strings.xml
@@ -913,4 +913,6 @@
     <string name="player.audio.unsupported">Niet ondersteund</string>
     <string name="player.audio.unsupportedCodec">Codec wordt niet ondersteund door dit apparaat</string>
     <string name="player.audio.noSupportedTracks">Geen ondersteunde audiotracks beschikbaar</string>
+    <string name="settings_stream_addon_logo_title">Addon-logo</string>
+    <string name="settings_stream_addon_logo_description">Toon addon-logo en -naam naast streambronnen.</string>
 </resources>

--- a/res/values-no/strings.xml
+++ b/res/values-no/strings.xml
@@ -1034,4 +1034,6 @@
     <string name="player.audio.unsupported">Ikke støttet</string>
     <string name="player.audio.unsupportedCodec">Kodeken støttes ikke av denne enheten</string>
     <string name="player.audio.noSupportedTracks">Ingen støttede lydspor er tilgjengelige</string>
+    <string name="settings_stream_addon_logo_title">Tilleggslogo</string>
+    <string name="settings_stream_addon_logo_description">Vis logoen og navnet til tillegget ved siden av strømmekildene.</string>
 </resources>

--- a/res/values-pl/strings.xml
+++ b/res/values-pl/strings.xml
@@ -2497,4 +2497,6 @@
     <string name="player.audio.unsupported">Nieobsługiwane</string>
     <string name="player.audio.unsupportedCodec">Kodek nie jest obsługiwany przez to urządzenie</string>
     <string name="player.audio.noSupportedTracks">Brak dostępnych obsługiwanych ścieżek audio</string>
+    <string name="settings_stream_addon_logo_title">Logo dodatku</string>
+    <string name="settings_stream_addon_logo_description">Pokazuj logo i nazwę dodatku obok źródeł.</string>
 </resources>

--- a/res/values-pt-br/strings.xml
+++ b/res/values-pt-br/strings.xml
@@ -2361,4 +2361,6 @@
     <string name="player.audio.unsupported">Não compatível</string>
     <string name="player.audio.unsupportedCodec">Codec não compatível com este dispositivo</string>
     <string name="player.audio.noSupportedTracks">Nenhuma faixa de áudio compatível disponível</string>
+    <string name="settings_stream_addon_logo_title">Logo do addon</string>
+    <string name="settings_stream_addon_logo_description">Mostrar o logo e o nome do addon ao lado das fontes de streaming.</string>
 </resources>

--- a/res/values-pt-pt/strings.xml
+++ b/res/values-pt-pt/strings.xml
@@ -2612,4 +2612,6 @@
     <string name="player.audio.unsupported">Não suportado</string>
     <string name="player.audio.unsupportedCodec">Codec não suportado por este dispositivo</string>
     <string name="player.audio.noSupportedTracks">Nenhuma faixa de áudio suportada disponível</string>
+    <string name="settings_stream_addon_logo_title">Logótipo do addon</string>
+    <string name="settings_stream_addon_logo_description">Mostra o logótipo e o nome do addon junto das fontes de stream.</string>
 </resources>

--- a/res/values-ro/strings.xml
+++ b/res/values-ro/strings.xml
@@ -757,4 +757,6 @@
     <string name="player.audio.unsupported">Neacceptat</string>
     <string name="player.audio.unsupportedCodec">Codecul nu este acceptat de acest dispozitiv</string>
     <string name="player.audio.noSupportedTracks">Nu sunt disponibile piste audio acceptate</string>
+    <string name="settings_stream_addon_logo_title">Siglă extensie</string>
+    <string name="settings_stream_addon_logo_description">Afișează sigla și numele extensiei lângă sursele fluxului.</string>
 </resources>

--- a/res/values-ru/strings.xml
+++ b/res/values-ru/strings.xml
@@ -2354,4 +2354,6 @@
     <string name="player.audio.unsupported">Не поддерживается</string>
     <string name="player.audio.unsupportedCodec">Кодек не поддерживается этим устройством</string>
     <string name="player.audio.noSupportedTracks">Нет доступных поддерживаемых аудиодорожек</string>
+    <string name="settings_stream_addon_logo_title">Логотип дополнения</string>
+    <string name="settings_stream_addon_logo_description">Показывать логотип и название дополнения рядом с источниками потоков.</string>
 </resources>

--- a/res/values-se/string.xml
+++ b/res/values-se/string.xml
@@ -852,4 +852,6 @@
     <string name="player.audio.unsupported">Stöds inte</string>
     <string name="player.audio.unsupportedCodec">Kodeken stöds inte av den här enheten</string>
     <string name="player.audio.noSupportedTracks">Inga ljudspår som stöds är tillgängliga</string>
+    <string name="settings_stream_addon_logo_title">Tilläggslogotyp</string>
+    <string name="settings_stream_addon_logo_description">Visa tilläggets logotyp och namn bredvid strömkällor.</string>
 </resources>

--- a/res/values-sk/strings.xml
+++ b/res/values-sk/strings.xml
@@ -2390,4 +2390,6 @@
     <string name="player.audio.unsupported">Nepodporované</string>
     <string name="player.audio.unsupportedCodec">Toto zariadenie nepodporuje kodek</string>
     <string name="player.audio.noSupportedTracks">Nie sú k dispozícii žiadne podporované zvukové stopy</string>
+    <string name="settings_stream_addon_logo_title">Logo doplnku</string>
+    <string name="settings_stream_addon_logo_description">Zobraziť logo a názov doplnku vedľa zdrojov streamov.</string>
 </resources>

--- a/res/values-sl/strings.xml
+++ b/res/values-sl/strings.xml
@@ -2203,4 +2203,6 @@
     <string name="player.audio.unsupported">Ni podprto</string>
     <string name="player.audio.unsupportedCodec">Ta naprava ne podpira kodeka</string>
     <string name="player.audio.noSupportedTracks">Na voljo ni podprtih zvočnih sledi</string>
+    <string name="settings_stream_addon_logo_title">Logotip dodatka</string>
+    <string name="settings_stream_addon_logo_description">Prikaži logotip in ime dodatka ob virih pretočnega predvajanja.</string>
 </resources>

--- a/res/values-sv/strings.xml
+++ b/res/values-sv/strings.xml
@@ -1419,4 +1419,6 @@
     <string name="player.audio.unsupported">Stöds inte</string>
     <string name="player.audio.unsupportedCodec">Kodeken stöds inte av den här enheten</string>
     <string name="player.audio.noSupportedTracks">Inga ljudspår som stöds är tillgängliga</string>
+    <string name="settings_stream_addon_logo_title">Tilläggslogotyp</string>
+    <string name="settings_stream_addon_logo_description">Visa tilläggets logotyp och namn bredvid strömkällor.</string>
 </resources>

--- a/res/values-ta/strings.xml
+++ b/res/values-ta/strings.xml
@@ -2085,4 +2085,6 @@
     <string name="player.audio.unsupported">ஆதரிக்கப்படவில்லை</string>
     <string name="player.audio.unsupportedCodec">இந்தச் சாதனம் இந்த கோடெக்கை ஆதரிக்கவில்லை</string>
     <string name="player.audio.noSupportedTracks">ஆதரிக்கப்படும் ஆடியோ தடங்கள் எதுவும் இல்லை</string>
+    <string name="settings_stream_addon_logo_title">துணை நிரல் லோகோ</string>
+    <string name="settings_stream_addon_logo_description">ஸ்ட்ரீம் மூலங்களுக்கு அருகில் துணை நிரல் லோகோ மற்றும் பெயரைக் காட்டு.</string>
 </resources>

--- a/res/values-tr/strings.xml
+++ b/res/values-tr/strings.xml
@@ -2360,4 +2360,6 @@
     <string name="player.audio.unsupported">Desteklenmiyor</string>
     <string name="player.audio.unsupportedCodec">Codec bu cihaz tarafından desteklenmiyor</string>
     <string name="player.audio.noSupportedTracks">Desteklenen ses parçası bulunmuyor</string>
+    <string name="settings_stream_addon_logo_title">Eklenti logosu</string>
+    <string name="settings_stream_addon_logo_description">Yayın kaynaklarının yanında eklenti logosunu ve adını göster.</string>
 </resources>

--- a/res/values-vi/strings.xml
+++ b/res/values-vi/strings.xml
@@ -933,4 +933,6 @@
     <string name="player.audio.unsupported">Không được hỗ trợ</string>
     <string name="player.audio.unsupportedCodec">Thiết bị này không hỗ trợ codec</string>
     <string name="player.audio.noSupportedTracks">Không có bản âm thanh được hỗ trợ</string>
+    <string name="settings_stream_addon_logo_title">Biểu tượng addon</string>
+    <string name="settings_stream_addon_logo_description">Hiển thị biểu tượng và tên addon bên cạnh mỗi nguồn phát</string>
 </resources>

--- a/res/values-zh-cn/strings.xml
+++ b/res/values-zh-cn/strings.xml
@@ -2173,4 +2173,6 @@
     <string name="player.audio.unsupported">不支持</string>
     <string name="player.audio.unsupportedCodec">此设备不支持该编解码器</string>
     <string name="player.audio.noSupportedTracks">没有可用的受支持音轨</string>
+    <string name="settings_stream_addon_logo_title">插件徽标</string>
+    <string name="settings_stream_addon_logo_description">在流媒体源旁显示插件徽标和名称。</string>
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1017,6 +1017,8 @@
     <string name="settings_stream_badges_description">Show quality, HDR, codec, audio, and size chips in source results.</string>
     <string name="settings_stream_size_badges_title">Size badges</string>
     <string name="settings_stream_size_badges_description">Show file size badges in stream results and player source panels.</string>
+    <string name="settings_stream_addon_logo_title">Addon logo</string>
+    <string name="settings_stream_addon_logo_description">Show addon logo and name next to stream sources.</string>
     <string name="settings_stream_badge_position_title">Badge position</string>
     <string name="settings_stream_badge_position_description">Choose whether Fusion and size badges appear above or below stream cards.</string>
     <string name="settings_stream_badge_position_dialog_title">Badge position</string>


### PR DESCRIPTION
## Summary

Adds an Android-parity **Addon logo** stream setting that controls whether stream source cards show the addon logo and addon name. Disabled mode reclaims the identity column and avoids hidden artwork loading work.

## PR type

- [ ] Translation/localization only
- [ ] Critical bug fix
- [x] Approved feature/change

Maintainer approval is recorded in #471 after Android TV parity review.

## Affected area

- [x] Shared web app
- [x] Samsung Tizen
- [x] LG webOS
- [x] Browser development mode
- [ ] Playback
- [ ] Audio tracks
- [ ] Subtitles
- [ ] Focus / Remote navigation
- [x] UI / Layout
- [ ] Resume / Watch progress
- [ ] Continue Watching
- [ ] Next Episode / Auto-play
- [ ] Packaging / Build
- [ ] Nuvio WebTV Installer compatibility
- [ ] TizenBrew wrapper
- [ ] webOS Homebrew wrapper
- [ ] Documentation
- [ ] Other

## Why

Stream cards currently always reserve space for an addon logo and addon name. This reduces the width available for source details on TV layouts, and users who prefer a denser list cannot hide the identity block. A CSS-only solution would still perform logo preloading, cache work, and readiness delays.

Android TV already provides this behavior with a profile-scoped **Addon logo** preference that defaults on, preserving the existing identity UI until the user disables it:

- `StreamBadgeSettings.showAddonLogo = true`
- `StreamBadgeSettingsDataStore` key `show_addon_logo`, default `true`
- Conditional identity rendering in the main stream list and both player source panels
- Profile settings blob sync through the `stream_badge_settings` feature
## Issue or approval

Feature request and approval tracker: #471. Maintainer approval is recorded there after Android TV parity review.

## Reproduction steps

1. Open any title with stream results.
2. Observe that every source card always reserves a logo/name identity column.
3. Open the player Sources panel or episode stream list and observe the same mandatory identity block.
4. Note that there is no Streams setting to hide it.

## Old behavior

Addon artwork or fallback initials and the addon name were always rendered. Main stream cards waited for logo readiness, and webOS player panels could preload image-proxy/cache data even when a user did not want addon identity artwork.

## New behavior

A profile-scoped, default-on **Addon logo** toggle is available under **Settings → Streams → Fusion Style**, matching Android TV and preserving the existing Web UI by default. When enabled, the existing logo and addon-name UI is preserved. When disabled, the identity block is omitted, source details reclaim the space, and hidden logo readiness/preload/network work is skipped. The setting applies to the main stream list, player Sources panel, and player episode-stream list.

## Platform impact

- Samsung Tizen: Shared stream and player card rendering changes only; no Tizen API or AVPlay changes.
- LG webOS: Shared rendering changes plus avoiding unnecessary addon-logo proxy/cache work while disabled; no Luna or media API changes.
- Browser development mode: Same profile setting and conditional card layout as packaged targets.
- Installer / packaging: No impact.
- Wrapper repositories: No impact.

## UI / behavior / playback impact

- [ ] No UI change
- [ ] No behavior change
- [x] No playback change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [x] UI change has explicit maintainer approval
- [x] Behavior change has explicit maintainer approval
- [ ] Playback change has explicit maintainer approval

The required UI and behavior approval is recorded in #471.

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact
- [ ] Tizen `.wgt` packaging changed
- [ ] webOS `.ipk` packaging changed
- [ ] App identifiers or metadata changed
- [ ] `local.properties` / environment handling changed
- [ ] `sync:tizen` changed
- [ ] `sync:webos` changed
- [ ] Nuvio WebTV Installer compatibility changed
- [ ] TizenBrew wrapper support changed
- [ ] webOS Homebrew metadata support changed

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I included a linked issue, reproduction steps, and testing notes if this is a critical bug fix.
- [x] I listed the testing performed below.

Approval-dependent boxes are checked after maintainer review and approval in #471.

## Scope boundaries

This does not change provider filter labels, addon names embedded in source titles/descriptions, Fusion badge images, size badges, source selection, playback behavior, cached logo deletion, addon management, platform APIs, packaging, installers, or wrappers. The setting is synchronized through the existing `stream_badge_settings` profile blob using Android's `show_addon_logo` key. The separate web-only detail-page episode chooser is not changed because it is not an Android `showAddonLogo` consumer.

## Testing

### Devices / platforms tested

- Browser development mode at 1920×1080 using the integrated browser.
- Shared rendering paths were inspected for browser, Tizen, and webOS conditionals.
- No physical Samsung Tizen or LG webOS device test was performed for this change.

### Commands tested

```sh
node --check js/data/local/streamBadgeSettingsStore.js
node --check js/core/profile/profileSettingsSyncService.js
node --check js/ui/screens/settings/settingsScreen.js
node --check js/ui/screens/stream/streamScreen.js
node --check js/ui/screens/player/playerScreen.js
find res -type f \( -name 'strings.xml' -o -name 'string.xml' \) -print0 | xargs -0 -n1 xmllint --noout
npm run build
```

## Manual test flow

1. Open **Settings → Streams → Fusion Style** and confirm **Addon logo** uses the Android copy and defaults on for a profile without a stored value.
2. Disable **Addon logo**, open stream results, and confirm logo/name identity columns are absent and source details reclaim the width.
3. Confirm provider filters, source text, Fusion badges, and size badges remain visible.
4. Confirm the browser DOM contains no addon identity blocks in disabled mode.
5. Enable the setting and confirm the existing logo/name rendering path is restored.
6. Verify the player Sources and episode-stream renderers preserve the independent **Playing** marker when addon identity is disabled.

## Screenshots / Video

<img width="2290" height="1297" alt="Screenshot From 2026-07-15 11-52-27" src="https://github.com/user-attachments/assets/e8d09485-cbdc-4f41-af92-7f31e85c6e1b" />

## Logs

Not applicable. This does not address a crash, blank screen, install failure, packaging failure, playback failure, or platform API error.

## Regression risk

Moderate and localized to stream-card rendering. Potential regressions are empty reserved space, hiding the player **Playing** marker, requesting hidden logos, or suppressing Fusion badge images. The implementation keeps these paths separate, defaults to the Android behavior, and preserves the previous enabled-state markup.

## Breaking changes

No default behavior changes: addon identity remains visible for profiles without a saved value, matching Android TV and the previous Web behavior. No public API, package, app identifier, or storage envelope is broken; existing normalized profile records gain an optional boolean field.

## Linked issues

- #471 — feature request and approval tracker
