### PR TITLE
Snap home focus scrolling on constrained TVs instead of animating

### DIFF
--- a/js/ui/screens/home/homeScreen.js
+++ b/js/ui/screens/home/homeScreen.js
@@ -3066,6 +3066,14 @@ export const HomeScreen = {
     return Boolean(globalThis.document?.body?.classList?.contains("performance-constrained"));
   },
 
+  // Constrained TVs (all webOS/Tizen, plus low-end) cannot afford the animated
+  // spring scroll on every focus move: each move runs a ~440ms rAF loop writing
+  // scrollTop/scrollLeft per frame, which stacks into seconds of input lag. Snap
+  // focus scrolling instead, matching the classic layout and Tizen behaviour.
+  shouldUseImmediateFocusScroll() {
+    return Boolean(Platform.isTizen() || this.isPerformanceConstrained());
+  },
+
   hasCollectionHomeRows() {
     return Array.isArray(this.collections) && this.collections.length > 0;
   },
@@ -6348,7 +6356,7 @@ export const HomeScreen = {
         if (delta <= 1) {
           return;
         }
-        if (Platform.isTizen() || (Platform.isBrowser() && this.isPerformanceConstrained())) {
+        if (this.shouldUseImmediateFocusScroll()) {
           this.cancelScrollAnimation(next.container, "y");
           next.container.scrollTop = Math.round(Number(next.value || 0));
           return;
@@ -6418,7 +6426,7 @@ export const HomeScreen = {
         cancelAnimationFrame(this._trackHorizRaf);
         this._trackHorizRaf = null;
       }
-      if (this.shouldUseImmediateHorizontalScrollForNode(target)) {
+      if (this.shouldUseImmediateHorizontalScrollForNode(target) || this.shouldUseImmediateFocusScroll()) {
         const next = this.getModernTrackAlignedScrollTarget(target, layoutAdjustment);
         if (next?.container) {
           this.cancelScrollAnimation(next.container, "x");


### PR DESCRIPTION
Related to #515 (webOS home navigation very laggy).

On the modern home layout every arrow keypress starts an animated spring scroll: a rAF loop that writes scrollTop/scrollLeft each frame for about 440ms, on both the horizontal track and the vertical rows. On low power TVs each of those per frame writes forces layout and paint, and consecutive presses stack up, so moving focus across rows takes what feels like seconds.

The classic layout and Tizen already skip this and snap the scroll into place. webOS modern was the odd one out: the vertical branch only snapped for Tizen or a performance constrained browser (never a real webOS device), and the horizontal branch only snapped for Continue Watching cards. So modern + webOS always ran the animation. This also matches the report that switching to classic makes it smoother.

This makes both axes snap immediately on performance constrained devices (all webOS/Tizen and low end), while capable devices keep the smooth animation.

Measured in a headless webOS profile (performance-constrained on): before, each move animated over 650-830ms with 30+ incremental scroll writes; after, the scroll lands in a single step and focus ends on the exact same position. A capable (non constrained) profile is unchanged and still animates.