### PR TITLE
Keep library sidebar open during background refresh

### DIFF
--- a/js/ui/screens/library/libraryScreen.js
+++ b/js/ui/screens/library/libraryScreen.js
@@ -974,6 +974,27 @@ export const LibraryScreen = {
       return;
     }
     const state = this.controller.getState();
+
+    // When the sidebar is the active focus zone, keep focus there across
+    // re-renders (e.g. a background library sync) instead of snapping back to
+    // the last content item, which visually collapses the open sidebar.
+    const sidebarActive =
+      this.focusZone === "sidebar" &&
+      !state.listEditorState &&
+      !state.showDeleteConfirm &&
+      !state.showManageDialog &&
+      !state.expandedPicker;
+    if (sidebarActive) {
+      const sidebarNode =
+        getRootSidebarSelectedNode(this.container, this.layoutPrefs) ||
+        getRootSidebarNodes(this.container, this.layoutPrefs)[0] ||
+        null;
+      if (sidebarNode) {
+        this.setFocusedNode(sidebarNode);
+        return;
+      }
+    }
+
     let selector = null;
 
     if (state.listEditorState) {


### PR DESCRIPTION
Fixes #493.

In the Library the left sidebar closes on its own after a couple of seconds. It happens when the library data refreshes in the background (for example a Trakt sync finishing). That refresh re-renders the screen and focus snaps back to the last poster or filter, so the open sidebar collapses.

Now when the sidebar is the active area, a background re-render keeps focus on the sidebar instead of jumping back to the content, so it stays open. Normal content focus is unchanged.