### PR TITLE
fix(player): resolve subtitle overlay key-repeat flickering, key leak and pause focus ring

### DIFF
--- a/js/ui/screens/player/playerScreen.js
+++ b/js/ui/screens/player/playerScreen.js
@@ -12879,7 +12879,35 @@ export const PlayerScreen = {
     });
   },
 
-  adjustSubtitleStyleControl(controlId, delta = 0) {
+  schedulePersistPlayerPresentationSettings(delayMs = 400) {
+    clearTimeout(this.persistSettingsTimer);
+    this.persistSettingsTimer = setTimeout(() => {
+      this.persistSettingsTimer = null;
+      this.persistPlayerPresentationSettings();
+    }, delayMs);
+  },
+
+  flushPersistPlayerPresentationSettings() {
+    if (this.persistSettingsTimer) {
+      clearTimeout(this.persistSettingsTimer);
+      this.persistSettingsTimer = null;
+      this.persistPlayerPresentationSettings();
+    }
+  },
+
+  renderSubtitleStyleControlInPlace(controlId) {
+    const dialog = this.uiRefs?.subtitleDialog;
+    if (!dialog || !this.subtitleDialogVisible) return false;
+    const styleControls = this.getSubtitleStyleControls();
+    const items = controlId === "reset" ? styleControls : styleControls.filter((c) => c.id === controlId);
+    items.forEach((item) => {
+      const subNode = dialog.querySelector(`button[data-style-id="${item.id}"]`)?.closest(".player-dialog-style-item")?.querySelector(".player-dialog-item-sub");
+      if (subNode) subNode.textContent = item.value || "";
+    });
+    return items.length > 0;
+  },
+
+  adjustSubtitleStyleControl(controlId, delta = 0, { isRepeat = false } = {}) {
     const activeControl = this.getSubtitleStyleControls().find((item) => item.id === controlId);
     if (!activeControl || activeControl.disabled) {
       return false;
@@ -12891,9 +12919,6 @@ export const PlayerScreen = {
         SUBTITLE_DELAY_MIN_MS,
         SUBTITLE_DELAY_MAX_MS
       );
-      this.applySubtitlePresentationSettings({ refreshTrackRendering: true });
-      this.renderSubtitleDialog();
-      return true;
     } else if (controlId === "fontSize") {
       style.fontSize = normalizeSubtitleFontSize(Number(style.fontSize || 100) + (delta * SUBTITLE_FONT_STEP));
     } else if (controlId === "bold" && delta !== 0) {
@@ -12912,15 +12937,16 @@ export const PlayerScreen = {
       const defaults = PlayerSettingsStore.get().subtitleStyle;
       this.subtitleDelayMs = 0;
       this.subtitleStyleSettings = { ...defaults };
-      this.persistPlayerPresentationSettings();
-      this.applySubtitlePresentationSettings({ refreshTrackRendering: true });
-      this.renderSubtitleDialog();
-      return true;
     }
-    this.subtitleStyleSettings = style;
-    this.persistPlayerPresentationSettings();
-    this.applySubtitlePresentationSettings({ refreshTrackRendering: true });
-    this.renderSubtitleDialog();
+
+    if (controlId !== "delay" && controlId !== "reset") {
+      this.subtitleStyleSettings = style;
+    }
+    this.schedulePersistPlayerPresentationSettings();
+    this.applySubtitlePresentationSettings({ refreshTrackRendering: !isRepeat });
+    if (!this.renderSubtitleStyleControlInPlace(controlId)) {
+      this.renderSubtitleDialog();
+    }
     return true;
   },
 
@@ -12951,6 +12977,7 @@ export const PlayerScreen = {
   },
 
   closeSubtitleDialog() {
+    this.flushPersistPlayerPresentationSettings();
     this.subtitleDialogVisible = false;
     this.subtitleFocusedRail = "language";
     this.subtitleStyleControlSide = "minus";
@@ -13487,10 +13514,9 @@ export const PlayerScreen = {
         }
       } else if (this.subtitleFocusedRail === "options") {
         this.subtitleFocusedRail = "language";
-      } else {
-        return false;
+        this.renderSubtitleDialog();
+        return true;
       }
-      this.renderSubtitleDialog();
       return true;
     }
     if (keyCode === 39) {
@@ -13543,7 +13569,11 @@ export const PlayerScreen = {
         return true;
       }
       if (styleItem && !styleItem.disabled) {
-        this.adjustSubtitleStyleControl(styleItem.id, this.getSubtitleStyleControlDelta(this.subtitleStyleControlSide));
+        this.adjustSubtitleStyleControl(
+          styleItem.id,
+          this.getSubtitleStyleControlDelta(this.subtitleStyleControlSide),
+          { isRepeat: Boolean(event?.repeat) }
+        );
       }
       return true;
     }
@@ -16599,7 +16629,7 @@ export const PlayerScreen = {
         } else if (this.seekOverlayVisible) {
           this.cancelSeekPreview({ commit: false });
         }
-        this.togglePause({ focusControls: false });
+        this.togglePause({ focusControls: true });
         this.renderControlButtons();
       }
       return;


### PR DESCRIPTION
## Summary

 Fixes subtitle overlay UI tearing during key repeat, traps Left key navigation within the subtitle modal, and ensures the Play/Pause button receives focus ring highlight when pausing media via OK/Select key. 

## PR type

<!-- Check exactly one. PRs outside these types are not accepted unless explicitly approved. -->

- [ ] Translation/localization only
- [x] Critical bug fix
- [ ] Approved feature/change

## Affected area

<!-- Check every area affected by this PR. -->

- [ ] Shared web app
- [ ] Samsung Tizen
- [x] LG webOS
- [x] Browser development mode
- [ ] Playback
- [ ] Audio tracks
- [x] Subtitles
- [x] Focus / Remote navigation
- [x] UI / Layout
- [ ] Resume / Watch progress
- [ ] Continue Watching
- [ ] Next Episode / Auto-play
- [ ] Packaging / Build
- [ ] Nuvio WebTV Installer compatibility
- [ ] TizenBrew wrapper
- [ ] webOS Homebrew wrapper
- [ ] Documentation
- [ ] Other

## Why

<!-- Why is this change needed? Explain the critical bug, localization update, or approved change. -->

 1. Holding down subtitle style adjustment controls (e.g. delay, font size) triggered continuous `innerHTML` teardowns/rebuilds and synchronous `localStorage`      
  writes every 16ms frame, causing cursor dismissal and heavy track flickering.                                                                                        
    2. Pressing Left arrow on the `language` rail in the subtitle overlay leaked focus navigation to background player control buttons (Next, Play/Pause).             
    3. Pressing OK/Select while media was playing paused the video but passed `focusControls: false`, leaving the player control bar without any visible focus ring    
  highlight.  

## Issue or approval

<!-- Required for critical bug fixes and approved changes. Link the bug issue or approved feature request. -->
<!-- Examples: Fixes #123 / Approved in #456 / No linked issue: localization-only update. -->

https://github.com/NuvioMedia/NuvioWeb/issues/525

## Reproduction steps

<!-- Required for critical bug fixes. For localization-only PRs, write: No reproduction steps - localization-only update. -->

 1. Play any media with subtitles enabled and open the subtitle overlay.                                                                                                                                                   
    2. Navigate right to style controls (e.g. subtitle delay) and hold down the OK or Right arrow key -> observe focus cursor disappearing and overlay flickering rapidly.                                                    
    3. Navigate back left to the `language` rail and press Left arrow again -> observe focus leaking to background player buttons (Next, Play/Pause).                                                                         
    4. While playing media, press OK to pause -> observe player control bar rendered with no button highlighted.  

## Old behavior

<!-- What happened before this PR? For localization-only PRs, write: Not applicable - localization-only update. -->

- Holding style adjustment controls destroyed and recreated overlay HTML every 16ms, triggering cursor dismissal and native track flickers.                                                                               
    - Unhandled Left key on `language` rail fell through `handleSubtitleDialogKey` to `handlePlayerKeyDown`, moving focus to background player controls.                                                                      
    - Pausing with OK key passed `focusControls: false`, leaving `controlFocusZone` empty without a focused button.    

## New behavior

<!-- What happens after this PR? -->

 - `renderSubtitleStyleControlInPlace` updates subtext values in-place during key repeat without destroying DOM nodes. Storage writes are debounced and native text track mode resets are skipped on `event.repeat`.       
    - Left key on `language` rail returns `true`, trapping focus inside the active modal overlay.                                                                                                                             
    - Pausing with OK key passes `focusControls: true`, focusing and highlighting the Play/Pause button immediately. 

## Platform impact

<!-- Explain which platforms were affected and whether this change touches shared code. -->

 - Samsung Tizen: Tested & unaffected.                                                                                                                                                                                     
 - LG webOS: Fixes key repeat tearing, focus leakage, and pause focus ring highlight.                                                                                                                                      
- Browser development mode: Tested & verified.                                                                                                                                                                            
- Installer / packaging: Unaffected.                                                                                                                                                                                      
- Wrapper repositories: Unaffected.         

## UI / behavior / playback impact

<!-- Check every box that applies. At least one must be checked. -->

- [ ] No UI change
- [ ] No behavior change
- [ ] No playback change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] Playback changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval
- [ ] Playback change has explicit maintainer approval

## Installer, packaging, or wrapper impact

<!-- Check every box that applies. -->

- [x] No installer, packaging, or wrapper impact
- [ ] Tizen `.wgt` packaging changed
- [ ] webOS `.ipk` packaging changed
- [ ] App identifiers or metadata changed
- [ ] `local.properties` / environment handling changed
- [ ] `sync:tizen` changed
- [ ] `sync:webos` changed
- [ ] Nuvio WebTV Installer compatibility changed
- [ ] TizenBrew wrapper support changed
- [ ] webOS Homebrew metadata support changed

## Policy check

<!-- ALL boxes must be checked or the PR may be closed without review. -->

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I included a linked issue, reproduction steps, and testing notes if this is a critical bug fix.
- [x] I listed the testing performed below.

> Feature additions, broad UI changes, refactors, playback rewrites, platform rewrites, installer rewrites, and other non-critical changes may be closed or deferred without review while NuvioTV Web is being prepared for a stable Smart TV release.

## Scope boundaries

<!-- List anything intentionally not changed. If this is a bug fix, confirm it does not include extra UI polish, behavior tweaks, playback changes, or platform rewrites. -->

Intentionally does not include any changes to subtitle parser logic, media player controllers, or general navigation handlers.   

## Testing

<!-- What did you test and how? Include devices, TVs, emulators, simulators, commands, packages, and manual flows. Do not write only "not tested" unless this is localization-only. -->

### Devices / platforms tested

<!-- Examples: LG C1 webOS 6, LG B4 webOS 24, Samsung S90F Tizen 9.0, Chrome on macOS, Tizen emulator, webOS simulator. -->

- LG webOS TV (2020+) via ares-install                                                                                                                                                                                    
- Chrome / Browser development mode   

### Commands tested

<!-- Include relevant commands if applicable. -->

```sh
# Examples:
    npm run build                                                                                                                                                                                                             
    npm run package:webos                                                                                                                                                                                                     
    npm run install:webos -- -d tv  
```

## Manual test flow

<!-- Describe the exact flow tested in the app. -->

  1. Opened subtitle overlay, held down delay + / - and font size controls -> verified values updated smoothly without overlay flashing or cursor dismissal.                                                                  
  2. Focused language rail and pressed Left arrow -> verified focus stayed inside the overlay and did not select background player buttons.                                                                                   
  3. Paused playing media with OK key -> verified Play/Pause button was immediately focused and highlighted.   

## Screenshots / Video

<!-- Required for any UI, layout, focus, or visual change. Write "Not a UI change" only if no UI changed. -->

  Not a UI layout change (fixes focus highlight and DOM updates on existing overlay).                                                                                                                                         


## Logs

<!-- Required for crashes, blank screens, install/package failures, playback failures, or platform API errors. Write "Not applicable" if not relevant. -->

  Not applicable                                                                                                                                                                                                              

## Regression risk

<!-- Describe what could break, especially across Samsung Tizen, LG webOS, browser development mode, installer, packaging, or wrappers. -->

Minimal. Changes are scoped strictly to playerScreen.js subtitle dialog key handler and pause focus toggle.                                                                                                                 


## Breaking changes

<!-- Any breaking behavior/config/schema/package/app-id changes? If none, write: None. -->

None

## Linked issues

<!-- Required for critical bug fixes and approved changes. For localization-only PRs with no issue, write: No linked issue - localization-only update. -->

https://github.com/NuvioMedia/NuvioWeb/issues/525