### PR TITLE
Stop auto-play looping when leaving the player

### DIFF
--- a/js/ui/screens/stream/streamScreen.js
+++ b/js/ui/screens/stream/streamScreen.js
@@ -1062,7 +1062,11 @@ export const StreamScreen = {
     this.addonLogoLookup = {};
     this.addonFilter = "all";
     this.hasRenderedStreamRouteShell = false;
-    this.autoResumeAttempted = false;
+    // Returning here from the player is a back navigation, not a fresh open, so
+    // do not auto-resume or auto-play again. Otherwise exiting the player drops
+    // back onto the stream list and immediately relaunches, looping forever.
+    const returningFromPlayer = Boolean(navigationContext?.isBackNavigation);
+    this.autoResumeAttempted = returningFromPlayer;
     const playerSettings = PlayerSettingsStore.get();
     const reusableStream = playerSettings.streamReuseLastLinkEnabled
       ? StreamPreferencesStore.getValid(
@@ -1079,7 +1083,7 @@ export const StreamScreen = {
       (String(this.params?.resumeStreamIdentity || "").trim() ||
         String(this.params?.preferredStreamId || "").trim())
     );
-    this.autoPlayAttempted = false;
+    this.autoPlayAttempted = returningFromPlayer;
     this.cancelAutoPlayCountdown();
     this.cancelAutoPlaySelectionWait();
     const autoPlayWaitSeconds = Math.max(0, Math.trunc(Number(playerSettings.streamAutoPlayTimeoutSeconds || 0)));


### PR DESCRIPTION
Closes #494

With auto stream selection (or auto resume) enabled, opening a title auto-selects and plays a stream. The problem is on the way back: leaving the player drops onto the stream list and it immediately auto-selects and plays again, so you get stuck in a loop and can never reach the list.

Returning from the player is a back navigation, but the stream screen was resetting its auto-resume/auto-play state on every mount and firing again. It now treats a back navigation as "already attempted", so it does not auto-launch when you come back. Opening a title fresh still auto-plays as before.

Verified in the browser with First Stream auto-play on: opening a movie auto-plays into the player (unchanged); pressing Back returns to the stream list and it stays there (no re-play), even after waiting, with focus on a stream card so you can pick one.