### PR TITLE
fix(streams): keep selected addon chip visible

### DIFF
--- a/js/ui/screens/stream/streamScreen.js
+++ b/js/ui/screens/stream/streamScreen.js
@@ -62,6 +62,29 @@ function clamp(value, min, max) {
   return Math.max(min, Math.min(max, value));
 }
 
+function getChipVisibilityScrollLeft(chipTrack, chip, padding = 24) {
+  if (!chipTrack || !chip) {
+    return null;
+  }
+  const scrollLeft = Number(chipTrack.scrollLeft || 0);
+  const clientWidth = Number(chipTrack.clientWidth || 0);
+  const scrollWidth = Number(chipTrack.scrollWidth || 0);
+  if (!clientWidth || scrollWidth <= clientWidth) {
+    return scrollLeft;
+  }
+  const left = Number(chip.offsetLeft || 0);
+  const right = left + Number(chip.offsetWidth || 0);
+  const viewRight = scrollLeft + clientWidth;
+  const maxScrollLeft = Math.max(0, scrollWidth - clientWidth);
+  if (right > viewRight - padding) {
+    return clamp(right - clientWidth + padding, 0, maxScrollLeft);
+  }
+  if (left < scrollLeft + padding) {
+    return clamp(left - padding, 0, maxScrollLeft);
+  }
+  return scrollLeft;
+}
+
 function escapeHtml(value = "") {
   return String(value || "")
     .replaceAll("&", "&amp;")
@@ -1555,17 +1578,9 @@ export const StreamScreen = {
     }
 
     const chipTrack = target.closest(".stream-route-chip-track");
-    if (chipTrack) {
-      const left = target.offsetLeft;
-      const right = left + target.offsetWidth;
-      const viewLeft = chipTrack.scrollLeft;
-      const viewRight = viewLeft + chipTrack.clientWidth;
-      const pad = 24;
-      if (right > viewRight - pad) {
-        chipTrack.scrollLeft = Math.max(0, right - chipTrack.clientWidth + pad);
-      } else if (left < viewLeft + pad) {
-        chipTrack.scrollLeft = Math.max(0, left - pad);
-      }
+    const chipScrollLeft = getChipVisibilityScrollLeft(chipTrack, target);
+    if (chipScrollLeft !== null) {
+      chipTrack.scrollLeft = chipScrollLeft;
     }
 
     const listNode = target.closest(".stream-route-list");
@@ -2234,6 +2249,12 @@ export const StreamScreen = {
     ScreenUtils.indexFocusables(this.container);
     this.restoreScrollPosition();
     this.applyFocus();
+    const selectedChip = this.container.querySelector(".stream-route-chip.selected");
+    const chipTrack = selectedChip?.closest(".stream-route-chip-track");
+    const chipScrollLeft = getChipVisibilityScrollLeft(chipTrack, selectedChip);
+    if (chipScrollLeft !== null) {
+      chipTrack.scrollLeft = chipScrollLeft;
+    }
     this.bindListScrollState();
     this.hasRenderedStreamRouteShell = true;
   },


### PR DESCRIPTION
## Summary

Keep the selected addon chip visible when Left/Right changes source filters while focus remains in the stream-card list.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix
- [ ] Approved feature/change

## Affected area

- [x] Shared web app
- [ ] Samsung Tizen
- [x] LG webOS
- [ ] Browser development mode
- [ ] Playback
- [ ] Audio tracks
- [ ] Subtitles
- [x] Focus / Remote navigation
- [x] UI / Layout
- [ ] Resume / Watch progress
- [ ] Continue Watching
- [ ] Next Episode / Auto-play
- [ ] Packaging / Build
- [ ] Nuvio WebTV Installer compatibility
- [ ] TizenBrew wrapper
- [ ] webOS Homebrew wrapper
- [ ] Documentation
- [ ] Other

## Why

The existing horizontal visibility correction runs only when a chip receives focus. Card-zone Left/Right changes the selected addon, rebuilds the route, then restores focus to the card. If the selected chip is outside the horizontal viewport, it remains invisible.

## Issue or approval

Fixes #569

## Reproduction steps

1. Open a stream screen with enough addon chips to overflow horizontally.
2. Move focus into the stream-card list.
3. Press Left/Right until the selected addon chip lies beyond the current chip viewport.
4. Observe that the filter changes but the selected chip remains off-screen.

## Old behavior

Only focused chips were scrolled into view. A selected chip could remain off-screen while focus stayed on a stream card.

## New behavior

Focused and selected chips use the same bounded 24px-padded horizontal geometry. After render restores card focus, the chip track scrolls just enough to reveal the selected chip without moving focus.

## Platform impact

- Samsung Tizen: Shared code path; direct bounded `scrollLeft` is retained instead of relying on `scrollIntoView` option support. Not hardware-tested.
- LG webOS: Manually verified on LG C5, webOS v33.31.58.
- Browser development mode: Expected to use the same direct horizontal scroll behavior; not separately tested.
- Installer / packaging: No impact.
- Wrapper repositories: No impact.

## UI / behavior / playback impact

- [ ] No UI change
- [ ] No behavior change
- [x] No playback change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] Playback changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval
- [ ] Playback change has explicit maintainer approval

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact
- [ ] Tizen `.wgt` packaging changed
- [ ] webOS `.ipk` packaging changed
- [ ] App identifiers or metadata changed
- [ ] `local.properties` / environment handling changed
- [ ] `sync:tizen` changed
- [ ] `sync:webos` changed
- [ ] Nuvio WebTV Installer compatibility changed
- [ ] TizenBrew wrapper support changed
- [ ] webOS Homebrew metadata support changed

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I included a linked issue, reproduction steps, and testing notes if this is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Only chip visibility is changed. This PR does not modify stream loading, filtering, badges, card rendering, playback, packaging, dependencies, or visual styling.

## Testing

### Devices / platforms tested

- LG C5, webOS v33.31.58, manual IPK install

### Commands tested

```sh
npx eslint js/ui/screens/stream/streamScreen.js
git diff --check
npm run build
npm run package:webos
```

The repository currently has no configured test script. Prettier assessment was baseline-aware: the upstream file is already nonconforming, and this PR introduces no formatting-only hunks.

## Manual test flow

1. Opened a movie with enough addons to overflow the chip track.
2. Moved focus into the stream list.
3. Switched repeatedly with Left/Right to off-screen addons.
4. Confirmed the selected chip scrolls into view while card focus remains unchanged.
5. Switched back left and confirmed the track scrolls back to reveal earlier chips.

## Screenshots / Video

Not captured. This is a dynamic remote-navigation issue; before/after behavior was manually verified on the affected LG TV.

## Logs

Not applicable. No crash, blank screen, playback error, or platform API error occurs.

## Regression risk

Low. The helper reuses the existing direct `scrollLeft` behavior, clamps within the track bounds, and changes only horizontal chip visibility. The shared path should still be manually checked on Samsung Tizen because hardware was unavailable.

## Breaking changes

None.

## Linked issues

Fixes #569