### PR TITLE
fix(router): add profileSelection to webOS history back guard

### DIFF
--- a/js/ui/navigation/router.js
+++ b/js/ui/navigation/router.js
@@ -393,7 +393,7 @@ export const Router = {
       // before the platform treats it as a request to exit the app.
       if (
         Platform.isWebOS() &&
-        this.current === "home" &&
+        (this.current === "home" || this.current === "profileSelection") &&
         !this.webOsHomeBackGuardInitialized
       ) {
         window.history.pushState(state, "");


### PR DESCRIPTION
## Summary

Adds `profileSelection` to `webOsHomeBackGuardInitialized` in `router.js` so pressing remote Back on PIN/profile overlays on initial boot closes the overlay instead of exiting the webOS app.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix
- [ ] Approved feature/change

## Affected area

- [ ] Shared web app
- [ ] Samsung Tizen
- [x] LG webOS
- [ ] Browser development mode
- [ ] Playback
- [ ] Audio tracks
- [ ] Subtitles
- [x] Focus / Remote navigation
- [x] UI / Layout
- [ ] Resume / Watch progress
- [ ] Continue Watching
- [ ] Next Episode / Auto-play
- [ ] Packaging / Build
- [ ] Nuvio WebTV Installer compatibility
- [ ] TizenBrew wrapper
- [ ] webOS Homebrew wrapper
- [ ] Documentation
- [ ] Other

## Why

When booting directly to `profileSelection` on fresh launch, history stack depth is 0. On webOS, pressing remote Back pops history entry 0 and prompts to exit the app. Including `profileSelection` in `webOsHomeBackGuardInitialized` initializes the history guard so `consumeBackRequest()` can close the active PIN overlay cleanly.

## Issue or approval

https://github.com/NuvioMedia/NuvioWeb/issues/526

## Reproduction steps

1. Enable PIN on a profile and launch the app freshly on LG webOS.
2. Select the PIN-protected profile on startup.
3. Press the remote Back key on the PIN entry dialog -> observe app prompting to exit.

## Old behavior

`profileSelection` was omitted from `webOsHomeBackGuardInitialized`, causing initial boot at history depth 0 on webOS to bypass `consumeBackRequest()` and trigger app exit.

## New behavior

`profileSelection` initializes the webOS history back guard on boot, allowing `consumeBackRequest()` to handle the Back key, close the PIN overlay, and remain on the profile screen.

## Platform impact

- Samsung Tizen: Unaffected.
- LG webOS: Fixes Back key app exit on initial startup PIN overlay.
- Browser development mode: Unaffected.
- Installer / packaging: Unaffected.
- Wrapper repositories: Unaffected.

## UI / behavior / playback impact

- [ ] No UI change
- [ ] No behavior change
- [ ] No playback change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] Playback changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval
- [ ] Playback change has explicit maintainer approval

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact
- [ ] Tizen `.wgt` packaging changed
- [ ] webOS `.ipk` packaging changed
- [ ] App identifiers or metadata changed
- [ ] `local.properties` / environment handling changed
- [ ] `sync:tizen` changed
- [ ] `sync:webos` changed
- [ ] Nuvio WebTV Installer compatibility changed
- [ ] TizenBrew wrapper support changed
- [ ] webOS Homebrew metadata support changed

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I included a linked issue, reproduction steps, and testing notes if this is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Intentionally limited to 1 line in `router.js`. Does not modify any screen rendering or navigation handlers.

## Testing

### Devices / platforms tested

- LG webOS TV (2020+) via ares-install

### Commands tested

```sh
npm run build
npm run package:webos
npm run install:webos -- -d tv
```

## Manual test flow

1. Booted app on webOS TV directly into profile selection with a PIN-protected profile.
2. Opened PIN entry overlay and pressed remote Back key -> verified PIN dialog closed cleanly and stayed on profile selection without prompting to exit.

## Screenshots / Video

Not a UI visual change.

## Logs

Not applicable

## Regression risk

None. 1 line addition in webOS router history initialization.

## Breaking changes

None.

## Linked issues
https://github.com/NuvioMedia/NuvioWeb/issues/526
