### PR TITLE
Align stream selector loading skeleton with real cards

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -19358,8 +19358,7 @@ html.legacy-webos .debug-console-log-frame {
 }
 
 .stream-route-card.skeleton {
-  display: block;
-  min-height: 160px;
+  pointer-events: none;
 }
 
 .stream-route-card-copy {
@@ -19624,22 +19623,24 @@ html.legacy-webos .debug-console-log-frame {
   );
   background-size: 220% 100%;
   animation: streamRouteSkeletonShimmer 2.2s ease-in-out infinite;
-  margin-bottom: 14px;
+  margin-top: 12px;
 }
 
-.stream-route-skeleton-line.wide {
+/* Widths/heights mirror the real card rows: heading, quality, then two lines. */
+.stream-route-skeleton-line:first-child {
   width: 34%;
   height: 22px;
+  margin-top: 0;
 }
 
-.stream-route-skeleton-line.short {
+.stream-route-skeleton-line:nth-child(2) {
   width: 12%;
   height: 18px;
+  margin-top: 14px;
 }
 
 .stream-route-skeleton-line:last-child {
   width: 56%;
-  margin-bottom: 0;
 }
 
 @keyframes streamRoutePanelEnter {

--- a/js/ui/screens/stream/streamScreen.js
+++ b/js/ui/screens/stream/streamScreen.js
@@ -2133,19 +2133,18 @@ export const StreamScreen = {
   },
 
   renderLoadingCards(count = 3) {
-    const safeCount = Math.max(1, Number(count || 0));
-    return Array.from({ length: safeCount })
-      .map(
-        () => `
-      <div class="stream-route-card skeleton">
-        <div class="stream-route-skeleton-line wide"></div>
-        <div class="stream-route-skeleton-line short"></div>
-        <div class="stream-route-skeleton-line"></div>
-        <div class="stream-route-skeleton-line"></div>
+    return `
+      <div class="stream-route-card-row">
+        <div class="stream-route-card skeleton">
+          <div class="stream-route-card-copy">
+            <div class="stream-route-skeleton-line"></div>
+            <div class="stream-route-skeleton-line"></div>
+            <div class="stream-route-skeleton-line"></div>
+            <div class="stream-route-skeleton-line"></div>
+          </div>
+        </div>
       </div>
-    `
-      )
-      .join("");
+    `.repeat(count);
   },
 
   render() {


### PR DESCRIPTION
## Summary

Align the stream-selector loading skeleton with the stream cards it replaces by using the same row wrapper and copy container. This restores the real card padding, minimum height, flex layout, and inter-card spacing while keeping the loading state non-interactive.

## PR type

- [ ] Translation/localization only
- [ ] Critical bug fix
- [x] Approved feature/change

## Affected area

- [x] Shared web app
- [x] Samsung Tizen
- [x] LG webOS
- [x] Browser development mode
- [ ] Playback
- [ ] Audio tracks
- [ ] Subtitles
- [ ] Focus / Remote navigation
- [x] UI / Layout
- [ ] Resume / Watch progress
- [ ] Continue Watching
- [ ] Next Episode / Auto-play
- [ ] Packaging / Build
- [ ] Nuvio WebTV Installer compatibility
- [ ] TizenBrew wrapper
- [ ] webOS Homebrew wrapper
- [ ] Documentation
- [ ] Other

## Why

The loading placeholders used a bare `.stream-route-card` instead of the real card's `.stream-route-card-row` wrapper. They therefore missed the 18px row spacing and overrode the shared card layout with `display: block` and a shorter 160px minimum height. The loading list visibly changed height and spacing when real results replaced it.

## Issue or approval

Approved by the maintainer during review of #574.

## Reproduction steps

1. Open a movie or episode and enter the stream selector while sources are loading.
2. Compare the placeholder cards with the loaded stream cards.
3. Before this change, placeholders are shorter and closer together because they do not use the real row wrapper and card dimensions.

## Old behavior

Skeleton cards used a separate 160px block layout and had no `.stream-route-card-row` wrapper, so their height and vertical spacing did not match loaded stream cards.

## New behavior

Skeleton cards use the same row wrapper, copy container, 214px minimum card height, 28px/32px padding, flex layout, and 18px row spacing as loaded stream cards. Skeletons remain non-interactive.

## Platform impact

- Samsung Tizen: Shared stream-selector CSS/markup only; no Tizen API, focus, or playback changes.
- LG webOS: Shared stream-selector CSS/markup only; legacy card background fallbacks remain unchanged.
- Browser development mode: Same corrected skeleton dimensions and spacing.
- Installer / packaging: No source or metadata changes.
- Wrapper repositories: No changes.

## UI / behavior / playback impact

- [ ] No UI change
- [x] No behavior change
- [x] No playback change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] Playback changed only to fix a documented bug/regression
- [x] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval
- [ ] Playback change has explicit maintainer approval

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact
- [ ] Tizen `.wgt` packaging changed
- [ ] webOS `.ipk` packaging changed
- [ ] App identifiers or metadata changed
- [ ] `local.properties` / environment handling changed
- [ ] `sync:tizen` changed
- [ ] `sync:webos` changed
- [ ] Nuvio WebTV Installer compatibility changed
- [ ] TizenBrew wrapper support changed
- [ ] webOS Homebrew metadata support changed

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I included a linked issue, reproduction steps, and testing notes if this is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

No stream fetching, filtering, focus, remote navigation, playback, platform adapter, packaging, dependency, or version behavior changed. The patch is limited to loading-card markup and its existing CSS.

## Testing

### Devices / platforms tested

- Chromium browser on macOS against the exact PR merge tree.
- Static compatibility review against the current Android TV `StreamsSkeletonList` / `StreamCardSkeleton` contract.
- No physical Samsung or LG TV was tested during maintainer review.

### Commands tested

```sh
npm ci
node --check js/ui/screens/stream/streamScreen.js
npx eslint js/ui/screens/stream/streamScreen.js
npm run build
npm run package:tizen
npm run package:webos
```

All commands passed. The generated packages remained version `0.3.25`.

## Manual test flow

Opened the local merge-tree build, continued without an account, opened a movie detail, and entered the stream selector. A focused visual fixture using the production markup and CSS confirmed that each skeleton inherits the real 214px card height, 28px/32px padding, flex layout, and 18px row spacing; the final row correctly has no bottom margin.

## Screenshots / Video

Contributor-provided screenshot:

<img width="1182" height="1000" alt="Aligned stream selector loading skeletons" src="https://github.com/user-attachments/assets/477846c0-4f7b-47ef-8caf-b28014db4023" />

## Logs

Not applicable. This change does not affect playback, platform APIs, networking, or packaging logic.

## Regression risk

Low. The only runtime compatibility change is `String.prototype.repeat`, supported above the repository's Chromium 68 webOS baseline and by supported Tizen versions. All current call sites pass positive integer counts. Focusable loaded cards and stream selection behavior are untouched.

## Breaking changes

None.

## Linked issues

Approval recorded in #574; no separate issue.
