### PR TITLE
fix(search): position cursor at end of input text on focus

### DIFF
--- a/js/ui/screens/search/searchScreen.js
+++ b/js/ui/screens/search/searchScreen.js
@@ -1634,6 +1634,10 @@ export const SearchScreen = {
       if (current !== input) {
         this.focusNode(current, input);
       }
+      const valueLength = String(input.value || "").length;
+      try {
+        input.setSelectionRange(valueLength, valueLength);
+      } catch (_) {}
     });
 
     input.addEventListener("keydown", async (event) => {


### PR DESCRIPTION
## Summary

Sets insertion cursor to the end of the search input text when the search bar gains focus.

## PR type

- [x] Critical bug fix
- [ ] Translation/localization only
- [ ] Approved feature/change

## Affected area

- [x] Shared web app
- [ ] Samsung Tizen
- [ ] LG webOS
- [ ] Browser development mode
- [ ] Playback
- [ ] Audio tracks
- [ ] Subtitles
- [x] Focus / Remote navigation
- [x] UI / Layout
- [ ] Resume / Watch progress
- [ ] Continue Watching
- [ ] Next Episode / Auto-play
- [ ] Packaging / Build
- [ ] Nuvio WebTV Installer compatibility
- [ ] TizenBrew wrapper
- [ ] webOS Homebrew wrapper
- [ ] Documentation
- [ ] Other

## Why

When returning to edit an existing search query after navigating search results, typing would prepend characters to the front of the text string instead of appending to the end.

## Issue or approval

https://github.com/NuvioMedia/NuvioWeb/issues/534

## Reproduction steps

1. Go to Search screen and type a search term.
2. Navigate down to search results.
3. Focus the search input bar again.
4. Observe cursor placed at index 0.

## Old behavior

Input focus placed the cursor at position 0 before existing text.

## New behavior

`input.setSelectionRange(len, len)` explicitly positions the cursor at the end of the existing query string on focus.

## Platform impact

- Samsung Tizen: Shared code fix, improves input behavior.
- LG webOS: Shared code fix, improves input behavior.
- Browser development mode: Works as expected.
- Installer / packaging: No impact.
- Wrapper repositories: No impact.

## UI / behavior / playback impact

- [ ] No UI change
- [ ] No behavior change
- [ ] No playback change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] Playback changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval
- [ ] Playback change has explicit maintainer approval

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact
- [ ] Tizen `.wgt` packaging changed
- [ ] webOS `.ipk` packaging changed
- [ ] App identifiers or metadata changed
- [ ] `local.properties` / environment handling changed
- [ ] `sync:tizen` changed
- [ ] `sync:webos` changed
- [ ] Nuvio WebTV Installer compatibility changed
- [ ] TizenBrew wrapper support changed
- [ ] webOS Homebrew metadata support changed

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I included a linked issue, reproduction steps, and testing notes if this is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Intentionally limited to `searchScreen.js` input focus handling. No changes to keyboard layout, search debouncing, or results fetching.

## Testing

### Devices / platforms tested

- LG webOS 6.0 TV
- Chrome (Linux dev mode)

### Commands tested

```sh
npm run build
npm run package:webos
npm run install:webos
```

## Manual test flow

1. Opened Search screen.
2. Entered "Batman" into search bar.
3. Navigated down to search results cards.
4. Navigated back up to focus search input bar.
5. Confirmed cursor is positioned at the end of "Batman" and typing continues cleanly.

## Screenshots / Video

Not a UI layout change. Focus/cursor placement fix.

## Logs

Not applicable.

## Regression risk

Minimal. Uses standard HTMLInputElement API (`setSelectionRange`).

## Breaking changes

None.

## Linked issues

https://github.com/NuvioMedia/NuvioWeb/issues/534