### PR TITLE
Remember selected audio track per title across sessions

### DIFF
--- a/js/data/local/audioTrackPreferencesStore.js
+++ b/js/data/local/audioTrackPreferencesStore.js
@@ -1,0 +1,70 @@
+import { LocalStore } from "../../core/storage/localStore.js";
+import { ProfileManager } from "../../core/profile/profileManager.js";
+
+const KEY = "audioTrackPreferences";
+const MAX_ENTRIES = 500;
+
+function activeProfileId() {
+  return String(ProfileManager.getActiveProfileId() || "1");
+}
+
+function readAll() {
+  const raw = LocalStore.get(KEY, {});
+  return raw && typeof raw === "object" ? raw : {};
+}
+
+function writeAll(next) {
+  LocalStore.set(KEY, next && typeof next === "object" ? next : {});
+}
+
+// Entries are kept as a newest-first array so cap eviction never depends on
+// object key iteration order (a numeric-looking content id would otherwise sort
+// ahead of string keys). Mirrors streamPreferencesStore.
+function readEntries(profileId = activeProfileId()) {
+  const all = readAll();
+  const list = all[String(profileId || "1")];
+  return Array.isArray(list)
+    ? list.filter((entry) => entry && typeof entry === "object" && entry.key)
+    : [];
+}
+
+function writeEntries(profileId, entries) {
+  const all = readAll();
+  all[String(profileId || "1")] = entries;
+  writeAll(all);
+}
+
+// Remembers the audio track a user explicitly picked for a title so it can be
+// re-applied next time they open it, matching the Android TV app. Keyed by the
+// title content id (remembered across episodes of a series).
+export const AudioTrackPreferencesStore = {
+  get(contentId, profileId = activeProfileId()) {
+    const key = String(contentId || "").trim();
+    if (!key) {
+      return null;
+    }
+    const entry = readEntries(profileId).find((item) => item.key === key);
+    if (!entry) {
+      return null;
+    }
+    return {
+      languageKey: String(entry.languageKey || ""),
+      label: String(entry.label || "")
+    };
+  },
+
+  set(contentId, { languageKey = "", label = "" } = {}, profileId = activeProfileId()) {
+    const key = String(contentId || "").trim();
+    const lang = String(languageKey || "").trim();
+    const name = String(label || "").trim();
+    if (!key || (!lang && !name)) {
+      return;
+    }
+    const entries = readEntries(profileId).filter((item) => item.key !== key);
+    entries.unshift({ key, languageKey: lang, label: name, cachedAtMs: Date.now() });
+    if (entries.length > MAX_ENTRIES) {
+      entries.length = MAX_ENTRIES;
+    }
+    writeEntries(profileId, entries);
+  }
+};

--- a/js/ui/screens/player/playerScreen.js
+++ b/js/ui/screens/player/playerScreen.js
@@ -45,6 +45,7 @@ import { TizenStreamingServerResolver } from "../../../core/p2p/tizenStreamingSe
 import { TizenEngineFsService } from "../../../platform/tizen/tizenEngineFsService.js";
 import { requestWebOsCompanionService, subscribeWebOsCompanionService } from "../../../platform/webos/webosCompanionService.js";
 import { StreamPreferencesStore } from "../../../data/local/streamPreferencesStore.js";
+import { AudioTrackPreferencesStore } from "../../../data/local/audioTrackPreferencesStore.js";
 import {
   shouldEnterStillWatchingPrompt,
   shouldShowNextEpisodeCard as shouldShowNextEpisodeCardRule
@@ -12387,9 +12388,98 @@ export const PlayerScreen = {
     return null;
   },
 
+  getRememberedAudioTrackForCurrentTitle() {
+    const contentId = String(this.params?.itemId || "").trim();
+    if (!contentId) {
+      return null;
+    }
+    return AudioTrackPreferencesStore.get(contentId);
+  },
+
+  rememberSelectedAudioTrack(index) {
+    const contentId = String(this.params?.itemId || "").trim();
+    if (!contentId) {
+      return;
+    }
+    const option = this.collectAudioOptionItems()[index];
+    if (!option) {
+      return;
+    }
+    AudioTrackPreferencesStore.set(contentId, {
+      languageKey: option.languageKey,
+      label: option.label
+    });
+  },
+
+  findRememberedAudioOption(options, remembered) {
+    if (!remembered) {
+      return null;
+    }
+    const supported = options.filter((option) => option.supported);
+    const rememberedLabel = normalizeComparableText(remembered.label || "");
+    if (rememberedLabel) {
+      const byName = supported.find(
+        (option) => normalizeComparableText(option.label || "") === rememberedLabel
+      );
+      if (byName) {
+        return byName;
+      }
+    }
+    const rememberedLanguage = String(remembered.languageKey || "");
+    if (rememberedLanguage) {
+      const byLanguage = supported.find((option) => option.languageKey === rememberedLanguage);
+      if (byLanguage) {
+        return byLanguage;
+      }
+    }
+    return null;
+  },
+
+  applyRememberedAudioTrackSelection() {
+    const remembered = this.getRememberedAudioTrackForCurrentTitle();
+    if (!remembered) {
+      return false;
+    }
+    const options = this.collectAudioOptionItems();
+    if (!options.length) {
+      return false;
+    }
+    const match = this.findRememberedAudioOption(options, remembered);
+    if (!match) {
+      return false;
+    }
+    if (match.selected) {
+      return true;
+    }
+    this.startupAudioPreferenceApplying = true;
+    try {
+      this.applyAudioTrack(match.entryIndex);
+    } finally {
+      this.startupAudioPreferenceApplying = false;
+    }
+    const applied = this.collectAudioOptionItems().find((entry) => entry.selected);
+    return Boolean(applied && this.findRememberedAudioOption([applied], remembered));
+  },
+
   applyStartupAudioPreference() {
     if (this.startupAudioPreferenceApplied || this.startupAudioPreferenceApplying) {
       return false;
+    }
+
+    // A track the user explicitly picked for this title in a past session takes
+    // precedence over the preferred-language default, matching Android TV. This
+    // sits on top of the normal flow: if nothing is remembered, or the
+    // remembered track is not among the available tracks, fall straight through.
+    if (this.getRememberedAudioTrackForCurrentTitle()) {
+      if (this.isAudioPreferenceDiscoveryPending()) {
+        if (this.scheduleStartupAudioPreferenceRetry()) {
+          return false;
+        }
+      } else if (this.applyRememberedAudioTrackSelection()) {
+        this.clearStartupAudioPreferenceRetry();
+        this.startupAudioPreferenceApplied = true;
+        return true;
+      }
     }
 
     const preferredTargets = this.getStartupPreferredAudioLanguageTargets();
@@ -14063,6 +14153,7 @@ export const PlayerScreen = {
     if (isSelectKeyCode(keyCode)) {
       if (this.audioFocusedColumn === "tracks") {
         this.applyAudioTrack(this.audioDialogIndex);
+        this.rememberSelectedAudioTrack(this.audioDialogIndex);
       } else {
         this.activateAudioControl(this.audioMixFocusIndex === 0 ? 1 : 0);
       }
@@ -16037,6 +16128,7 @@ export const PlayerScreen = {
     if (audioNode && this.audioDialogVisible) {
       if (this.audioFocusedColumn === "tracks") {
         this.applyAudioTrack(this.audioDialogIndex);
+        this.rememberSelectedAudioTrack(this.audioDialogIndex);
       } else {
         this.activateAudioControl(this.audioMixFocusIndex === 0 ? 1 : 0);
       }


### PR DESCRIPTION
Fixes #513.

On multi audio streams the audio track a user picks was forgotten between sessions, so reopening a title always reverted to the default track. Android TV remembers the chosen track per title and re-applies it on the next play, so this brings the web player in line.

When you pick an audio track it is now saved for that title (per profile). Next time you open the title the saved track is re-applied if it is available, taking precedence over the preferred audio language. Matching is by track name first, then language, so it still works when a different source labels the track a bit differently. If nothing was saved, or the saved track is not in the stream, the existing preferred language behaviour is used unchanged.

Mirrors the Android TV TrackPreferenceDataStore (per title audio persistence).