### PR TITLE
Hide player controls on Back before exiting

### DIFF
--- a/js/ui/screens/player/playerScreen.js
+++ b/js/ui/screens/player/playerScreen.js
@@ -15989,6 +15989,14 @@ export const PlayerScreen = {
       return this.navigateBackToStreamScreen();
     }
 
+    // Match Android TV: when the on screen controls are showing, Back hides
+    // them and keeps the video playing. The player only leaves on a Back press
+    // once the controls are already hidden.
+    if (this.controlsVisible && !this.nextEpisodeBackExitArmed) {
+      this.setControlsVisible(false, { focus: false });
+      return true;
+    }
+
     this.nextEpisodeBackExitArmed = false;
     return this.navigateBackToStreamScreen();
   },


### PR DESCRIPTION
Fixes #492.

On the player, pressing Back always left the video, even when the controls were on screen. Android TV hides the controls first and only exits once they are already hidden, so this brings the web player in line.

Now Back hides the controls if they are showing and keeps playing. Pressing Back again with the controls hidden exits as before. The next episode card case that arms an exit on the following Back is untouched.

Matches Android TV handleBackPress (PlayerScreen.kt): shows controls -> hideControls(), otherwise exitPlayer().