### PR TITLE
Speed up webOS source list navigation on long lists

### DIFF
--- a/js/ui/screens/stream/streamScreen.js
+++ b/js/ui/screens/stream/streamScreen.js
@@ -47,8 +47,11 @@ import { normalizeMathematicalAlphanumericSymbols } from "../../../core/streams/
 import { renderLoadingIndicator } from "../../components/loadingIndicator.js";
 
 const STREAM_BADGE_LIMIT = 9;
-const WEBOS_STREAM_BADGE_OVERSCAN_RATIO = 0.35;
-const WEBOS_STREAM_BADGE_MIN_OVERSCAN_PX = 180;
+// Number of rows on each side of the focused source to keep badge-hydrated.
+// Windowing by row index (instead of measuring every card) keeps a single
+// focus move O(1) in layout reads on webOS, where a getBoundingClientRect per
+// card forced a full list reflow every keypress on long source lists.
+const WEBOS_STREAM_BADGE_WINDOW_ROWS = 24;
 const WEBOS_NATIVE_PLAYER_APP_IDS = [
   "com.webos.app.mediadiscovery",
   "com.webos.app.photovideo",
@@ -1524,11 +1527,31 @@ export const StreamScreen = {
   },
 
   getFilteredStreams(filter = this.addonFilter) {
-    const orderedStreams = sortStreamsByAddonOrder(this.streams, this.sourceChips);
-    if (filter === "all") {
-      return DebridStreamPresentation.sortForDisplay(orderedStreams, DebridSettingsStore.get());
+    // Cache the sorted/filtered result so focus navigation (which re-requests
+    // this on every move via badge hydration) does not re-sort and re-parse
+    // the whole source list each keypress. The cache is keyed on the inputs
+    // that affect the result and is cleared in render() when data changes.
+    const cache = this._filteredStreamsCache;
+    if (
+      cache &&
+      cache.streams === this.streams &&
+      cache.chips === this.sourceChips &&
+      cache.filter === filter
+    ) {
+      return cache.result;
     }
-    return orderedStreams.filter((stream) => stream.addonName === filter);
+    const orderedStreams = sortStreamsByAddonOrder(this.streams, this.sourceChips);
+    const result =
+      filter === "all"
+        ? DebridStreamPresentation.sortForDisplay(orderedStreams, DebridSettingsStore.get())
+        : orderedStreams.filter((stream) => stream.addonName === filter);
+    this._filteredStreamsCache = {
+      streams: this.streams,
+      chips: this.sourceChips,
+      filter,
+      result
+    };
+    return result;
   },
 
   hasPendingSourceLoads(filter = this.addonFilter) {
@@ -2206,6 +2229,8 @@ export const StreamScreen = {
 
   render() {
     this.cancelScheduledRender();
+    // Rebuilt markup means the memoised filtered-stream list may be stale.
+    this._filteredStreamsCache = null;
     const { isSeries, title, subtitle, episodeLabel, detailLine } = this.getHeaderMeta();
     const backdrop = this.getBackdropUrl();
     const logo = this.params?.logo || "";
@@ -2360,29 +2385,23 @@ export const StreamScreen = {
     const filtered = this.getFilteredStreams();
     const streamBadgesEnabled = DebridSettingsStore.get().streamBadgesEnabled !== false;
     const badgeSettings = StreamBadgeSettingsStore.snapshot();
-    const listRect = list.getBoundingClientRect();
-    const overscan = Math.max(
-      WEBOS_STREAM_BADGE_MIN_OVERSCAN_PX,
-      Number(list.clientHeight || 0) * WEBOS_STREAM_BADGE_OVERSCAN_RATIO
-    );
-    const viewportTop = Number(listRect?.top || 0) - overscan;
-    const viewportBottom = Number(listRect?.bottom || 0) + overscan;
     const focusedRow =
       this.focusState?.zone === "card" ? Number(this.focusState?.row || 0) : -1;
 
     // Android's LazyColumn only composes badge images near the viewport. Keep
     // the complete Web card list for existing remote/pointer navigation, but
-    // apply the same bounded image/DOM lifetime on webOS.
+    // apply the same bounded image/DOM lifetime on webOS. Window by row index
+    // around the focus (the focused row is always scrolled into view) instead
+    // of measuring every card: a getBoundingClientRect per card forced a full
+    // list reflow on every focus move, which made long source lists unusable
+    // on webOS.
+    const anchorRow = focusedRow >= 0 ? focusedRow : 0;
+    const windowStart = anchorRow - WEBOS_STREAM_BADGE_WINDOW_ROWS;
+    const windowEnd = anchorRow + WEBOS_STREAM_BADGE_WINDOW_ROWS;
     placeholders.forEach((placeholder) => {
       const rowIndex = Number(placeholder.dataset.streamBadgeRow || -1);
-      const card = placeholder.closest(".stream-route-card-row");
-      const cardRect = card?.getBoundingClientRect?.();
-      const nearViewport = Boolean(
-        cardRect &&
-          Number(cardRect.bottom || 0) >= viewportTop &&
-          Number(cardRect.top || 0) <= viewportBottom
-      );
-      const shouldHydrate = rowIndex === focusedRow || nearViewport;
+      const shouldHydrate =
+        rowIndex === focusedRow || (rowIndex >= windowStart && rowIndex <= windowEnd);
       const hydrated = placeholder.dataset.badgesHydrated === "true";
       if (shouldHydrate && !hydrated) {
         placeholder.innerHTML = renderStreamBadgeContents(


### PR DESCRIPTION
## Summary

Speed up LG webOS source-list navigation for titles with large stream lists by removing per-card layout measurements from badge hydration and memoizing the sorted/filtered stream list between renders.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix
- [ ] Approved feature/change

## Affected area

- [x] Shared web app
- [ ] Samsung Tizen
- [x] LG webOS
- [ ] Browser development mode
- [ ] Playback
- [ ] Audio tracks
- [ ] Subtitles
- [x] Focus / Remote navigation
- [x] UI / Layout
- [ ] Resume / Watch progress
- [ ] Continue Watching
- [ ] Next Episode / Auto-play
- [ ] Packaging / Build
- [ ] Nuvio WebTV Installer compatibility
- [ ] TizenBrew wrapper
- [ ] webOS Homebrew wrapper
- [ ] Documentation
- [ ] Other

## Why

On webOS, moving focus in a source list with roughly 100 or more entries could take several seconds per D-pad press. Badge hydration measured every source card and the stream list was repeatedly sorted and parsed on each focus move.

## Issue or approval

Fixes #583.

## Reproduction steps

1. On LG webOS, open a movie or episode with roughly 100 or more available sources.
2. Open the source picker.
3. Press Down once, then hold Down.
4. Observe multi-second focus movement and eventual loss of visible focus.

## Old behavior

Each focus move performed layout reads for every source card and repeatedly rebuilt the sorted stream list, making navigation scale poorly with the number of sources.

## New behavior

Badge hydration uses a bounded row-index window around the focused source, avoiding per-card `getBoundingClientRect()` calls. The sorted/filtered stream result is reused until the next render.

## Platform impact

- Samsung Tizen: Shared source file is built successfully; the optimized hydration path remains webOS-only.
- LG webOS: Source-list focus navigation avoids per-card layout measurements.
- Browser development mode: No intended behavior change.
- Installer / packaging: No packaging logic or metadata change.
- Wrapper repositories: No changes.

## UI / behavior / playback impact

- [ ] No UI change
- [ ] No behavior change
- [x] No playback change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] Playback changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval
- [ ] Playback change has explicit maintainer approval

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact
- [ ] Tizen `.wgt` packaging changed
- [ ] webOS `.ipk` packaging changed
- [ ] App identifiers or metadata changed
- [ ] `local.properties` / environment handling changed
- [ ] `sync:tizen` changed
- [ ] `sync:webos` changed
- [ ] Nuvio WebTV Installer compatibility changed
- [ ] TizenBrew wrapper support changed
- [ ] webOS Homebrew metadata support changed

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I included a linked issue, reproduction steps, and testing notes if this is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

No playback, source loading, filtering policy, UI redesign, dependency, packaging, metadata, installer, or wrapper changes. The complete source-card list and existing remote/pointer navigation remain in place.

## Testing

Validated the current official merge tree in a detached worktree. The contributor also verified a 150-source headless webOS profile: layout reads in one hydration pass fell from 151 to 0 and the focused-row window remained hydrated.

### Devices / platforms tested

Headless webOS profile with 150 sources. No physical LG or Samsung TV confirmation was performed during maintainer review.

### Commands tested

```sh
git diff --check origin/main...HEAD
node --check js/ui/screens/stream/streamScreen.js
npx eslint js/ui/screens/stream/streamScreen.js
npm test
npm run build
npm run package:tizen
npm run package:webos
```

## Manual test flow

Exercised the badge-hydration logic with 150 stream rows and focus on row 16; rows in the bounded focus window remained hydrated without per-card layout reads. Package and source validation completed on the official merge tree.

## Screenshots / Video

No visual redesign. The user-visible change is restored responsive focus navigation for the documented bug; no before/after recording is available.

## Logs

Not applicable: this is a pre-playback navigation performance issue with no crash or platform API failure.

## Regression risk

Low. The main risk is badges outside the fixed focus window being released too early, but the focused row and 24 rows on either side remain hydrated. The path is webOS-only, while shared builds and both platform packages passed.

## Breaking changes

None.

## Linked issues

Fixes #583.
