### PR TITLE
fix: keep Trakt rewatches in Continue Watching

### DIFF
--- a/js/data/repository/watchProgressRepository.js
+++ b/js/data/repository/watchProgressRepository.js
@@ -168,6 +168,14 @@ function selectedContinueWatchingSource() {
     : WatchProgressSource.NUVIO_SYNC;
 }
 
+function selectedLocalProgressSource() {
+  // Playback is recorded locally even when Trakt owns Continue Watching.
+  // Keep that fresh state in the selected source until Trakt catches up.
+  return selectedContinueWatchingSource() === WatchProgressSource.TRAKT
+    ? "trakt_local"
+    : WatchProgressSource.NUVIO_SYNC;
+}
+
 function filterForSelectedContinueWatchingSource(items = []) {
   const useTrakt = selectedContinueWatchingSource() === WatchProgressSource.TRAKT;
   const all = Array.isArray(items) ? items : [];
@@ -511,6 +519,7 @@ class WatchProgressRepository {
     WatchProgressStore.upsert(
       {
         ...progress,
+        source: String(progress?.source || "").trim() || selectedLocalProgressSource(),
         updatedAt: progress.updatedAt || Date.now()
       },
       activeProfileId()

--- a/tests/watchProgressRepository.test.mjs
+++ b/tests/watchProgressRepository.test.mjs
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+class MemoryStorage {
+  constructor() {
+    this.values = new Map();
+  }
+
+  getItem(key) {
+    return this.values.has(String(key)) ? this.values.get(String(key)) : null;
+  }
+
+  setItem(key, value) {
+    this.values.set(String(key), String(value));
+  }
+
+  removeItem(key) {
+    this.values.delete(String(key));
+  }
+}
+
+globalThis.localStorage = new MemoryStorage();
+globalThis.fetch = async () =>
+  new Response("[]", {
+    status: 200,
+    headers: { "Content-Type": "application/json" }
+  });
+
+const { TraktAuthStore } = await import("../js/data/local/traktAuthStore.js");
+const { TraktSettingsStore, WatchProgressSource } =
+  await import("../js/data/local/traktSettingsStore.js");
+const { watchProgressRepository } =
+  await import("../js/data/repository/watchProgressRepository.js");
+const { metaRepository } = await import("../js/data/repository/metaRepository.js");
+
+metaRepository.getMetaFromAllAddons = async () => null;
+
+test("keeps locally recorded rewatch progress in the selected Trakt source", async () => {
+  TraktAuthStore.saveToken({
+    access_token: "test-access-token",
+    refresh_token: "test-refresh-token",
+    created_at: Math.floor(Date.now() / 1000),
+    expires_in: 3600
+  });
+  TraktSettingsStore.setWatchProgressSource(WatchProgressSource.TRAKT);
+
+  await watchProgressRepository.saveProgress({
+    contentId: "tt0944947",
+    contentType: "series",
+    videoId: "tt0944947:1:1",
+    season: 1,
+    episode: 1,
+    positionMs: 120_000,
+    durationMs: 3_600_000
+  });
+
+  const traktItems = await watchProgressRepository.getRecent();
+  assert.equal(traktItems.length, 1);
+  assert.equal(traktItems[0].source, "trakt_local");
+  assert.equal(traktItems[0].contentId, "tt0944947");
+
+  TraktSettingsStore.setWatchProgressSource(WatchProgressSource.NUVIO_SYNC);
+  const nuvioItems = await watchProgressRepository.getRecent();
+  assert.equal(nuvioItems.length, 0);
+});


### PR DESCRIPTION
## Summary

Keep locally recorded rewatch progress visible when Trakt is the selected Continue Watching source. Progress saved during playback now carries the active source, and a regression test covers the Trakt rewatch path.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix
- [ ] Approved feature/change

## Affected area

- [x] Shared web app
- [x] Samsung Tizen
- [ ] LG webOS
- [ ] Browser development mode
- [ ] Playback
- [ ] Audio tracks
- [ ] Subtitles
- [ ] Focus / Remote navigation
- [ ] UI / Layout
- [x] Resume / Watch progress
- [x] Continue Watching
- [ ] Next Episode / Auto-play
- [ ] Packaging / Build
- [ ] Nuvio WebTV Installer compatibility
- [ ] TizenBrew wrapper
- [ ] webOS Homebrew wrapper
- [ ] Documentation
- [ ] Other

## Why

When Trakt owned Continue Watching, playback still stored fresh progress locally without a source. The Trakt source filter then removed that progress. Rewatching an already watched series could therefore disappear from Continue Watching before Trakt caught up.

## Issue or approval

Fixes #517

## Reproduction steps

1. Connect Trakt and use it as the watch progress source.
2. Start rewatching an episode from a series that is already marked watched.
3. Return to the home screen.
4. Check Continue Watching.

## Old behavior

The fresh local progress had no Trakt source marker, so the selected-source filter removed it and the series disappeared.

## New behavior

Fresh playback progress is tagged for the active source. A Trakt-backed rewatch remains in Continue Watching while preserving source isolation when switching to Nuvio Sync.

## Platform impact

- Samsung Tizen: Fixes the reported shared Continue Watching behavior. No Tizen API changes.
- LG webOS: Shared watch-progress code receives the same fix. No webOS API changes.
- Browser development mode: Shared watch-progress code receives the same fix.
- Installer / packaging: No impact.
- Wrapper repositories: No impact.

## UI / behavior / playback impact

- [x] No UI change
- [ ] No behavior change
- [x] No playback change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] Playback changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval
- [ ] Playback change has explicit maintainer approval

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact
- [ ] Tizen `.wgt` packaging changed
- [ ] webOS `.ipk` packaging changed
- [ ] App identifiers or metadata changed
- [ ] `local.properties` / environment handling changed
- [ ] `sync:tizen` changed
- [ ] `sync:webos` changed
- [ ] Nuvio WebTV Installer compatibility changed
- [ ] TizenBrew wrapper support changed
- [ ] webOS Homebrew metadata support changed

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I included a linked issue, reproduction steps, and testing notes if this is a critical bug fix.
- [x] I listed the testing performed below.

> Feature additions, broad UI changes, refactors, playback rewrites, platform rewrites, installer rewrites, and other non-critical changes may be closed or deferred without review while NuvioTV Web is being prepared for a stable Smart TV release.

## Scope boundaries

No UI, playback engine, Trakt API, packaging, or platform-specific changes. Existing explicit progress sources remain untouched.

## Testing

### Devices / platforms tested

Automated Node test on macOS. I do not have access to the reported Samsung Tizen device; the failing shared source-filter path is covered directly by the regression test.

### Commands tested

```sh
node --test tests/*.test.mjs
npx eslint js/data/repository/watchProgressRepository.js tests/watchProgressRepository.test.mjs
npx prettier --check tests/watchProgressRepository.test.mjs
npm run build
```

## Manual test flow

No physical TV manual run. The regression test authenticates a Trakt-backed profile, records partial series progress, verifies it remains in Continue Watching, switches to Nuvio Sync, and verifies the Trakt-local progress does not leak across sources.

## Screenshots / Video

Not a UI change.

## Logs

Not applicable.

## Regression risk

Low. The change only supplies a source when newly saved progress does not already have one. The test covers both Trakt visibility and Nuvio Sync isolation.

## Breaking changes

None.

## Linked issues

Fixes #517
