### PR TITLE
Fix profile grid overlap at exactly 4 profiles (#579)

### DIFF
--- a/js/core/profile/profileSelectionScreen.js
+++ b/js/core/profile/profileSelectionScreen.js
@@ -443,7 +443,7 @@ export const ProfileSelectionScreen = {
     const visibleProfiles = this.getVisibleProfiles();
     const canAddProfile = visibleProfiles.length < MAX_PROFILES;
     const totalItems = visibleProfiles.length + (canAddProfile ? 1 : 0);
-    const gridClass = totalItems >= 6 ? "profile-grid profile-grid-compact" : "profile-grid";
+    const gridClass = totalItems >= 5 ? "profile-grid profile-grid-compact" : "profile-grid";
     const title = this.isManagementMode
       ? t("profile_manage_title", {}, "Manage Profiles")
       : t("profile_selection_title", {}, "Who's watching?");
@@ -458,7 +458,7 @@ export const ProfileSelectionScreen = {
     const pinScreenPhaseClass = isPinActive
       ? ` is-pin-${escapeHtml(this.pinOverlayPhase || "open")}`
       : "";
-    const compactGridScreenClass = totalItems >= 6 ? " profile-screen-compact-grid" : "";
+    const compactGridScreenClass = totalItems >= 5 ? " profile-screen-compact-grid" : "";
 
     this.container.innerHTML = `
       <div class="profile-screen${pinScreenPhaseClass}${compactGridScreenClass}">


### PR DESCRIPTION
Regular profile grid only fits 4 cards per row but the compact layout switch only triggered at totalItems >= 6 leaving a gap at totalItems == 5 (4 profiles + Add button) where the Add button wrapped to a second row and overlapped the hint text.

Lowered both thresholds to >= 5.

Fixes #579

## Summary

<!-- What changed in this PR? Keep it short and specific. -->

Fixes a layout bug where the Add-profile button wrapped to a second row and overlapped hint text when there were exactly 4 profiles.

## PR type

<!-- Check exactly one. PRs outside these types are not accepted unless explicitly approved. -->

- [ ] Translation/localization only
- [x] Critical bug fix
- [ ] Approved feature/change

## Affected area

<!-- Check every area affected by this PR. -->

- [x] Shared web app
- [x] Samsung Tizen
- [x] LG webOS
- [x] Browser development mode
- [ ] Playback
- [ ] Audio tracks
- [ ] Subtitles
- [ ] Focus / Remote navigation
- [x] UI / Layout
- [ ] Resume / Watch progress
- [ ] Continue Watching
- [ ] Next Episode / Auto-play
- [ ] Packaging / Build
- [ ] Nuvio WebTV Installer compatibility
- [ ] TizenBrew wrapper
- [ ] webOS Homebrew wrapper
- [ ] Documentation
- [ ] Other

## Why

<!-- Why is this change needed? Explain the critical bug, localization update, or approved change. -->

The Add-profile button and the last profile card wrap onto a second row and overlap the hint text below the grid whenever there are exactly 4 profiles.

## Issue or approval

<!-- Required for critical bug fixes and approved changes. Link the bug issue or approved feature request. -->
<!-- Examples: Fixes #123 / Approved in #456 / No linked issue: localization-only update. -->

Fixes #579

## Reproduction steps

<!-- Required for critical bug fixes. For localization-only PRs, write: No reproduction steps - localization-only update. -->

1. Open NuvioTV Web
2. Go to the profile selection screen
3. Create profiles until exactly 4

## Old behavior

<!-- What happened before this PR? For localization-only PRs, write: Not applicable - localization-only update. -->

At exactly 4 profiles the Add profile card wraps to a second row by itself and that row overlaps the hint text below the profile grid.

## New behavior

<!-- What happens after this PR? -->

With any profile count all cards should stay aligned on a single row.

## Platform impact

<!-- Explain which platforms were affected and whether this change touches shared code. -->

- Samsung Tizen: Shared code change, same layout logic applies; not yet tested on a physical Tizen device.
- LG webOS: Tested and confirmed fixed on physical LG OLED55B56LA via Nuvio WebTV Installer (.ipk).
- Browser development mode: Tested and confirmed fixed via npm run build + local dev server in Safari.
- Installer / packaging: No impact, JS/CSS logic change only.
- Wrapper repositories: No impact.

## UI / behavior / playback impact

<!-- Check every box that applies. At least one must be checked. -->

- [ ] No UI change
- [ ] No behavior change
- [ ] No playback change
- [x] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] Playback changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval
- [ ] Playback change has explicit maintainer approval

## Installer, packaging, or wrapper impact

<!-- Check every box that applies. -->

- [x] No installer, packaging, or wrapper impact
- [ ] Tizen `.wgt` packaging changed
- [ ] webOS `.ipk` packaging changed
- [ ] App identifiers or metadata changed
- [ ] `local.properties` / environment handling changed
- [ ] `sync:tizen` changed
- [ ] `sync:webos` changed
- [ ] Nuvio WebTV Installer compatibility changed
- [ ] TizenBrew wrapper support changed
- [ ] webOS Homebrew metadata support changed

## Policy check

<!-- ALL boxes must be checked or the PR may be closed without review. -->

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I included a linked issue, reproduction steps, and testing notes if this is a critical bug fix.
- [x] I listed the testing performed below.

> Feature additions, broad UI changes, refactors, playback rewrites, platform rewrites, installer rewrites, and other non-critical changes may be closed or deferred without review while NuvioTV Web is being prepared for a stable Smart TV release.

## Scope boundaries

<!-- List anything intentionally not changed. If this is a bug fix, confirm it does not include extra UI polish, behavior tweaks, playback changes, or platform rewrites. -->

This PR only adjusts the two numeric thresholds that decide when the profile grid switches to its compact layout.

## Testing

<!-- What did you test and how? Include devices, TVs, emulators, simulators, commands, packages, and manual flows. Do not write only "not tested" unless this is localization-only. -->

Verified the profile grid renders correctly with 1, 2, 3, 4, 5, and 6 profiles after the fix with no wrapping/overlap at any count.

### Devices / platforms tested

<!-- Examples: LG C1 webOS 6, LG B4 webOS 24, Samsung S90F Tizen 9.0, Chrome on macOS, Tizen emulator, webOS simulator. -->

Tested .ipk on LG OLED55B56LA via Nuvio WebTV Installer, plus local dev build (npm run build + python3 http.server) in Safari.

### Commands tested

<!-- Include relevant commands if applicable. -->

```sh
# Examples:
npm run build
npm run package:tizen
npm run package:webos
npm run install:webos -- -d lg
npm run logs:webos -- -d lg
npm run inspect:webos -- -d lg
```

npm run build
npm run install:webos -- -d lg

## Manual test flow

<!-- Describe the exact flow tested in the app. -->

Opened the profile selection screen, created/removed profiles to hit each count from 1 to 6 and confirmed the grid and Add-profile card stayed aligned on one row without overlapping the hint text at every count. This was tested on the physical TV and the local browser build.

## Screenshots / Video

<!-- Required for any UI, layout, focus, or visual change. Write "Not a UI change" only if no UI changed. -->

Before:
<img width="1689" height="996" alt="Skärmavbild 2026-07-28 kl  11 49 13" src="https://github.com/user-attachments/assets/c1916fa9-ab0f-4040-a24e-d5b328f964ba" />

After:
<img width="1686" height="1000" alt="Skärmavbild 2026-07-28 kl  11 48 22" src="https://github.com/user-attachments/assets/c13eebb7-4fe1-4937-855b-1a23c8c48b8e" />

## Logs

<!-- Required for crashes, blank screens, install/package failures, playback failures, or platform API errors. Write "Not applicable" if not relevant. -->

Not applicable

## Regression risk

<!-- Describe what could break, especially across Samsung Tizen, LG webOS, browser development mode, installer, packaging, or wrappers. -->

Low. This only changes the numeric threshold for switching layouts. The compact layout itself is unchanged and already handles up to 6 items reliably (previously used for 5-6 profile counts). No other code is touched.

## Breaking changes

<!-- Any breaking behavior/config/schema/package/app-id changes? If none, write: None. -->

None 

## Linked issues

<!-- Required for critical bug fixes and approved changes. For localization-only PRs with no issue, write: No linked issue - localization-only update. -->

Fixes #579  