### PR TITLE
fix(discover): close filter pickers in DOM to prevent focus flashing

### DIFF
--- a/js/ui/components/filterPicker.js
+++ b/js/ui/components/filterPicker.js
@@ -7,10 +7,8 @@ function escapeHtml(value) {
     .replace(/'/g, "&#39;");
 }
 
-function chevronSvg(open, className) {
-  const path = open
-    ? "M7.41 15.41 12 10.83l4.59 4.58L18 14l-6-6-6 6z"
-    : "M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6z";
+function chevronSvg(className) {
+  const path = "M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6z";
   return `
     <svg viewBox="0 0 24 24" class="${className}" aria-hidden="true" focusable="false">
       <path d="${path}" fill="currentColor" />
@@ -80,7 +78,7 @@ export function renderFilterPicker({
           <span class="${classPrefix}-title">${escapeHtml(title)}</span>
           <span class="${classPrefix}-value">${escapeHtml(value)}</span>
         </span>
-        <span class="${classPrefix}-icon">${chevronSvg(open, chevronClassName)}</span>
+        <span class="${classPrefix}-icon">${chevronSvg(chevronClassName)}</span>
       </div>
       ${
         shouldRenderMenu

--- a/js/ui/screens/search/discoverScreen.js
+++ b/js/ui/screens/search/discoverScreen.js
@@ -806,10 +806,9 @@ export const DiscoverScreen = {
 
   closePickerMenu() {
     if (!this.openPicker) return;
+    const action = actionForPickerKind(this.openPicker);
     this.openPicker = null;
-    if (!this.suppressInitialLoadingRenders) {
-      this.requestRender();
-    }
+    this.closePickerMenuInDom(action);
   },
 
   isPosterHoldTarget(node) {
@@ -1023,7 +1022,7 @@ export const DiscoverScreen = {
     this.lastFocusedDiscoverItemId = "";
     this.openPicker = null;
     if (!hasChanged) {
-      this.requestRender();
+      this.closePickerMenuInDom(this.lastFocusedAction);
       return;
     }
     if (option) {
@@ -1553,10 +1552,12 @@ export const DiscoverScreen = {
     if (Platform.isBackEvent(event)) {
       event?.preventDefault?.();
       if (this.closePosterOptionsMenu()) {
+        Router.suppressNextPopstate?.();
         return;
       }
       if (this.openPicker) {
         this.closePickerMenu();
+        Router.suppressNextPopstate?.();
         return;
       }
       await Router.back();
@@ -1609,16 +1610,9 @@ export const DiscoverScreen = {
       }
       if (isLeftKey(event) || isRightKey(event)) {
         const movingRight = isRightKey(event);
-        const action =
-          this.openPicker === "type"
-            ? "discoverFilterType"
-            : this.openPicker === "catalog"
-              ? "discoverFilterCatalog"
-              : "discoverFilterGenre";
         this.openPicker = null;
-        this.lastFocusedAction = action;
         this.moveFilterFocus(movingRight ? 1 : -1);
-        this.requestRender();
+        this.closePickerMenuInDom(this.lastFocusedAction);
         return;
       }
       return;


### PR DESCRIPTION
## Summary

Closes filter pickers directly in the DOM on option re-selection, DPAD Left/Right navigation, and Back key press without triggering full-screen re-renders. Standardizes chevron SVG rotation via CSS.

## PR type

- [x] Critical bug fix
- [ ] Translation/localization only
- [ ] Approved feature/change

## Affected area

- [x] Shared web app
- [x] Samsung Tizen
- [x] LG webOS
- [x] Browser development mode
- [ ] Playback
- [ ] Audio tracks
- [ ] Subtitles
- [x] Focus / Remote navigation
- [x] UI / Layout
- [ ] Resume / Watch progress
- [ ] Continue Watching
- [ ] Next Episode / Auto-play
- [ ] Packaging / Build
- [ ] Nuvio WebTV Installer compatibility
- [ ] TizenBrew wrapper
- [ ] webOS Homebrew wrapper
- [ ] Documentation
- [ ] Other

## Why

`selectCurrentPickerOption()`, `closePickerMenu()`, and DPAD Left/Right navigation were calling `requestRender()`. This scheduled multiple full-screen DOM re-renders via `startClosingPicker()` and `closingPickerTimer`, destroying and recreating the focused filter selector element 2–3 times in rapid succession.

## Issue or approval

https://github.com/NuvioMedia/NuvioWeb/issues/533

## Reproduction steps

1. Navigate to Discover screen.
2. Open Type, Catalog, or Genre filter dropdown.
3. Press Enter on the active option (or press Left/Right DPAD).
4. Observe white focus outline flashing 2–3 times.

## Old behavior

Picker close triggered 2–3 full DOM re-renders (`requestRender()` -> `startClosingPicker()` -> `closingPickerTimer`). Chevron SVG path was also being swapped in JS while CSS applied `rotate(180deg)`.

## New behavior

`closePickerMenuInDom()` closes the dropdown menu node directly in the DOM and restores focus in-place without triggering full screen re-renders. Chevron SVG path is fixed to standard down chevron while CSS `.library-picker.open .library-picker-chevron` handles smooth rotation. `Router.suppressNextPopstate()` is called on Back press.

## Platform impact

- Samsung Tizen: Eliminates focus outline flashing during filter navigation.
- LG webOS: Eliminates focus outline flashing and suppresses popstate event on Back press.
- Browser development mode: Works smoothly.
- Installer / packaging: No impact.
- Wrapper repositories: No impact.

## UI / behavior / playback impact

- [ ] No UI change
- [ ] No behavior change
- [ ] No playback change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] Playback changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval
- [ ] Playback change has explicit maintainer approval

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact
- [ ] Tizen `.wgt` packaging changed
- [ ] webOS `.ipk` packaging changed
- [ ] App identifiers or metadata changed
- [ ] `local.properties` / environment handling changed
- [ ] `sync:tizen` changed
- [ ] `sync:webos` changed
- [ ] Nuvio WebTV Installer compatibility changed
- [ ] TizenBrew wrapper support changed
- [ ] webOS Homebrew metadata support changed

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I included a linked issue, reproduction steps, and testing notes if this is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Limited to `discoverScreen.js` picker close handling and `filterPicker.js` chevron SVG path. No changes to catalog data fetching, grid rendering, or poster cards.

## Testing

### Devices / platforms tested

- LG webOS 6.0 TV
- Chrome (Linux dev mode)

### Commands tested

```sh
npm run build
npm run package:webos
npm run install:webos
```

## Manual test flow

1. Opened Discover screen.
2. Opened Type picker dropdown.
3. Re-selected active "Movie" option -> confirmed picker closes in DOM with zero focus flashing.
4. Opened Catalog picker and pressed Right arrow -> confirmed focus shifts cleanly to Genre picker with zero flashing.
5. Opened Genre picker and pressed Back key -> confirmed picker closes smoothly without exiting or flashing.

## Screenshots / Video

Fixed focus flashing glitch on filter selector.

## Logs

Not applicable.

## Regression risk

Low. Uses existing `closePickerMenuInDom()` helper for in-place DOM cleanup.

## Breaking changes

None.

## Linked issues

https://github.com/NuvioMedia/NuvioWeb/issues/533