### PR TITLE
fix(router): restore caller during detail skeleton Back

### DIFF
--- a/js/ui/navigation/router.js
+++ b/js/ui/navigation/router.js
@@ -356,27 +356,6 @@ export const Router = {
     this.currentParams = targetParams;
     const navigationContext = this.resolveNavigationContext(routeName, this.currentParams, options);
 
-    await Screen.mount(this.currentParams, navigationContext);
-    this.completeRouteReturnBackGuard(routeReturnBackGuardNavigationId);
-    logRouterPerf("navigate", {
-      ms: Number((routerPerfNow() - navigationStart).toFixed(2)),
-      route: routeName,
-      previousRoute,
-      fromHistory,
-      skipStackPush,
-      replaceHistory
-    });
-
-    // If another navigation happened while this screen was mounting, this
-    // navigation is stale and must not write an extra history entry.
-    if (this.current !== routeName || this.currentParams !== targetParams) {
-      return;
-    }
-
-    if (bootGuard && typeof bootGuard.ready === "function") {
-      bootGuard.ready();
-    }
-
     if (window?.history && typeof window.history.pushState === "function") {
       const state = { route: this.current, params: this.currentParams };
       if (!this.historyInitialized) {
@@ -401,6 +380,26 @@ export const Router = {
         this.webOsHomeBackGuardInitialized = true;
       }
     }
+
+    await Screen.mount(this.currentParams, navigationContext);
+    this.completeRouteReturnBackGuard(routeReturnBackGuardNavigationId);
+    logRouterPerf("navigate", {
+      ms: Number((routerPerfNow() - navigationStart).toFixed(2)),
+      route: routeName,
+      previousRoute,
+      fromHistory,
+      skipStackPush,
+      replaceHistory
+    });
+
+    if (this.current !== routeName || this.currentParams !== targetParams) {
+      return;
+    }
+
+    if (bootGuard && typeof bootGuard.ready === "function") {
+      bootGuard.ready();
+    }
+
     this.persistWebOsResumeRoute(this.current, this.currentParams);
   },
 

--- a/js/ui/navigation/router.js
+++ b/js/ui/navigation/router.js
@@ -405,6 +405,8 @@ export const Router = {
   },
 
   async backFromPendingNavigation() {
+    // The current history entry still represents the caller until mount completes.
+    // Restore that entry in place so a fast Back neither skips it nor records a stale route.
     const historyState = window?.history?.state || null;
     const targetRoute = String(historyState?.route || "");
 

--- a/js/ui/navigation/router.js
+++ b/js/ui/navigation/router.js
@@ -356,6 +356,27 @@ export const Router = {
     this.currentParams = targetParams;
     const navigationContext = this.resolveNavigationContext(routeName, this.currentParams, options);
 
+    await Screen.mount(this.currentParams, navigationContext);
+    this.completeRouteReturnBackGuard(routeReturnBackGuardNavigationId);
+    logRouterPerf("navigate", {
+      ms: Number((routerPerfNow() - navigationStart).toFixed(2)),
+      route: routeName,
+      previousRoute,
+      fromHistory,
+      skipStackPush,
+      replaceHistory
+    });
+
+    // If another navigation happened while this screen was mounting, this
+    // navigation is stale and must not write an extra history entry.
+    if (this.current !== routeName || this.currentParams !== targetParams) {
+      return;
+    }
+
+    if (bootGuard && typeof bootGuard.ready === "function") {
+      bootGuard.ready();
+    }
+
     if (window?.history && typeof window.history.pushState === "function") {
       const state = { route: this.current, params: this.currentParams };
       if (!this.historyInitialized) {
@@ -380,27 +401,28 @@ export const Router = {
         this.webOsHomeBackGuardInitialized = true;
       }
     }
+    this.persistWebOsResumeRoute(this.current, this.currentParams);
+  },
 
-    await Screen.mount(this.currentParams, navigationContext);
-    this.completeRouteReturnBackGuard(routeReturnBackGuardNavigationId);
-    logRouterPerf("navigate", {
-      ms: Number((routerPerfNow() - navigationStart).toFixed(2)),
-      route: routeName,
-      previousRoute,
-      fromHistory,
-      skipStackPush,
-      replaceHistory
-    });
+  async backFromPendingNavigation() {
+    const historyState = window?.history?.state || null;
+    const targetRoute = String(historyState?.route || "");
 
-    if (this.current !== routeName || this.currentParams !== targetParams) {
+    if (targetRoute && this.routes[targetRoute]) {
+      const previous = this.stack[this.stack.length - 1];
+      const previousRoute = typeof previous === "string" ? previous : previous?.route;
+      if (previousRoute === targetRoute) {
+        this.stack.pop();
+      }
+      await this.navigate(targetRoute, historyState.params || {}, {
+        fromHistory: true,
+        skipStackPush: true,
+        isBackNavigation: true
+      });
       return;
     }
 
-    if (bootGuard && typeof bootGuard.ready === "function") {
-      bootGuard.ready();
-    }
-
-    this.persistWebOsResumeRoute(this.current, this.currentParams);
+    await this.back({ skipConsume: true, skipHistory: true });
   },
 
   async back(options = {}) {
@@ -420,7 +442,12 @@ export const Router = {
       return;
     }
 
-    if (window?.history && typeof window.history.back === "function" && this.historyInitialized) {
+    if (
+      !options?.skipHistory &&
+      window?.history &&
+      typeof window.history.back === "function" &&
+      this.historyInitialized
+    ) {
       if (options?.skipConsume) {
         this.skipConsumeNextPopstate = true;
       }

--- a/js/ui/screens/detail/metaDetailsScreen.js
+++ b/js/ui/screens/detail/metaDetailsScreen.js
@@ -1,4 +1,4 @@
-import { Router } from "../../navigation/router.js";
+﻿import { Router } from "../../navigation/router.js";
 import { ScreenUtils } from "../../navigation/screen.js";
 import { metaRepository } from "../../../data/repository/metaRepository.js";
 import { watchProgressRepository } from "../../../data/repository/watchProgressRepository.js";
@@ -6863,6 +6863,10 @@ export const MetaDetailsScreen = {
       return true;
     }
     if (this.navigateBackFromDetail()) {
+      return true;
+    }
+    if (this.isLoadingDetail) {
+      void Router.backFromPendingNavigation();
       return true;
     }
     return false;

--- a/js/ui/screens/detail/metaDetailsScreen.js
+++ b/js/ui/screens/detail/metaDetailsScreen.js
@@ -1,4 +1,4 @@
-﻿import { Router } from "../../navigation/router.js";
+import { Router } from "../../navigation/router.js";
 import { ScreenUtils } from "../../navigation/screen.js";
 import { metaRepository } from "../../../data/repository/metaRepository.js";
 import { watchProgressRepository } from "../../../data/repository/watchProgressRepository.js";
@@ -6863,19 +6863,6 @@ export const MetaDetailsScreen = {
       return true;
     }
     if (this.navigateBackFromDetail()) {
-      return true;
-    }
-    if (this.isLoadingDetail) {
-      // Loading details must use the same Tizen Back contract as loaded ones.
-      Router.navigate(
-        "home",
-        {},
-        {
-          isBackNavigation: true,
-          skipStackPush: true,
-          replaceHistory: true
-        }
-      );
       return true;
     }
     return false;


### PR DESCRIPTION
## Summary

Restores the caller's existing history entry when Back is pressed during detail skeleton loading, without advancing browser history before the mount completes.

## PR type

- [x] Critical bug fix
- [ ] Translation/localization only
- [ ] Approved feature/change

## Affected area

- [x] Shared web app
- [x] Samsung Tizen
- [x] LG webOS
- [x] Browser development mode
- [ ] Playback
- [ ] Audio tracks
- [ ] Subtitles
- [x] Focus / Remote navigation
- [x] UI / Layout
- [ ] Resume / Watch progress
- [ ] Continue Watching
- [ ] Next Episode / Auto-play
- [ ] Packaging / Build
- [ ] Nuvio WebTV Installer compatibility
- [ ] TizenBrew wrapper
- [ ] webOS Homebrew wrapper
- [ ] Documentation
- [ ] Other

## Why

Rapid Back button presses during detail skeleton loading triggered `history.back()` before `pushState` had completed for the detail route. This dropped history entries and forced history to jump past the previous caller route to Home.

## Issue or approval

https://github.com/NuvioMedia/NuvioWeb/issues/532

## Reproduction steps

1. Go to Search or Discover screen.
2. Select a title.
3. Rapidly press Back button on remote while skeleton loader is visible.
4. Observe app navigating to Home instead of Search/Discover.

## Old behavior

Detail routes are committed to browser history only after mounting completes. During skeleton loading, legacy detail logic forced Home, so Back skipped the Search, Discover, or Catalog caller.

## New behavior

`metaDetailsScreen.consumeBackRequest()` delegates loading-time Back to `Router.backFromPendingNavigation()`. The router restores the already-current history entry in place, realigns its internal stack, and falls back without invoking browser history when no valid state exists. Normal `pushState` timing remains after a successful mount, so stale navigations are not recorded.

## Platform impact

- Samsung Tizen: Fixes history stack synchronization during rapid navigation.
- LG webOS: Fixes remote Back button history popping during skeleton view.
- Browser development mode: Synchronizes browser back button state.
- Installer / packaging: No impact.
- Wrapper repositories: No impact.

## UI / behavior / playback impact

- [ ] No UI change
- [ ] No behavior change
- [ ] No playback change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] Playback changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval
- [ ] Playback change has explicit maintainer approval

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact
- [ ] Tizen `.wgt` packaging changed
- [ ] webOS `.ipk` packaging changed
- [ ] App identifiers or metadata changed
- [ ] `local.properties` / environment handling changed
- [ ] `sync:tizen` changed
- [ ] `sync:webos` changed
- [ ] Nuvio WebTV Installer compatibility changed
- [ ] TizenBrew wrapper support changed
- [ ] webOS Homebrew metadata support changed

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I included a linked issue, reproduction steps, and testing notes if this is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Limited to `router.js` pending-navigation Back restoration and the `metaDetailsScreen.js` loading handler. No changes to normal history commit timing, details fetching, metadata parsing, or hero rendering.

## Testing

### Devices / platforms tested

- LG webOS 6.0 TV
- Chrome (Linux dev mode)

### Commands tested

```sh
node --check js/ui/navigation/router.js
node --check js/ui/screens/detail/metaDetailsScreen.js
# deterministic pending-navigation assertions
npm run build
npm run package:tizen
npm run package:webos
```

## Manual test flow

1. Opened Search screen and searched for title.
2. Selected a title card.
3. Immediately pressed Back key on remote during skeleton load state.
4. Verified app popped back to Search screen cleanly instead of Home.

## Screenshots / Video

Not a UI layout change. Navigation history fix.

## Logs

Not applicable.

## Regression risk

Low. Only Back during a pending detail mount uses the new restoration path; normal mounted-route history behavior and the stale-navigation guard remain unchanged.

## Breaking changes

None.

## Linked issues

https://github.com/NuvioMedia/NuvioWeb/issues/532