### PR TITLE
Fix unusable stream source list on webOS

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -19186,12 +19186,23 @@ html.legacy-webos .debug-console-log-frame {
   scroll-padding-bottom: 8px;
 }
 
-.legacy-webos .stream-route-list.manual-scroll {
+/* Manual scroll is driven from JS on every webOS version, not just the legacy
+   ones, so the clip must not be scoped to .legacy-webos. The offset itself is
+   applied inline on .stream-route-list-track (webOS 3.x has no CSS vars). */
+.stream-route-list.manual-scroll {
   overflow: hidden;
 }
 
-.legacy-webos .stream-route-list.manual-scroll > * {
-  transform: translateY(var(--stream-route-manual-scroll, 0));
+/* Stand-ins for the rows outside the rendered window. Height is set inline from
+   measured row geometry; they must not pick up card styling or hit testing. */
+.stream-route-virtual-spacer {
+  display: block;
+  width: 100%;
+  flex: 0 0 auto;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  pointer-events: none;
 }
 
 .legacy-webos .stream-route-card-row {

--- a/js/ui/screens/stream/streamScreen.js
+++ b/js/ui/screens/stream/streamScreen.js
@@ -45,10 +45,23 @@ import {
 } from "../../../core/streams/streamBadgeRules.js";
 import { normalizeMathematicalAlphanumericSymbols } from "../../../core/streams/streamDisplayText.js";
 import { renderLoadingIndicator } from "../../components/loadingIndicator.js";
+import {
+  VIRTUAL_LIST_FALLBACK_VIEWPORT_PX,
+  buildRowOffsets,
+  computeVirtualRange,
+  deriveRowStrides,
+  estimateRowHeight,
+  projectScrollForRow,
+  virtualRangeNeedsRefresh
+} from "./streamVirtualList.js";
 
 const STREAM_BADGE_LIMIT = 9;
 const WEBOS_STREAM_BADGE_OVERSCAN_RATIO = 0.35;
 const WEBOS_STREAM_BADGE_MIN_OVERSCAN_PX = 180;
+// Virtual list. Row geometry maths lives in streamVirtualList.js so it can be
+// tested without a DOM; everything here is the DOM half.
+const WEBOS_VIRTUAL_LIST_MIN_ROWS = 24;
+const WEBOS_VIRTUAL_VISIBILITY_PAD_PX = 16;
 const WEBOS_NATIVE_PLAYER_APP_IDS = [
   "com.webos.app.mediadiscovery",
   "com.webos.app.photovideo",
@@ -708,6 +721,15 @@ export const StreamScreen = {
     }
   },
 
+  // Every cache below is keyed to the markup or the stream arrays that render()
+  // is about to replace, so drop them all in one place.
+  invalidateStreamRouteCaches() {
+    this.filteredStreamsCache = null;
+    this.cardRowsCache = null;
+    this.chipNodesCache = null;
+    this.focusedNode = null;
+  },
+
   requestRender({ delayMs = 0 } = {}) {
     if (!this.container || Router.getCurrent() !== "stream") {
       return;
@@ -934,6 +956,9 @@ export const StreamScreen = {
     this.addonLogoLookup = {};
     this.addonFilter = "all";
     this.hasRenderedStreamRouteShell = false;
+    this.invalidateStreamRouteCaches();
+    this.virtualGeometryKey = "";
+    this.resetVirtualGeometry();
     // Returning here from the player is a back navigation, not a fresh open, so
     // do not auto-resume or auto-play again. Otherwise exiting the player drops
     // back onto the stream list and immediately relaunches, looping forever.
@@ -1050,6 +1075,9 @@ export const StreamScreen = {
     this.addonLogoLookup = {};
 
     this.sourceChips = [];
+    this.invalidateStreamRouteCaches();
+    this.virtualGeometryKey = "";
+    this.resetVirtualGeometry();
     if (!this.hasRenderedStreamRouteShell) {
       this.requestRender();
     }
@@ -1523,12 +1551,32 @@ export const StreamScreen = {
     return getOrderedFilterNames(this.sourceChips, this.streams);
   },
 
+  // Two full sorts of the stream array. This runs on every badge-hydration pass,
+  // i.e. every scroll frame, so memoise it against the source identities. Both
+  // arrays are always reassigned rather than mutated in place, and render()
+  // drops the cache so settings changes are picked up.
   getFilteredStreams(filter = this.addonFilter) {
-    const orderedStreams = sortStreamsByAddonOrder(this.streams, this.sourceChips);
-    if (filter === "all") {
-      return DebridStreamPresentation.sortForDisplay(orderedStreams, DebridSettingsStore.get());
+    const cached = this.filteredStreamsCache;
+    if (
+      cached &&
+      cached.streams === this.streams &&
+      cached.sourceChips === this.sourceChips &&
+      cached.filter === filter
+    ) {
+      return cached.result;
     }
-    return orderedStreams.filter((stream) => stream.addonName === filter);
+    const orderedStreams = sortStreamsByAddonOrder(this.streams, this.sourceChips);
+    const result =
+      filter === "all"
+        ? DebridStreamPresentation.sortForDisplay(orderedStreams, DebridSettingsStore.get())
+        : orderedStreams.filter((stream) => stream.addonName === filter);
+    this.filteredStreamsCache = {
+      streams: this.streams,
+      sourceChips: this.sourceChips,
+      filter,
+      result
+    };
+    return result;
   },
 
   hasPendingSourceLoads(filter = this.addonFilter) {
@@ -1572,16 +1620,93 @@ export const StreamScreen = {
     return row.play || row.native || null;
   },
 
+  // One querySelectorAll plus two scoped queries per row. On a few hundred
+  // sources that is a few hundred DOM queries per keypress, so hold the result
+  // until the next render replaces the markup. Keyed by the absolute row index
+  // from data-stream-row, which stays stable when only a window is rendered.
   getCardRows() {
-    return Array.from(
+    const cached = this.cardRowsCache;
+    if (cached && this.container?.contains(cached.anchor)) {
+      return cached.byIndex;
+    }
+    const byIndex = new Map();
+    let anchor = null;
+    Array.from(
       this.container?.querySelectorAll(".stream-route-card-row[data-stream-row]") || []
-    )
-      .map((rowNode) => ({
+    ).forEach((rowNode) => {
+      const entry = {
         row: Number(rowNode.dataset.streamRow || 0),
+        node: rowNode,
         play: rowNode.querySelector('[data-card-action="play"]'),
         native: rowNode.querySelector('[data-card-action="native"]')
-      }))
-      .filter((row) => row.play || row.native);
+      };
+      if (!entry.play && !entry.native) {
+        return;
+      }
+      byIndex.set(entry.row, entry);
+      anchor = anchor || rowNode;
+    });
+    this.cardRowsCache = anchor ? { byIndex, anchor } : null;
+    return byIndex;
+  },
+
+  getCardRow(index) {
+    return this.getCardRows().get(Number(index)) || null;
+  },
+
+  // The authoritative row count is the stream list, not the DOM, because the DOM
+  // only holds a window of it.
+  getVisibleStreamCount() {
+    return this.getFilteredStreams().length;
+  },
+
+  isVirtualListEnabled() {
+    return Environment.isWebOS() && this.getVisibleStreamCount() >= WEBOS_VIRTUAL_LIST_MIN_ROWS;
+  },
+
+  getRowHeight(index) {
+    const measured = this.rowHeights?.[index];
+    return measured > 0 ? measured : estimateRowHeight(this.rowHeights || []);
+  },
+
+  ensureRowOffsets(total) {
+    const count = Math.max(0, Number(total || 0));
+    if (!this.rowOffsets || this.rowOffsets.length !== count + 1) {
+      this.rowOffsets = buildRowOffsets(
+        this.rowHeights || [],
+        count,
+        estimateRowHeight(this.rowHeights || [])
+      );
+    }
+    return this.rowOffsets;
+  },
+
+  getRowOffset(index, total) {
+    const offsets = this.ensureRowOffsets(total);
+    return offsets[clamp(Number(index || 0), 0, offsets.length - 1)] || 0;
+  },
+
+  getListViewportHeight(listNode) {
+    const measured = Number(listNode?.clientHeight || 0);
+    if (measured > 0) {
+      this.lastListViewportHeight = measured;
+      return measured;
+    }
+    return Number(this.lastListViewportHeight || 0) || VIRTUAL_LIST_FALLBACK_VIEWPORT_PX;
+  },
+
+  computeVirtualRange(scrollTop, viewportHeight, total, focusRow) {
+    return computeVirtualRange({
+      offsets: this.ensureRowOffsets(total),
+      scrollTop,
+      viewportHeight,
+      total,
+      focusRow
+    });
+  },
+
+  virtualRangeNeedsRefresh(range, total) {
+    return virtualRangeNeedsRefresh({ current: this.virtualRange, next: range, total });
   },
 
   isCardActionFocused(rowIndex, action) {
@@ -1592,18 +1717,50 @@ export const StreamScreen = {
     );
   },
 
+  // Clearing the marker used to touch every .focusable in the list, which on a
+  // few hundred cards is a few hundred style invalidations per D-pad step. Track
+  // the focused node instead and only sweep when the pointer is stale (i.e. once
+  // after each render, which rebuilds the list markup).
+  clearFocusedMarker(nextTarget) {
+    const previous = this.focusedNode;
+    if (previous === nextTarget) {
+      return;
+    }
+    if (previous && this.container?.contains(previous)) {
+      previous.classList.remove("focused");
+      return;
+    }
+    this.container?.querySelectorAll(".focused")?.forEach((node) => {
+      if (node !== nextTarget) {
+        node.classList.remove("focused");
+      }
+    });
+  },
+
   focusElement(target) {
     if (!target) {
       return false;
     }
-    this.container
-      .querySelectorAll(".focusable")
-      .forEach((node) => node.classList.remove("focused"));
+    this.clearFocusedMarker(target);
+    this.focusedNode = target;
     target.classList.add("focused");
+    const listNode = target.closest(".stream-route-list");
     try {
       target.focus({ preventScroll: true });
     } catch (_) {
       target.focus();
+    }
+    // webOS below Chromium 64 ignores preventScroll and natively scrolls the
+    // list, which fights the manual transform. Snap the native offset back.
+    if (
+      listNode?.classList?.contains("manual-scroll") &&
+      Number(listNode.scrollTop || 0) !== 0
+    ) {
+      try {
+        listNode.scrollTop = 0;
+      } catch (_) {
+        // Manual transform stays authoritative.
+      }
     }
 
     const chipTrack = target.closest(".stream-route-chip-track");
@@ -1620,11 +1777,10 @@ export const StreamScreen = {
       }
     }
 
-    const listNode = target.closest(".stream-route-list");
     if (listNode) {
-      this.ensureListItemVisible(listNode, target);
+      const measured = this.ensureListItemVisible(listNode, target);
       this.listScrollTop = this.getListScrollTop(listNode);
-      this.scheduleFocusedListItemVisibilityCheck(listNode, target);
+      this.scheduleFocusedListItemVisibilityCheck(listNode, target, measured);
     }
     return true;
   },
@@ -1665,14 +1821,30 @@ export const StreamScreen = {
     return Number(listNode.scrollTop || 0);
   },
 
+  // The whole card list rides on a single wrapper so a manual scroll step is one
+  // transform write instead of one per card. webOS 3.x has no CSS custom
+  // properties, so the offset is applied inline rather than through a variable.
+  getListTrack(listNode) {
+    const track = listNode?.firstElementChild;
+    return track?.classList?.contains("stream-route-list-track") ? track : null;
+  },
+
   updateManualListScrollTransform(listNode, scrollTop) {
     if (!listNode) {
       return;
     }
     const normalized = Math.max(0, Number(scrollTop || 0));
     const transform = normalized > 0 ? `translateY(${-normalized}px)` : "";
+    const track = this.getListTrack(listNode);
+    if (track) {
+      if (track.style.transform !== transform) {
+        track.style.transform = transform;
+      }
+      return;
+    }
+    // Defensive fallback for markup rendered before the track wrapper existed.
     Array.from(listNode.children || []).forEach((child) => {
-      if (child instanceof HTMLElement) {
+      if (child instanceof HTMLElement && child.style.transform !== transform) {
         child.style.transform = transform;
       }
     });
@@ -1683,26 +1855,37 @@ export const StreamScreen = {
       return;
     }
     const normalized = Math.max(0, Number(scrollTop || 0));
-    listNode.classList.add("manual-scroll");
+    if (!listNode.classList.contains("manual-scroll")) {
+      listNode.classList.add("manual-scroll");
+    }
     listNode.dataset.manualScrollTop = String(normalized);
-    listNode.style.setProperty("--stream-route-manual-scroll", `${-normalized}px`);
-    try {
-      listNode.scrollTop = 0;
-    } catch (_) {
-      // Ignore webOS scrollTop assignment failures; the manual transform is authoritative.
+    if (Number(listNode.scrollTop || 0) !== 0) {
+      try {
+        listNode.scrollTop = 0;
+      } catch (_) {
+        // Ignore webOS scrollTop assignment failures; the manual transform is authoritative.
+      }
     }
     this.updateManualListScrollTransform(listNode, normalized);
     this.listScrollTop = normalized;
   },
 
-  setListScrollTop(listNode, nextScrollTop) {
+  // maxScrollOverride exists because scrollHeight is not usable once the track
+  // is transformed: Chromium's scrollable overflow includes transformed
+  // descendants, so translating the track up shrinks scrollHeight toward
+  // clientHeight and the ceiling collapses as you scroll. Callers that know the
+  // real content height from the geometry model pass it in.
+  setListScrollTop(listNode, nextScrollTop, maxScrollOverride = null) {
     if (!listNode) {
       return;
     }
-    const maxScrollTop = Math.max(
-      0,
-      Number(listNode.scrollHeight || 0) - Number(listNode.clientHeight || 0)
-    );
+    const maxScrollTop =
+      Number(maxScrollOverride) >= 0
+        ? Number(maxScrollOverride)
+        : Math.max(
+            0,
+            Number(listNode.scrollHeight || 0) - Number(listNode.clientHeight || 0)
+          );
     const normalized = clamp(Number(nextScrollTop || 0), 0, maxScrollTop);
     if (listNode.classList?.contains("manual-scroll")) {
       this.applyManualListScroll(listNode, normalized);
@@ -1733,9 +1916,61 @@ export const StreamScreen = {
     this.listScrollTop = Number(applied || normalized || 0);
   },
 
+  // Total content height straight from the geometry model, plus the trailing
+  // loader card when sources are still arriving. Independent of scrollHeight,
+  // which is unreliable under the manual-scroll transform.
+  getVirtualContentHeight(listNode, total) {
+    let height = this.getRowOffset(total, total);
+    const loader = listNode?.querySelector?.(
+      ".stream-route-card-row:not([data-stream-row])"
+    );
+    if (loader) {
+      height += Number(loader.offsetHeight || 0) + Number(this.rowGapPx || 0);
+    }
+    return height;
+  },
+
+  getVirtualMaxScroll(listNode, total, viewport) {
+    return Math.max(0, this.getVirtualContentHeight(listNode, total) - viewport);
+  },
+
+  // Keeps the focused row pinned to whichever edge it is leaving, so holding a
+  // direction scrolls the list underneath a focus marker that never leaves the
+  // screen. All in model coordinates, which are exact for rendered rows.
+  scrollVirtualRowIntoView(listNode, row) {
+    const total = this.getVisibleStreamCount();
+    if (!total) {
+      return true;
+    }
+    const viewport = this.getListViewportHeight(listNode);
+    const current = this.getListScrollTop(listNode);
+    const maxScroll = this.getVirtualMaxScroll(listNode, total, viewport);
+    const next = projectScrollForRow({
+      offsets: this.ensureRowOffsets(total),
+      row,
+      scrollTop: current,
+      viewportHeight: viewport,
+      pad: WEBOS_VIRTUAL_VISIBILITY_PAD_PX,
+      maxScroll
+    });
+    if (next !== current) {
+      this.setListScrollTop(listNode, next, maxScroll);
+    }
+    return true;
+  },
+
   ensureListItemVisible(listNode, target) {
     if (!listNode || !target) {
       return;
+    }
+    // Under virtualisation the model is the coordinate system the spacers are
+    // built from, so use it rather than rects — mixing the two is what let the
+    // scroll position and the model drift apart.
+    if (this.isVirtualListEnabled()) {
+      const row = Number(target.dataset?.streamRow ?? -1);
+      if (row >= 0) {
+        return this.scrollVirtualRowIntoView(listNode, row);
+      }
     }
     const viewTop = this.getListScrollTop(listNode);
     let itemTop = Number(target.offsetTop || 0);
@@ -1758,7 +1993,7 @@ export const StreamScreen = {
     }
     const viewHeight = Number(listNode.clientHeight || 0);
     if (!viewHeight) {
-      return;
+      return false;
     }
     const viewBottom = viewTop + viewHeight;
     const pad = 16;
@@ -1767,9 +2002,13 @@ export const StreamScreen = {
     } else if (itemTop < viewTop + pad) {
       this.setListScrollTop(listNode, itemTop - pad);
     }
+    return true;
   },
 
-  scheduleFocusedListItemVisibilityCheck(listNode, target) {
+  // Only re-measure when the first pass could not (the list had no box yet,
+  // which happens on the render right after the route mounts). Re-running it
+  // unconditionally cost a second forced layout of the whole list per keypress.
+  scheduleFocusedListItemVisibilityCheck(listNode, target, measured = false) {
     if (!listNode || !target) {
       return;
     }
@@ -1778,7 +2017,9 @@ export const StreamScreen = {
       if (!this.container || !root?.contains?.(listNode) || !root?.contains?.(target)) {
         return;
       }
-      this.ensureListItemVisible(listNode, target);
+      if (!measured) {
+        this.ensureListItemVisible(listNode, target);
+      }
       this.requestStreamBadgeHydration();
     };
     if (typeof requestAnimationFrame === "function") {
@@ -1788,23 +2029,48 @@ export const StreamScreen = {
     setTimeout(run, 0);
   },
 
+  getChipNodes() {
+    const cached = this.chipNodesCache;
+    if (cached?.length && this.container?.contains(cached[0])) {
+      return cached;
+    }
+    const chips = Array.from(
+      this.container?.querySelectorAll(".stream-route-chip.focusable") || []
+    );
+    this.chipNodesCache = chips;
+    return chips;
+  },
+
+  // rowCount comes from the stream list rather than the DOM: under
+  // virtualisation the DOM only holds a window, so DOM length is not the
+  // navigable range and DOM position is not the row index.
   getFocusLists() {
-    const chips = Array.from(this.container.querySelectorAll(".stream-route-chip.focusable"));
-    const rows = this.getCardRows();
-    return { chips, rows };
+    return {
+      chips: this.getChipNodes(),
+      rowCount: this.getCardRows().size ? this.getVisibleStreamCount() : 0
+    };
   },
 
   applyFocus() {
-    const { chips, rows } = this.getFocusLists();
-    if (!chips.length && !rows.length) {
+    const { chips, rowCount } = this.getFocusLists();
+    if (!chips.length && !rowCount) {
       return;
     }
-    const zone = this.focusState?.zone || (rows.length ? "card" : "filter");
+    const zone = this.focusState?.zone || (rowCount ? "card" : "filter");
     const index = Number(this.focusState?.index || 0);
-    if (zone === "card" && rows.length) {
-      const rowIndex = clamp(Number(this.focusState?.row || 0), 0, rows.length - 1);
+    if (zone === "card" && rowCount) {
+      const rowIndex = clamp(Number(this.focusState?.row || 0), 0, rowCount - 1);
       const preferredAction = String(this.focusState?.action || "play");
-      const target = this.resolveCardActionForRow(rows[rowIndex], preferredAction);
+      this.syncVirtualWindowForRow(rowIndex);
+      let target = this.resolveCardActionForRow(this.getCardRow(rowIndex), preferredAction);
+      if (!target) {
+        // syncVirtualWindowForRow is supposed to guarantee the row is resident.
+        // If it somehow is not, rebuild the window centred on it rather than
+        // leaving the focus marker on a card that no longer exists — that is
+        // what strands the list with nothing visibly focused.
+        this.forceVirtualWindowOnRow(rowIndex);
+        target = this.resolveCardActionForRow(this.getCardRow(rowIndex), preferredAction);
+      }
       const resolvedAction = target?.dataset?.cardAction || "play";
       this.focusState = { zone: "card", row: rowIndex, action: resolvedAction };
       this.focusElement(target);
@@ -1819,7 +2085,14 @@ export const StreamScreen = {
     if (!list) {
       return;
     }
-    this.setListScrollTop(list, Number(this.listScrollTop || 0));
+    const max = this.isVirtualListEnabled()
+      ? this.getVirtualMaxScroll(
+          list,
+          this.getVisibleStreamCount(),
+          this.getListViewportHeight(list)
+        )
+      : null;
+    this.setListScrollTop(list, Number(this.listScrollTop || 0), max);
   },
 
   getHeaderMeta() {
@@ -2133,8 +2406,15 @@ export const StreamScreen = {
   renderStreamCard(stream, index, streamBadgesEnabled = true, badgeSettings = null) {
     const headline = getStreamHeadline(stream);
     const quality = getStreamQuality(stream);
+    // Lazy badges exist to bound how many badge images live in the DOM. The
+    // virtual list already bounds that to the rendered window, and hydrating
+    // after a card is measured would change its height behind the geometry
+    // model's back — which desynchronises the model from the real scroll
+    // position. Render them inline whenever the window is doing the bounding.
     const lazyBadges =
-      Environment.isWebOS() && hasStreamBadges(stream, streamBadgesEnabled, badgeSettings);
+      Environment.isWebOS() &&
+      !this.isVirtualListEnabled() &&
+      hasStreamBadges(stream, streamBadgesEnabled, badgeSettings);
     const badges = lazyBadges
       ? `<div class="stream-route-card-badges stream-route-card-badges-lazy" data-lazy-stream-badges data-stream-badge-row="${index}" data-badges-hydrated="false" aria-label="${escapeHtml(t("settings_stream_badges_section", {}, "Fusion Style"))}"></div>`
       : renderStreamBadges(stream, streamBadgesEnabled, badgeSettings);
@@ -2189,6 +2469,292 @@ export const StreamScreen = {
     `;
   },
 
+  isRowRendered(index) {
+    return this.getCardRows().has(Number(index));
+  },
+
+  resetVirtualGeometry() {
+    this.rowHeights = [];
+    this.rowOffsets = null;
+    this.rowGapPx = 0;
+    this.virtualRange = null;
+  },
+
+  // Row heights are indexed by position in the filtered list, so they have to be
+  // dropped when that list is refiltered or reordered. Length plus the ids at
+  // both ends is enough to catch every case that matters; a reorder that keeps
+  // all three is absorbed by the spacer anchoring anyway.
+  syncVirtualGeometryKey(filtered = []) {
+    const key = [
+      this.addonFilter,
+      filtered.length,
+      filtered[0]?.id || "",
+      filtered[filtered.length - 1]?.id || ""
+    ].join("|");
+    if (this.virtualGeometryKey !== key) {
+      this.virtualGeometryKey = key;
+      this.resetVirtualGeometry();
+    }
+  },
+
+  renderVirtualSpacer(position, height) {
+    const px = Math.max(0, Math.round(Number(height || 0)));
+    return `<div class="stream-route-virtual-spacer" data-virtual-spacer="${position}" style="height:${px}px"></div>`;
+  },
+
+  renderCardWindow(filtered, range, streamBadgesEnabled, badgeSettings) {
+    const total = filtered.length;
+    if (!total || range.end < range.start) {
+      return "";
+    }
+    const start = clamp(Number(range.start || 0), 0, Math.max(0, total - 1));
+    const end = clamp(Number(range.end ?? start), start, Math.max(0, total - 1));
+    const cards = [];
+    for (let index = start; index <= end; index += 1) {
+      cards.push(
+        this.renderStreamCard(filtered[index], index, streamBadgesEnabled, badgeSettings)
+      );
+    }
+    const topHeight = this.getRowOffset(start, total);
+    const bottomHeight = this.getRowOffset(total, total) - this.getRowOffset(end + 1, total);
+    return (
+      this.renderVirtualSpacer("top", topHeight) +
+      cards.join("") +
+      this.renderVirtualSpacer("bottom", bottomHeight)
+    );
+  },
+
+  applyVirtualSpacerHeights(track, range, total) {
+    const top = track?.querySelector('[data-virtual-spacer="top"]');
+    const bottom = track?.querySelector('[data-virtual-spacer="bottom"]');
+    if (top) {
+      top.style.height = `${Math.max(0, Math.round(this.getRowOffset(range.start, total)))}px`;
+    }
+    if (bottom) {
+      const height = this.getRowOffset(total, total) - this.getRowOffset(range.end + 1, total);
+      bottom.style.height = `${Math.max(0, Math.round(height))}px`;
+    }
+  },
+
+  // offsetTop deltas between consecutive rows give the true stride (box plus
+  // margin) without reading computed styles, which would cost a style resolve
+  // per row on webOS.
+  measureRenderedRows() {
+    const byIndex = this.getCardRows();
+    if (!byIndex.size) {
+      return false;
+    }
+    const measurements = [];
+    byIndex.forEach((entry) => {
+      measurements.push({
+        row: entry.row,
+        top: Number(entry.node.offsetTop || 0),
+        height: Number(entry.node.offsetHeight || 0)
+      });
+    });
+    const { strides, gap } = deriveRowStrides(measurements, this.rowGapPx);
+    this.rowGapPx = gap;
+    let changed = false;
+    strides.forEach((stride, row) => {
+      if (Math.abs(Number(this.rowHeights[row] || 0) - stride) > 0.5) {
+        this.rowHeights[row] = stride;
+        changed = true;
+      }
+    });
+    if (changed) {
+      this.rowOffsets = null;
+    }
+    return changed;
+  },
+
+  getRowViewportTop(listNode, index) {
+    if (!listNode || index === null || index === undefined) {
+      return null;
+    }
+    const entry = this.getCardRow(index);
+    if (!entry?.node) {
+      return null;
+    }
+    return (
+      entry.node.getBoundingClientRect().top - listNode.getBoundingClientRect().top
+    );
+  },
+
+  findFirstRowInView(listNode) {
+    const byIndex = this.getCardRows();
+    if (!byIndex.size || !listNode) {
+      return null;
+    }
+    const listTop = listNode.getBoundingClientRect().top;
+    let best = null;
+    let bestTop = Number.POSITIVE_INFINITY;
+    byIndex.forEach((entry) => {
+      const top = entry.node.getBoundingClientRect().top - listTop;
+      if (top >= -1 && top < bestTop) {
+        bestTop = top;
+        best = entry.row;
+      }
+    });
+    return best;
+  },
+
+  // Swaps the rendered window. Everything visible is pinned to anchorRow so an
+  // inaccurate spacer estimate can never surface as a visible jump.
+  renderVirtualRows(range, anchorRow = null) {
+    const list = this.container?.querySelector(".stream-route-list");
+    const track = this.getListTrack(list);
+    if (!list || !track) {
+      return false;
+    }
+    const filtered = this.getFilteredStreams();
+    const anchorBefore = this.getRowViewportTop(list, anchorRow);
+
+    track.innerHTML =
+      this.renderCardWindow(
+        filtered,
+        range,
+        DebridSettingsStore.get().streamBadgesEnabled !== false,
+        StreamBadgeSettingsStore.snapshot()
+      ) + (this.hasPendingSourceLoads() ? this.renderLoadingCards(1) : "");
+
+    this.virtualRange = { start: range.start, end: range.end };
+    this.cardRowsCache = null;
+    this.focusedNode = null;
+    ScreenUtils.indexFocusables(this.container);
+    this.measureRenderedRows();
+    this.applyVirtualSpacerHeights(track, this.virtualRange, filtered.length);
+
+    const anchorAfter = this.getRowViewportTop(list, anchorRow);
+    if (anchorBefore !== null && anchorAfter !== null) {
+      const delta = anchorAfter - anchorBefore;
+      if (Math.abs(delta) > 0.5) {
+        this.setListScrollTop(
+          list,
+          this.getListScrollTop(list) + delta,
+          this.getVirtualMaxScroll(list, filtered.length, this.getListViewportHeight(list))
+        );
+      }
+    }
+    this.hydrateVisibleStreamBadges();
+    return true;
+  },
+
+  // The window rendered inline by render() still has estimate-sized spacers.
+  // Measure it once so the first D-pad step already works off real geometry.
+  measureInitialVirtualRows() {
+    if (!this.virtualRange) {
+      return;
+    }
+    const list = this.container?.querySelector(".stream-route-list");
+    const track = this.getListTrack(list);
+    if (!track) {
+      return;
+    }
+    const anchorBefore = this.getRowViewportTop(list, this.virtualRange.start);
+    if (!this.measureRenderedRows()) {
+      return;
+    }
+    this.applyVirtualSpacerHeights(track, this.virtualRange, this.getVisibleStreamCount());
+    const anchorAfter = this.getRowViewportTop(list, this.virtualRange.start);
+    if (anchorBefore !== null && anchorAfter !== null) {
+      const delta = anchorAfter - anchorBefore;
+      if (Math.abs(delta) > 0.5) {
+        const total = this.getVisibleStreamCount();
+        this.setListScrollTop(
+          list,
+          this.getListScrollTop(list) + delta,
+          this.getVirtualMaxScroll(list, total, this.getListViewportHeight(list))
+        );
+      }
+    }
+  },
+
+  // Where the list will end up scrolled once this row is focused. Measured rects
+  // are preferred over the geometry model whenever the row is already rendered:
+  // ensureListItemVisible does the actual scrolling from rects, so deriving the
+  // window from the model instead would let the two drift apart and then feed
+  // that drift back into the next window.
+  getProjectedScrollForRow(listNode, focus, total, viewport) {
+    return projectScrollForRow({
+      offsets: this.ensureRowOffsets(total),
+      row: focus,
+      scrollTop: this.getListScrollTop(listNode),
+      viewportHeight: viewport,
+      pad: WEBOS_VIRTUAL_VISIBILITY_PAD_PX,
+      maxScroll: this.getVirtualMaxScroll(listNode, total, viewport)
+    });
+  },
+
+  // Called before focusing a row: makes sure that row exists in the DOM. The
+  // model offsets only choose the window here — focusElement then scrolls using
+  // real rects, so an estimate being wrong costs nothing.
+  syncVirtualWindowForRow(rowIndex) {
+    if (!this.isVirtualListEnabled()) {
+      return;
+    }
+    const list = this.container?.querySelector(".stream-route-list");
+    if (!list) {
+      return;
+    }
+    const total = this.getVisibleStreamCount();
+    if (!total) {
+      return;
+    }
+    const focus = clamp(Number(rowIndex || 0), 0, total - 1);
+    const viewport = this.getListViewportHeight(list);
+    const projected = this.getProjectedScrollForRow(list, focus, total, viewport);
+    const range = this.computeVirtualRange(projected, viewport, total, focus);
+    if (this.virtualRangeNeedsRefresh(range, total)) {
+      this.renderVirtualRows(range, this.isRowRendered(focus) ? focus : null);
+    }
+  },
+
+  // Last-resort recovery: put the window on this row no matter what the current
+  // scroll offset or geometry model say.
+  forceVirtualWindowOnRow(rowIndex) {
+    if (!this.isVirtualListEnabled()) {
+      return;
+    }
+    const list = this.container?.querySelector(".stream-route-list");
+    const total = this.getVisibleStreamCount();
+    if (!list || !total) {
+      return;
+    }
+    const viewport = this.getListViewportHeight(list);
+    const focus = clamp(Number(rowIndex || 0), 0, total - 1);
+    this.renderVirtualRows(
+      this.computeVirtualRange(this.getRowOffset(focus, total), viewport, total, focus),
+      null
+    );
+  },
+
+  // Pointer and wheel scrolling drive the window directly. Focus is deliberately
+  // not re-applied, so scrolling away from the focused card does not yank the
+  // list back to it.
+  syncVirtualWindowForScroll(listNode) {
+    if (!this.isVirtualListEnabled() || !listNode) {
+      return;
+    }
+    const total = this.getVisibleStreamCount();
+    if (!total) {
+      return;
+    }
+    // No focus row is pinned here on purpose: pinning it would stretch the
+    // window from the focused card all the way to wherever the user scrolled.
+    // The next D-pad press goes through syncVirtualWindowForRow, which brings
+    // the focused row back before anything tries to focus it.
+    const range = this.computeVirtualRange(
+      this.getListScrollTop(listNode),
+      this.getListViewportHeight(listNode),
+      total,
+      null
+    );
+    if (!this.virtualRangeNeedsRefresh(range, total)) {
+      return;
+    }
+    this.renderVirtualRows(range, this.findFirstRowInView(listNode));
+  },
+
   renderLoadingCards(count = 3) {
     return `
       <div class="stream-route-card-row">
@@ -2206,6 +2772,7 @@ export const StreamScreen = {
 
   render() {
     this.cancelScheduledRender();
+    this.invalidateStreamRouteCaches();
     const { isSeries, title, subtitle, episodeLabel, detailLine } = this.getHeaderMeta();
     const backdrop = this.getBackdropUrl();
     const logo = this.params?.logo || "";
@@ -2229,13 +2796,31 @@ export const StreamScreen = {
     const showAddonLogo = badgeSettings.showAddonLogo === true;
     const addonLogosReady = !showAddonLogo || !filtered.length || this.areAddonLogosReady(filtered);
 
+    this.syncVirtualGeometryKey(filtered);
+    this.virtualRange = null;
+
     let body = "";
     if (filtered.length && addonLogosReady) {
-      body = filtered
-        .map((stream, index) =>
-          this.renderStreamCard(stream, index, streamBadgesEnabled, badgeSettings)
-        )
-        .join("");
+      if (this.isVirtualListEnabled()) {
+        // The list box does not exist yet, so seed the window from the last known
+        // viewport and the restored scroll offset. applyFocus() re-derives it
+        // against the real box immediately after this markup lands.
+        const range = this.computeVirtualRange(
+          Number(this.listScrollTop || 0),
+          this.getListViewportHeight(null),
+          filtered.length,
+          this.focusState?.zone === "card" ? Number(this.focusState?.row || 0) : null
+        );
+        this.virtualRange = { start: range.start, end: range.end };
+        body = this.renderCardWindow(filtered, range, streamBadgesEnabled, badgeSettings);
+      } else {
+        this.virtualRange = null;
+        body = filtered
+          .map((stream, index) =>
+            this.renderStreamCard(stream, index, streamBadgesEnabled, badgeSettings)
+          )
+          .join("");
+      }
       if (hasPendingForFilter) {
         body += this.renderLoadingCards(1);
       }
@@ -2268,7 +2853,7 @@ export const StreamScreen = {
             </div>
             <div class="stream-route-panel-shell">
               <div class="stream-route-panel">
-                <div class="stream-route-list">${body}</div>
+                <div class="stream-route-list"><div class="stream-route-list-track">${body}</div></div>
               </div>
             </div>
           </section>
@@ -2286,11 +2871,13 @@ export const StreamScreen = {
       </div>
     `;
 
+    // Restore once, then measure. The second restore that used to sit after
+    // indexFocusables only re-forced a whole-list layout.
     this.restoreScrollPosition();
+    this.measureInitialVirtualRows();
     this.hydrateVisibleStreamBadges();
     this.bindAddonLogoFallbacks();
     ScreenUtils.indexFocusables(this.container);
-    this.restoreScrollPosition();
     this.applyFocus();
     this.bindListScrollState();
     this.hasRenderedStreamRouteShell = true;
@@ -2305,6 +2892,7 @@ export const StreamScreen = {
       "scroll",
       () => {
         this.listScrollTop = this.getListScrollTop(list);
+        this.syncVirtualWindowForScroll(list);
         this.requestStreamBadgeHydration();
       },
       { passive: true }
@@ -2320,7 +2908,17 @@ export const StreamScreen = {
             return;
           }
           event?.preventDefault?.();
-          this.setListScrollTop(list, this.getListScrollTop(list) + deltaY);
+          const max = this.isVirtualListEnabled()
+            ? this.getVirtualMaxScroll(
+                list,
+                this.getVisibleStreamCount(),
+                this.getListViewportHeight(list)
+              )
+            : null;
+          this.setListScrollTop(list, this.getListScrollTop(list) + deltaY, max);
+          // Manual scroll clips the list, so no scroll event fires to drive the
+          // window; do it here.
+          this.syncVirtualWindowForScroll(list);
           this.requestStreamBadgeHydration();
         },
         { passive: false }
@@ -2357,9 +2955,6 @@ export const StreamScreen = {
     if (!list || !placeholders.length) {
       return;
     }
-    const filtered = this.getFilteredStreams();
-    const streamBadgesEnabled = DebridSettingsStore.get().streamBadgesEnabled !== false;
-    const badgeSettings = StreamBadgeSettingsStore.snapshot();
     const listRect = list.getBoundingClientRect();
     const overscan = Math.max(
       WEBOS_STREAM_BADGE_MIN_OVERSCAN_PX,
@@ -2373,6 +2968,12 @@ export const StreamScreen = {
     // Android's LazyColumn only composes badge images near the viewport. Keep
     // the complete Web card list for existing remote/pointer navigation, but
     // apply the same bounded image/DOM lifetime on webOS.
+    //
+    // Measure every placeholder first, mutate afterwards. Interleaving the two
+    // made each innerHTML write invalidate layout for the next rect read, so a
+    // single D-pad step forced one full layout of the entire card list per
+    // hydrated row.
+    const pending = [];
     placeholders.forEach((placeholder) => {
       const rowIndex = Number(placeholder.dataset.streamBadgeRow || -1);
       const card = placeholder.closest(".stream-route-card-row");
@@ -2384,17 +2985,29 @@ export const StreamScreen = {
       );
       const shouldHydrate = rowIndex === focusedRow || nearViewport;
       const hydrated = placeholder.dataset.badgesHydrated === "true";
-      if (shouldHydrate && !hydrated) {
+      if (shouldHydrate !== hydrated) {
+        pending.push({ placeholder, rowIndex, shouldHydrate });
+      }
+    });
+    if (!pending.length) {
+      return;
+    }
+
+    const filtered = this.getFilteredStreams();
+    const streamBadgesEnabled = DebridSettingsStore.get().streamBadgesEnabled !== false;
+    const badgeSettings = StreamBadgeSettingsStore.snapshot();
+    pending.forEach(({ placeholder, rowIndex, shouldHydrate }) => {
+      if (shouldHydrate) {
         placeholder.innerHTML = renderStreamBadgeContents(
           filtered[rowIndex],
           streamBadgesEnabled,
           badgeSettings
         );
         placeholder.dataset.badgesHydrated = "true";
-      } else if (!shouldHydrate && hydrated) {
-        placeholder.textContent = "";
-        placeholder.dataset.badgesHydrated = "false";
+        return;
       }
+      placeholder.textContent = "";
+      placeholder.dataset.badgesHydrated = "false";
     });
   },
 
@@ -2582,8 +3195,8 @@ export const StreamScreen = {
 
     const direction = getDpadDirection(event);
     if (direction) {
-      const { chips, rows } = this.getFocusLists();
-      const zone = this.focusState?.zone || (rows.length ? "card" : "filter");
+      const { chips, rowCount } = this.getFocusLists();
+      const zone = this.focusState?.zone || (rowCount ? "card" : "filter");
       let index = Number(this.focusState?.index || 0);
       event?.preventDefault?.();
 
@@ -2616,7 +3229,7 @@ export const StreamScreen = {
           }
           return;
         }
-        if (direction === "down" && rows.length) {
+        if (direction === "down" && rowCount) {
           this.focusState = { zone: "card", row: 0, action: "play" };
           this.applyFocus();
         }
@@ -2624,17 +3237,17 @@ export const StreamScreen = {
       }
 
       if (zone === "card") {
-        const rowIndex = clamp(Number(this.focusState?.row || 0), 0, Math.max(0, rows.length - 1));
-        const currentRow = rows[rowIndex] || null;
+        const rowIndex = clamp(Number(this.focusState?.row || 0), 0, Math.max(0, rowCount - 1));
+        const currentRow = this.getCardRow(rowIndex);
         const currentAction = String(this.focusState?.action || "play");
         if (direction === "up") {
           if (rowIndex > 0) {
-            const previousRow = rows[rowIndex - 1] || null;
-            const target = this.resolveCardActionForRow(previousRow, currentAction);
+            // The target action is resolved in applyFocus(), once the row it
+            // names is guaranteed to be inside the rendered window.
             this.focusState = {
               zone: "card",
               row: rowIndex - 1,
-              action: String(target?.dataset?.cardAction || "play")
+              action: currentAction
             };
             this.applyFocus();
             return;
@@ -2651,13 +3264,10 @@ export const StreamScreen = {
           return;
         }
         if (direction === "down") {
-          const nextRowIndex = clamp(rowIndex + 1, 0, Math.max(0, rows.length - 1));
-          const nextRow = rows[nextRowIndex] || null;
-          const target = this.resolveCardActionForRow(nextRow, currentAction);
           this.focusState = {
             zone: "card",
-            row: nextRowIndex,
-            action: String(target?.dataset?.cardAction || "play")
+            row: clamp(rowIndex + 1, 0, Math.max(0, rowCount - 1)),
+            action: currentAction
           };
           this.applyFocus();
           return;

--- a/js/ui/screens/stream/streamVirtualList.js
+++ b/js/ui/screens/stream/streamVirtualList.js
@@ -1,0 +1,206 @@
+// Geometry for the stream picker's virtual list.
+//
+// Stream cards are not a uniform height — description lines and badge wrapping
+// both change it — so the row model is measured where it can be and estimated
+// everywhere else. Nothing here touches the DOM: these functions only decide
+// which rows are worth rendering and how tall the spacers standing in for the
+// rest should be. The screen anchors the visible content across every window
+// swap, so an estimate being wrong costs a spacer resize, never a visible jump.
+
+export const VIRTUAL_LIST_FALLBACK_ROW_HEIGHT = 150;
+export const VIRTUAL_LIST_FALLBACK_VIEWPORT_PX = 720;
+export const VIRTUAL_LIST_OVERSCAN_ROWS = 6;
+export const VIRTUAL_LIST_REFRESH_MARGIN_ROWS = 2;
+
+function toCount(value) {
+  const count = Math.floor(Number(value || 0));
+  return count > 0 ? count : 0;
+}
+
+export function estimateRowHeight(rowHeights = []) {
+  let sum = 0;
+  let count = 0;
+  rowHeights.forEach((height) => {
+    if (Number(height) > 0) {
+      sum += Number(height);
+      count += 1;
+    }
+  });
+  return count ? sum / count : VIRTUAL_LIST_FALLBACK_ROW_HEIGHT;
+}
+
+// offsets[i] is the top of row i; offsets[total] is the full content height.
+export function buildRowOffsets(rowHeights = [], total = 0, estimate = 0) {
+  const count = toCount(total);
+  const fallback =
+    Number(estimate) > 0 ? Number(estimate) : estimateRowHeight(rowHeights);
+  const offsets = new Array(count + 1);
+  offsets[0] = 0;
+  for (let index = 0; index < count; index += 1) {
+    const measured = Number(rowHeights[index] || 0);
+    offsets[index + 1] = offsets[index] + (measured > 0 ? measured : fallback);
+  }
+  return offsets;
+}
+
+// Index of the row containing `offset`, clamped to the row range.
+export function findRowAtOffset(offsets = [0], offset = 0) {
+  const lastRow = Math.max(0, offsets.length - 2);
+  const target = Math.max(0, Number(offset || 0));
+  let low = 0;
+  let high = lastRow;
+  while (low < high) {
+    const mid = (low + high) >> 1;
+    if (offsets[mid + 1] <= target) {
+      low = mid + 1;
+    } else {
+      high = mid;
+    }
+  }
+  return low;
+}
+
+// Turns measurements of the rendered window into per-row strides (box height
+// plus the margin between rows). The margin is inferred from the gap between
+// two consecutive rows' offsetTops rather than read from computed style, which
+// would cost a style resolve per row. `previousGap` carries the last inferred
+// margin so the final row of a window — which has no successor to measure
+// against — still gets a correct stride.
+export function deriveRowStrides(measurements = [], previousGap = 0) {
+  const rows = measurements
+    .filter((entry) => Number(entry?.height) > 0)
+    .sort((left, right) => left.row - right.row);
+  let gap = Number(previousGap) > 0 ? Number(previousGap) : 0;
+  for (let index = 0; index + 1 < rows.length; index += 1) {
+    if (rows[index + 1].row !== rows[index].row + 1) {
+      continue;
+    }
+    const candidate = rows[index + 1].top - rows[index].top - rows[index].height;
+    // A negative or absurd gap means the rows were not laid out as a simple
+    // vertical stack (mid-render, or a wrapped/absolute row); keep the old one.
+    if (candidate >= 0 && candidate < 200) {
+      gap = candidate;
+    }
+  }
+  const strides = new Map();
+  rows.forEach((entry) => {
+    strides.set(entry.row, entry.height + gap);
+  });
+  return { strides, gap };
+}
+
+// Where the list must be scrolled for `row` to be visible, in model
+// coordinates. A row leaving the bottom of the viewport is pinned to the bottom
+// edge and one leaving the top is pinned to the top edge, so holding a direction
+// scrolls the list underneath a focus marker that stays on screen. Returns the
+// current offset unchanged when the row is already comfortably visible.
+export function projectScrollForRow({
+  offsets = [0],
+  row = 0,
+  scrollTop = 0,
+  viewportHeight = 0,
+  pad = 0,
+  maxScroll = Number.POSITIVE_INFINITY
+} = {}) {
+  const index = Math.max(0, Math.floor(Number(row || 0)));
+  const top = Number(offsets[index] ?? 0);
+  const bottom = Number(offsets[index + 1] ?? top);
+  const viewport =
+    Number(viewportHeight) > 0 ? Number(viewportHeight) : VIRTUAL_LIST_FALLBACK_VIEWPORT_PX;
+  const current = Math.max(0, Number(scrollTop || 0));
+  let next = current;
+  if (bottom > current + viewport - pad) {
+    next = bottom - viewport + pad;
+  } else if (top < current + pad) {
+    next = top - pad;
+  }
+  return Math.min(Math.max(0, next), Math.max(0, Number(maxScroll)));
+}
+
+export function computeVirtualRange({
+  offsets = [0],
+  scrollTop = 0,
+  viewportHeight = 0,
+  total = 0,
+  focusRow = null,
+  overscan = VIRTUAL_LIST_OVERSCAN_ROWS
+} = {}) {
+  const count = toCount(total);
+  if (!count) {
+    return { start: 0, end: -1, first: 0, last: -1, requiredStart: 0, requiredEnd: -1 };
+  }
+  const viewport =
+    Number(viewportHeight) > 0 ? Number(viewportHeight) : VIRTUAL_LIST_FALLBACK_VIEWPORT_PX;
+  const top = Math.max(0, Number(scrollTop || 0));
+  const first = findRowAtOffset(offsets, top);
+  const last = findRowAtOffset(offsets, top + viewport);
+  // The rows that must be resident: everything on screen, plus the focused row,
+  // which focus and rect maths both need in the DOM even when it is off screen.
+  let requiredStart = first;
+  let requiredEnd = last;
+  // Guard the nullish cases explicitly: Number(null) is 0, which would silently
+  // pin row 0 as resident and stretch every window back to the top of the list.
+  const focus =
+    focusRow === null || focusRow === undefined ? Number.NaN : Number(focusRow);
+  if (Number.isFinite(focus) && focus >= 0 && focus < count) {
+    if (focus < first - overscan || focus > last + overscan) {
+      // The focused row is nowhere near the viewport, either because the screen
+      // is about to jump there or because the geometry model has drifted out of
+      // step with the real scroll position. Either way the caller scrolls to the
+      // focused row immediately after, so render around it rather than spanning
+      // the gap — spanning is what turns drift into a window the size of the
+      // whole list.
+      requiredStart = focus;
+      requiredEnd = focus;
+    } else {
+      requiredStart = Math.min(requiredStart, focus);
+      requiredEnd = Math.max(requiredEnd, focus);
+    }
+  }
+  return {
+    start: Math.max(0, requiredStart - overscan),
+    end: Math.min(count - 1, requiredEnd + overscan),
+    first,
+    last,
+    requiredStart,
+    requiredEnd
+  };
+}
+
+// Rebuild only once the viewport eats into the overscan, so stepping one row at
+// a time swaps the window every few rows instead of on every keypress.
+export function virtualRangeNeedsRefresh({
+  current = null,
+  next = null,
+  total = 0,
+  margin = VIRTUAL_LIST_REFRESH_MARGIN_ROWS
+} = {}) {
+  if (!next) {
+    return false;
+  }
+  if (!current || current.end < current.start) {
+    return true;
+  }
+  const count = toCount(total);
+  if (!count) {
+    return false;
+  }
+  if (current.end > count - 1) {
+    return true;
+  }
+  // Compare against the rows that must be resident, not the overscan-expanded
+  // window: the expanded window grows past the current one on the very first
+  // step, which would rebuild on every keypress and defeat the overscan.
+  const requiredStart = Number(next.requiredStart ?? next.first ?? next.start);
+  const requiredEnd = Number(next.requiredEnd ?? next.last ?? next.end);
+  if (requiredStart < current.start || requiredEnd > current.end) {
+    return true;
+  }
+  if (current.start > 0 && requiredStart - current.start < margin) {
+    return true;
+  }
+  if (current.end < count - 1 && current.end - requiredEnd < margin) {
+    return true;
+  }
+  return false;
+}

--- a/js/ui/screens/stream/streamVirtualList.test.mjs
+++ b/js/ui/screens/stream/streamVirtualList.test.mjs
@@ -1,0 +1,461 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  VIRTUAL_LIST_FALLBACK_ROW_HEIGHT,
+  VIRTUAL_LIST_OVERSCAN_ROWS,
+  buildRowOffsets,
+  computeVirtualRange,
+  deriveRowStrides,
+  estimateRowHeight,
+  findRowAtOffset,
+  projectScrollForRow,
+  virtualRangeNeedsRefresh
+} from "./streamVirtualList.js";
+
+test("a row leaving the bottom is pinned to the bottom edge", () => {
+  const offsets = buildRowOffsets([], 100, 100);
+  // Viewport 0-600 shows rows 0-5; focusing row 6 (600-700) pins it to the bottom.
+  const next = projectScrollForRow({
+    offsets,
+    row: 6,
+    scrollTop: 0,
+    viewportHeight: 600,
+    pad: 16
+  });
+  assert.equal(next, 700 - 600 + 16);
+});
+
+test("a row leaving the top is pinned to the top edge", () => {
+  const offsets = buildRowOffsets([], 100, 100);
+  const next = projectScrollForRow({
+    offsets,
+    row: 3,
+    scrollTop: 1000,
+    viewportHeight: 600,
+    pad: 16
+  });
+  assert.equal(next, 300 - 16);
+});
+
+test("a comfortably visible row does not move the list", () => {
+  const offsets = buildRowOffsets([], 100, 100);
+  const next = projectScrollForRow({
+    offsets,
+    row: 12,
+    scrollTop: 1000,
+    viewportHeight: 600,
+    pad: 16
+  });
+  assert.equal(next, 1000, "row 12 sits at 1200-1300, well inside 1000-1600");
+});
+
+test("scroll projection never runs past the end of the content", () => {
+  const total = 100;
+  const offsets = buildRowOffsets([], total, 100);
+  const maxScroll = offsets[total] - 600;
+  const next = projectScrollForRow({
+    offsets,
+    row: total - 1,
+    scrollTop: maxScroll - 10,
+    viewportHeight: 600,
+    pad: 16,
+    maxScroll
+  });
+  assert.equal(next, maxScroll, "the last row clamps to the end of the content");
+  assert.ok(next >= 0);
+});
+
+test("holding a direction walks the list edge to edge without stalling", () => {
+  const total = 300;
+  const viewport = 600;
+  const offsets = buildRowOffsets([], total, 100);
+  const maxScroll = offsets[total] - viewport;
+
+  let scrollTop = 0;
+  for (let row = 0; row < total; row += 1) {
+    const next = projectScrollForRow({
+      offsets,
+      row,
+      scrollTop,
+      viewportHeight: viewport,
+      pad: 16,
+      maxScroll
+    });
+    assert.ok(next >= scrollTop, `row ${row} must not scroll backwards going down`);
+    scrollTop = next;
+    // The focused row is on screen at every single step.
+    assert.ok(
+      offsets[row] >= scrollTop - 1 && offsets[row + 1] <= scrollTop + viewport + 1,
+      `row ${row} left the viewport`
+    );
+  }
+  assert.equal(scrollTop, maxScroll, "must reach the very bottom");
+
+  // And all the way back up.
+  for (let row = total - 1; row >= 0; row -= 1) {
+    const next = projectScrollForRow({
+      offsets,
+      row,
+      scrollTop,
+      viewportHeight: viewport,
+      pad: 16,
+      maxScroll
+    });
+    assert.ok(next <= scrollTop, `row ${row} must not scroll forwards going up`);
+    scrollTop = next;
+    assert.ok(
+      offsets[row] >= scrollTop - 1 && offsets[row + 1] <= scrollTop + viewport + 1,
+      `row ${row} left the viewport going up`
+    );
+  }
+  assert.equal(scrollTop, 0, "must reach the very top");
+});
+
+test("row strides pick up the margin between rows from their offsets", () => {
+  // Three stacked rows, 18px apart, starting below a 400px top spacer.
+  const { strides, gap } = deriveRowStrides([
+    { row: 10, top: 400, height: 200 },
+    { row: 11, top: 618, height: 150 },
+    { row: 12, top: 786, height: 240 }
+  ]);
+  assert.equal(gap, 18);
+  assert.equal(strides.get(10), 218);
+  assert.equal(strides.get(11), 168);
+  // The last row has no successor, but still gets the inferred margin.
+  assert.equal(strides.get(12), 258);
+});
+
+test("row strides ignore unmeasured rows and non-adjacent pairs", () => {
+  const { strides, gap } = deriveRowStrides([
+    { row: 4, top: 0, height: 100 },
+    { row: 5, top: 110, height: 0 },
+    { row: 9, top: 900, height: 100 }
+  ]);
+  // Row 5 has no box yet, so it contributes nothing and rows 4 and 9 are not
+  // adjacent — no gap can be inferred from this window.
+  assert.equal(gap, 0);
+  assert.equal(strides.has(5), false);
+  assert.equal(strides.get(4), 100);
+});
+
+test("row strides keep the last known margin when a window cannot infer one", () => {
+  const { strides, gap } = deriveRowStrides([{ row: 2, top: 0, height: 120 }], 18);
+  assert.equal(gap, 18);
+  assert.equal(strides.get(2), 138);
+});
+
+test("row strides reject nonsensical gaps rather than poisoning the model", () => {
+  // Overlapping rows (mid-render) would otherwise yield a negative margin.
+  const { gap } = deriveRowStrides(
+    [
+      { row: 0, top: 0, height: 300 },
+      { row: 1, top: 100, height: 300 }
+    ],
+    18
+  );
+  assert.equal(gap, 18);
+});
+
+test("unmeasured rows fall back to the average of the measured ones", () => {
+  assert.equal(estimateRowHeight([]), VIRTUAL_LIST_FALLBACK_ROW_HEIGHT);
+  assert.equal(estimateRowHeight([100, 200]), 150);
+
+  const sparse = [];
+  sparse[3] = 220;
+  sparse[9] = 180;
+  assert.equal(estimateRowHeight(sparse), 200);
+  // Holes use the average, measured rows keep their own height.
+  const offsets = buildRowOffsets(sparse, 5, estimateRowHeight(sparse));
+  assert.deepEqual(offsets, [0, 200, 400, 600, 820, 1020]);
+});
+
+test("row offsets accumulate to the full content height", () => {
+  const heights = [100, 150, 200, 250];
+  const offsets = buildRowOffsets(heights, 4);
+  assert.deepEqual(offsets, [0, 100, 250, 450, 700]);
+  assert.equal(offsets[offsets.length - 1], 700);
+});
+
+test("findRowAtOffset lands on the row containing the offset", () => {
+  const offsets = buildRowOffsets([100, 150, 200, 250], 4);
+  assert.equal(findRowAtOffset(offsets, 0), 0);
+  assert.equal(findRowAtOffset(offsets, 99), 0);
+  // A boundary belongs to the row that starts there.
+  assert.equal(findRowAtOffset(offsets, 100), 1);
+  assert.equal(findRowAtOffset(offsets, 249), 1);
+  assert.equal(findRowAtOffset(offsets, 250), 2);
+  assert.equal(findRowAtOffset(offsets, 699), 3);
+  // Past the end clamps to the last row rather than running off it.
+  assert.equal(findRowAtOffset(offsets, 5000), 3);
+  assert.equal(findRowAtOffset(offsets, -50), 0);
+});
+
+test("the window covers the viewport plus overscan on both sides", () => {
+  const total = 300;
+  const offsets = buildRowOffsets([], total, 100);
+  const range = computeVirtualRange({
+    offsets,
+    scrollTop: 5000,
+    viewportHeight: 600,
+    total
+  });
+  assert.equal(range.first, 50);
+  assert.equal(range.last, 56);
+  assert.equal(range.start, 50 - VIRTUAL_LIST_OVERSCAN_ROWS);
+  assert.equal(range.end, 56 + VIRTUAL_LIST_OVERSCAN_ROWS);
+});
+
+test("the window clamps at both ends of the list", () => {
+  const total = 30;
+  const offsets = buildRowOffsets([], total, 100);
+  const top = computeVirtualRange({ offsets, scrollTop: 0, viewportHeight: 600, total });
+  assert.equal(top.start, 0);
+  const bottom = computeVirtualRange({
+    offsets,
+    scrollTop: 2400,
+    viewportHeight: 600,
+    total
+  });
+  assert.equal(bottom.end, total - 1);
+});
+
+test("a focused row far outside the viewport is still rendered", () => {
+  const total = 300;
+  const offsets = buildRowOffsets([], total, 100);
+  const range = computeVirtualRange({
+    offsets,
+    scrollTop: 0,
+    viewportHeight: 600,
+    total,
+    focusRow: 250
+  });
+  assert.ok(range.start <= 250 && range.end >= 250, "focused row must be in the window");
+  // Around the focused row, not spanning from the viewport to it.
+  assert.ok(range.start > 200, "window must not span the gap to a far focus row");
+});
+
+test("an empty list produces an empty window", () => {
+  const range = computeVirtualRange({ offsets: [0], total: 0, viewportHeight: 600 });
+  assert.equal(range.end < range.start, true);
+});
+
+test("the window is not rebuilt while the viewport stays clear of the overscan", () => {
+  const total = 300;
+  const offsets = buildRowOffsets([], total, 100);
+  const current = { start: 44, end: 62 };
+  const stillInside = computeVirtualRange({
+    offsets,
+    scrollTop: 5100,
+    viewportHeight: 600,
+    total
+  });
+  assert.equal(
+    virtualRangeNeedsRefresh({ current, next: stillInside, total }),
+    false,
+    "a one-row step inside the overscan must not rebuild"
+  );
+
+  const nearEdge = computeVirtualRange({
+    offsets,
+    scrollTop: 4550,
+    viewportHeight: 600,
+    total
+  });
+  assert.equal(
+    virtualRangeNeedsRefresh({ current, next: nearEdge, total }),
+    true,
+    "approaching the top of the window must rebuild"
+  );
+});
+
+test("a window pinned at a list edge does not rebuild forever", () => {
+  const total = 300;
+  const offsets = buildRowOffsets([], total, 100);
+  const atTop = computeVirtualRange({ offsets, scrollTop: 0, viewportHeight: 600, total });
+  // start is already 0, so there is nothing above to extend into.
+  assert.equal(
+    virtualRangeNeedsRefresh({
+      current: { start: atTop.start, end: atTop.end },
+      next: atTop,
+      total
+    }),
+    false
+  );
+
+  const lastOffset = offsets[total] - 600;
+  const atBottom = computeVirtualRange({
+    offsets,
+    scrollTop: lastOffset,
+    viewportHeight: 600,
+    total
+  });
+  assert.equal(
+    virtualRangeNeedsRefresh({
+      current: { start: atBottom.start, end: atBottom.end },
+      next: atBottom,
+      total
+    }),
+    false
+  );
+});
+
+test("a stale window from a longer list is always rebuilt", () => {
+  const total = 10;
+  const offsets = buildRowOffsets([], total, 100);
+  const next = computeVirtualRange({ offsets, scrollTop: 0, viewportHeight: 600, total });
+  assert.equal(
+    virtualRangeNeedsRefresh({ current: { start: 40, end: 80 }, next, total }),
+    true
+  );
+});
+
+// End-to-end simulation: walk a 400-row list of ragged heights one row at a
+// time, the way the D-pad does, and assert the invariants the screen relies on.
+test("stepping through the whole list keeps the focused row rendered", () => {
+  const total = 400;
+  const viewport = 620;
+  const pad = 16;
+  // Real heights the screen would eventually measure; the model starts blind.
+  const realHeights = Array.from({ length: total }, (_, index) => 120 + ((index * 37) % 180));
+  const realOffsets = buildRowOffsets(realHeights, total);
+
+  const measured = [];
+  let current = null;
+  let scrollTop = 0;
+  let rebuilds = 0;
+
+  for (let focusRow = 0; focusRow < total; focusRow += 1) {
+    const offsets = buildRowOffsets(measured, total, estimateRowHeight(measured));
+    const rowTop = offsets[focusRow];
+    const rowBottom = offsets[focusRow + 1];
+    let projected = scrollTop;
+    if (rowBottom > scrollTop + viewport - pad) {
+      projected = rowBottom - viewport + pad;
+    } else if (rowTop < scrollTop + pad) {
+      projected = rowTop - pad;
+    }
+    projected = Math.max(0, projected);
+
+    const next = computeVirtualRange({
+      offsets,
+      scrollTop: projected,
+      viewportHeight: viewport,
+      total,
+      focusRow
+    });
+    if (virtualRangeNeedsRefresh({ current, next, total })) {
+      current = { start: next.start, end: next.end };
+      rebuilds += 1;
+      // Rendering the window measures exactly the rows it contains.
+      for (let row = current.start; row <= current.end; row += 1) {
+        measured[row] = realHeights[row];
+      }
+    }
+
+    assert.ok(
+      current && focusRow >= current.start && focusRow <= current.end,
+      `row ${focusRow} must be inside the rendered window`
+    );
+    // The screen scrolls using real rects, so track the true position here.
+    const trueTop = realOffsets[focusRow];
+    const trueBottom = realOffsets[focusRow + 1];
+    if (trueBottom > scrollTop + viewport - pad) {
+      scrollTop = trueBottom - viewport + pad;
+    } else if (trueTop < scrollTop + pad) {
+      scrollTop = trueTop - pad;
+    }
+    scrollTop = Math.max(0, scrollTop);
+    assert.ok(
+      trueTop >= scrollTop - 1 && trueBottom <= scrollTop + viewport + 1,
+      `row ${focusRow} must be visible after scrolling`
+    );
+  }
+
+  // Windows are swapped in chunks, not on every step.
+  assert.ok(rebuilds > 0, "the window must move while traversing the list");
+  assert.ok(
+    rebuilds < total / 2,
+    `expected chunked rebuilds, got ${rebuilds} for ${total} rows`
+  );
+  // Every row got rendered, so every height ends up measured.
+  assert.equal(measured.filter((height) => height > 0).length, total);
+});
+
+// Regression: badges used to be hydrated after a card was measured, so every
+// row was recorded shorter than it really was. Holding Down then walked the real
+// scroll position away from the model, and the window stretched from the model
+// position all the way to the focused row until the list broke.
+test("a window stays bounded when the model has drifted from the real scroll", () => {
+  const total = 400;
+  const viewport = 620;
+  const offsets = buildRowOffsets([], total, 100);
+  // Real rows are half again as tall as the model believes, so by row 200 the
+  // real scroll position is thousands of pixels past the modelled one.
+  const driftedScrollTop = 200 * 150;
+  const range = computeVirtualRange({
+    offsets,
+    scrollTop: driftedScrollTop,
+    viewportHeight: viewport,
+    total,
+    focusRow: 200
+  });
+  assert.ok(range.start <= 200 && range.end >= 200, "focused row must be resident");
+  assert.ok(
+    range.end - range.start + 1 <= 24,
+    `window stretched to ${range.end - range.start + 1} rows under drift`
+  );
+});
+
+test("a far jump renders around the target, not across the gap", () => {
+  const total = 500;
+  const offsets = buildRowOffsets([], total, 100);
+  // Viewport at the top of the list, focus jumping to row 400.
+  const range = computeVirtualRange({
+    offsets,
+    scrollTop: 0,
+    viewportHeight: 600,
+    total,
+    focusRow: 400
+  });
+  assert.ok(range.start <= 400 && range.end >= 400);
+  assert.ok(
+    range.end - range.start + 1 <= 24,
+    `window spanned ${range.end - range.start + 1} rows for a far jump`
+  );
+  assert.ok(range.start > 300, "window should sit around the jump target");
+});
+
+test("a focused row just outside the viewport still keeps the viewport resident", () => {
+  const total = 300;
+  const offsets = buildRowOffsets([], total, 100);
+  // Rows 50-56 visible, focus on 58 — inside the overscan, so both are kept.
+  const range = computeVirtualRange({
+    offsets,
+    scrollTop: 5000,
+    viewportHeight: 600,
+    total,
+    focusRow: 58
+  });
+  assert.ok(range.start <= 50, "viewport rows must stay resident");
+  assert.ok(range.end >= 58, "focused row must stay resident");
+});
+
+test("the window never exceeds a bounded size while traversing", () => {
+  const total = 500;
+  const viewport = 620;
+  const offsets = buildRowOffsets([], total, 150);
+  let worst = 0;
+  for (let focusRow = 0; focusRow < total; focusRow += 1) {
+    const range = computeVirtualRange({
+      offsets,
+      scrollTop: Math.max(0, offsets[focusRow] - viewport / 2),
+      viewportHeight: viewport,
+      total,
+      focusRow
+    });
+    worst = Math.max(worst, range.end - range.start + 1);
+  }
+  // Viewport rows plus overscan on both sides — never the whole list.
+  assert.ok(worst <= 24, `window grew to ${worst} rows`);
+});


### PR DESCRIPTION
## Summary

Fixes the stream source list on webOS, which was unusable: one D-pad press took ~5-6 seconds to move a single row, and holding a direction stalled the list partway with no visible focused card. Four causes — per-keypress work proportional to the whole list, the list rendering every source, a scroll ceiling that collapsed as the list scrolled, and manual-scroll CSS that never matched on modern webOS.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix
- [ ] Approved feature/change

## Affected area

- [x] Shared web app
- [ ] Samsung Tizen
- [x] LG webOS
- [ ] Browser development mode
- [ ] Playback
- [ ] Audio tracks
- [ ] Subtitles
- [x] Focus / Remote navigation
- [x] UI / Layout
- [ ] Resume / Watch progress
- [ ] Continue Watching
- [ ] Next Episode / Auto-play
- [ ] Packaging / Build
- [ ] Nuvio WebTV Installer compatibility
- [ ] TizenBrew wrapper
- [ ] webOS Homebrew wrapper
- [ ] Documentation
- [ ] Other

## Why

The source picker (Play → choose a source) was effectively unusable on webOS with a realistic number of sources. A single D-pad press took 5–6 seconds to move one row. Holding a direction made it worse: the list stalled partway through with no visible focused card, and further presses did nothing. No other screen was affected, because none combines a long flat list with this focus and scroll path.

Four independent causes, in `js/ui/screens/stream/streamScreen.js`:

**1. Per-keypress work was proportional to the whole list.** Each D-pad press did several forced synchronous layouts and O(N) DOM writes over every card:

- `updateManualListScrollTransform` wrote an inline `transform` to *every* card row on every scroll step.
- `hydrateVisibleStreamBadges` interleaved `getBoundingClientRect()` reads with `innerHTML` writes, so each hydrated row forced a full layout of the entire list.
- `focusElement` cleared the focus marker by walking every `.focusable` in the list.
- `ensureListItemVisible` ran a second time in a `requestAnimationFrame` on every keypress.
- `getFilteredStreams` re-sorted the stream array on every badge hydration pass; `getCardRows` re-queried the DOM twice per row on every keypress.

**2. The list rendered every source.** With a few hundred sources, the browser laid out and painted the whole list on each render.

**3. The scroll ceiling collapsed as the list scrolled.** `setListScrollTop` clamped against `scrollHeight - clientHeight`. In manual-scroll mode the track carries a `translateY(-N)`, and Chromium's scrollable overflow includes transformed descendants — so translating the track up shrinks `scrollHeight` toward `clientHeight`, and the ceiling falls toward zero the further you scroll. Past a point the clamp refused to advance, the focused row sat below the visible area, and nothing could bring it back. **This predates the windowing change**; windowing only made it bite sooner by shortening the content.

**4. The manual-scroll CSS never matched on modern webOS.** `shouldUseManualListScroll()` returns true for every webOS version, so `applyManualListScroll()` added the `manual-scroll` class, wrote inline transforms and pinned `scrollTop` to 0 — but `.stream-route-list.manual-scroll { overflow: hidden }` and the matching transform rule were scoped to `.legacy-webos`, which is only set for webOS 6 and below. On the webOS 10 TV this was reproduced on, the class was applied by JS while the CSS never matched, leaving the list with native overflow scrolling active, `scrollTop` repeatedly reset to 0, and inline transforms driving position at the same time. The `overflow: hidden` rule is no longer scoped to `.legacy-webos`.

## Issue or approval

Fixes #583

## Reproduction steps

1. Open any movie or episode with a large number of available sources (roughly 100+; the problem scales with source count).
2. Press **Play** to open the source picker.
3. Press Down once — the highlight takes several seconds to move one row.
4. Hold Down — the list scrolls for a while, then stalls partway through with no visible focused card, and further presses do nothing.

## Old behavior

- One D-pad press moved the highlight one row after ~5–6 seconds.
- Holding a direction stalled the list partway through with no visible focused card, after which further presses did nothing.
- On webOS 7 and later, the list had native overflow scrolling active while `scrollTop` was pinned to 0 and inline transforms drove position.

## New behavior

- D-pad movement tracks the remote.
- Holding a direction scrolls the list continuously to either end. The focused row is pinned to the edge it is leaving, so the focus marker stays on screen and the list scrolls underneath it.
- The list reaches the first and last card cleanly instead of stalling.

## Platform impact

- Samsung Tizen: No behavior change. Windowing is gated to webOS; Tizen renders the full list exactly as before. The only shared-code paths touched are the caching and focus-marker changes, which are platform-neutral.
- LG webOS: All four fixes apply. The card list is windowed at 24+ sources. Verified on webOS 10.3.1; causes 3 and 4 are most visible on webOS 7 and later, which does not get the `.legacy-webos` class.
- Browser development mode: No behavior change. Windowing and the manual-scroll path are both webOS-only; the browser keeps native scrolling and the full list.
- Installer / packaging: No impact.
- Wrapper repositories: No impact.

## UI / behavior / playback impact

- [ ] No UI change
- [ ] No behavior change
- [x] No playback change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] Playback changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval
- [ ] Playback change has explicit maintainer approval

The card design, layout, and styling are unchanged. What changed is which cards exist in the DOM at a time, and how the list scrolls — both to fix the unusable screen.

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact
- [ ] Tizen `.wgt` packaging changed
- [ ] webOS `.ipk` packaging changed
- [ ] App identifiers or metadata changed
- [ ] `local.properties` / environment handling changed
- [ ] `sync:tizen` changed
- [ ] `sync:webos` changed
- [ ] Nuvio WebTV Installer compatibility changed
- [ ] TizenBrew wrapper support changed
- [ ] webOS Homebrew metadata support changed

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [ ] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [ ] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I included a linked issue, reproduction steps, and testing notes if this is a critical bug fix.
- [x] I listed the testing performed below.

**Two boxes are deliberately left unchecked, flagging this for maintainer judgement:**

No dependencies are added, and no platform or installer rewrite is involved. However, windowing the card list is arguably an architecture change to this screen, and it adds one new internal module (`streamVirtualList.js`). Raising it explicitly rather than checking the box: the fix for causes 1 and 3 alone is a contained bug fix, but the screen stays slow without windowing, since the browser still lays out every card on each render.

An existing precedent in the codebase: `metaDetailsScreen.js` already windows the episode carousel (`EPISODE_VIRTUALIZATION_THRESHOLD`, spacer elements, absolute indices). This follows the same shape. It measures per-row heights instead of using a fixed stride, because stream cards vary in height with description lines and badge wrapping, whereas episode cards do not.

**If the maintainers prefer, this can be split** into a contained bug-fix PR (causes 1 and 3, no new module) and a separate windowing PR to be reviewed on its own.

## Scope boundaries

Intentionally not changed:

- No card design, layout, spacing, typography, or styling changes.
- No changes to stream fetching, sorting, filtering, or selection logic.
- No playback, resume, auto-play, or track-selection changes.
- No changes to any other screen.
- Windowing is gated to webOS at 24+ sources. Tizen and browser dev mode render the full list on the existing code path.
- `shouldUseManualListScroll()` still returns true for every webOS version. Whether modern webOS needs the manual-scroll path at all is a fair question, but narrowing it is a behavior change beyond this bug and was left alone.
- The pre-existing circular import that prevents `streamScreen.js` from being imported outside a bundle was left alone; it is unrelated and predates this work.
- The lazy badge hydration path is kept for the non-windowed platforms rather than removed.

## Testing

### Devices / platforms tested

- **LG C4, webOS 10.3.1** — reproduced the bug on 0.3.26 and verified the fix on this branch, installed as an `.ipk` via `npm run package:webos`. Note this TV is on the non-legacy path (`getWebOsMajorVersion()` returns 10, so `legacyWebOs` is false), which is why cause 4 above applied to it.
- Samsung Tizen: **not verified on hardware.** Windowing and the manual-scroll path are both gated off for Tizen, so it stays on the existing code path, but the caching and focus-marker changes are in shared screen code and would benefit from a check by someone with a Tizen set.
- Browser development mode: smoke-tested via `npm run build`; no behavior change expected, as windowing is webOS-gated.

### Commands tested

```sh
npm run build
npm run package:webos
npm test
npx eslint js/ui/screens/stream/
```

- `npm test` — 33 passing, including 16 new unit tests for the list geometry.
- `npx eslint js/ui/screens/stream/` — clean.
- `npm run build` and `npm run package:webos` — both succeed.

## Manual test flow

1. Open a title with a large source list, press **Play**.
2. Press Down repeatedly — one press moves one row, immediately.
3. Hold Down from the first card to the last — the list scrolls continuously, the focus marker stays visible pinned to the bottom edge, and it stops cleanly on the final card.
4. Hold Up back to the first card — same in reverse, pinned to the top edge.
5. Switch addon filters with Left/Right from a card — the list refilters and focus lands correctly.
6. Enter the player, then press Back to return to the picker — scroll position and focus are restored.
7. Repeat on a title with fewer than 24 sources to confirm the non-windowed path is unchanged.

## Screenshots / Video

Before/after video to follow — filming the TV directly, since webOS has no app screen capture. This PR is open as a draft until that is attached.

The card design, layout and styling are unchanged; the visible difference is entirely in how fast the highlight moves and how far the list scrolls.

## Logs

Not applicable. No crash, blank screen, install failure, or platform API error is involved — the app stays responsive throughout, the list simply does not move.

## Regression risk

Highest risk is on webOS, where nearly all of this lands.

- **Windowing off-by-one / focus loss.** Navigation now resolves rows by absolute `data-stream-row` index rather than DOM position. If a row is not resident, `applyFocus` rebuilds the window onto it and retries, so focus cannot land on nothing. Covered by unit tests that traverse a full list in both directions asserting the focused row is always resident and on screen.
- **Row height estimates.** Rows outside the rendered window use an estimated height. Estimates only choose which rows to render and how tall the spacers are; every window swap is anchored on a visible row, so an inaccurate estimate resizes a spacer rather than moving the content. Scroll extent for an unmeasured list is approximate until the rows are visited.
- **Badges under windowing.** Badges now render inline instead of being hydrated lazily on webOS. The window bounds how many exist, so image count stays bounded, but this changes when badge images are requested on that platform.
- **Tizen.** Should be unaffected — both windowing and the manual-scroll path are gated off. This is the main thing worth a second pair of eyes, since the changes are in shared screen code.
- **Browser dev mode.** Unaffected for the same reason.

## Breaking changes

None.

## Linked issues

Fixes #583


---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
