### PR TITLE
Fix stale subtitle switches during playback

### DIFF
--- a/js/core/player/playerController.js
+++ b/js/core/player/playerController.js
@@ -1265,7 +1265,14 @@ export const PlayerController = {
       });
       return false;
     }
-    this.applyAvPlaySubtitleRenderMode(renderMode);
+    const mode = normalizeAvPlaySubtitleRenderMode(renderMode);
+    try {
+      // Re-arm AVPlay's subtitle decoder before selecting. Selecting the same
+      // TEXT track is otherwise a no-op after subtitles were disabled.
+      avplay.setSilentSubtitle?.(mode === "native");
+    } catch (_) {
+      // Track selection can still succeed when this toggle is unavailable.
+    }
     try {
       logTizenAvPlayDebug("Tizen AVPlay setSelectTrack(TEXT)", {
         state,
@@ -1279,9 +1286,10 @@ export const PlayerController = {
         targetIndex,
         error: error?.message || String(error || "")
       });
+      this.applyAvPlaySubtitleRenderMode(mode);
       return false;
     }
-    this.applyAvPlaySubtitleRenderMode(renderMode);
+    this.applyAvPlaySubtitleRenderMode(mode);
     if (nudge) {
       this.nudgeAvPlayAfterTrackSwitch();
     }

--- a/js/core/player/playerController.test.mjs
+++ b/js/core/player/playerController.test.mjs
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { PlayerController } from "./playerController.js";
+
+function createController(renderMode) {
+  const calls = [];
+  const avplay = {
+    setSilentSubtitle(silent) {
+      calls.push(["setSilentSubtitle", silent]);
+    },
+    setSelectTrack(type, index) {
+      calls.push(["setSelectTrack", type, index]);
+    }
+  };
+  const controller = Object.create(PlayerController);
+  Object.assign(controller, {
+    avplaySubtitleRenderMode: renderMode,
+    avplaySubtitleTracks: [{ avplayTrackIndex: 4 }],
+    getAvPlay: () => avplay,
+    getAvPlayState: () => "PLAYING",
+    reapplyTizenAvPlayDisplayRect() {}
+  });
+  return { calls, controller };
+}
+
+test("AVPlay re-arms native subtitles before selecting a track", () => {
+  const { calls, controller } = createController("native");
+
+  assert.equal(controller.trySelectAvPlaySubtitleTrackIndex(4), true);
+  assert.deepEqual(calls, [
+    ["setSilentSubtitle", true],
+    ["setSelectTrack", "TEXT", 4],
+    ["setSilentSubtitle", false]
+  ]);
+  assert.equal(controller.avplaySubtitlesSilent, false);
+  assert.equal(controller.avplayNativeSubtitleRendering, true);
+});
+
+test("AVPlay re-arms HTML subtitle callbacks before selecting a track", () => {
+  const { calls, controller } = createController("html");
+
+  assert.equal(controller.trySelectAvPlaySubtitleTrackIndex(4), true);
+  assert.deepEqual(calls, [
+    ["setSilentSubtitle", false],
+    ["setSelectTrack", "TEXT", 4],
+    ["setSilentSubtitle", true]
+  ]);
+  assert.equal(controller.avplaySubtitlesSilent, false);
+  assert.equal(controller.avplayNativeSubtitleRendering, false);
+});

--- a/js/ui/screens/player/playerScreen.js
+++ b/js/ui/screens/player/playerScreen.js
@@ -2259,6 +2259,7 @@ export const PlayerScreen = {
     this.skipIntroSuppressedUntil = 0;
     this.lastActionOverlayBottomPx = null;
     this.subtitleSelectionTimer = null;
+    this.subtitleSelectionToken = 0;
     this.subtitleLoadToken = 0;
     this.subtitleLoading = false;
     this.embeddedSubtitleLoadToken = 0;
@@ -11573,7 +11574,11 @@ export const PlayerScreen = {
     }, hideDelayMs);
   },
 
-  async applyTvHtmlAddonSubtitle(subtitle, subtitleIndex) {
+  async applyTvHtmlAddonSubtitle(subtitle, subtitleIndex, selectionToken = this.subtitleSelectionToken) {
+    const isCurrentSelection = () => Number(selectionToken) === Number(this.subtitleSelectionToken);
+    if (!isCurrentSelection()) {
+      return false;
+    }
     const subtitleId = subtitle?.id || subtitle?.url || `subtitle-${subtitleIndex}`;
     const subtitleUrl = Environment.isTizen()
       ? await this.resolveTizenAvPlaySubtitleUrl(subtitle?.url)
@@ -11586,6 +11591,9 @@ export const PlayerScreen = {
       throw new Error(`HTML subtitle fetch failed with HTTP ${response.status}`);
     }
     const text = await response.text();
+    if (!isCurrentSelection()) {
+      return false;
+    }
     const cues = this.parseSubtitleCues(text);
     if (!cues.length) {
       throw new Error("HTML subtitle fetch returned no cues");
@@ -13283,6 +13291,8 @@ export const PlayerScreen = {
     if (!entry || entry.disabled) {
       return;
     }
+    const selectionToken = Number(this.subtitleSelectionToken || 0) + 1;
+    this.subtitleSelectionToken = selectionToken;
     const previousSubtitleSelectionKey = this.getActiveSubtitleSelectionKey();
 
     const isEmbeddedEntry = Object.prototype.hasOwnProperty.call(entry, "embeddedSubtitleTrackIndex");
@@ -13382,6 +13392,12 @@ export const PlayerScreen = {
     }
 
     if (entry.fallbackAddonSubtitle) {
+      this.clearMountedExternalSubtitleTracks();
+      this.clearHtmlSubtitleOverlay();
+      if (this.subtitleSelectionTimer) {
+        clearTimeout(this.subtitleSelectionTimer);
+        this.subtitleSelectionTimer = null;
+      }
       const subtitle = this.subtitles[entry.subtitleIndex];
       const subtitleId = subtitle?.id || subtitle?.url || `subtitle-${entry.subtitleIndex}`;
       this.selectedAddonSubtitleId = subtitleId;
@@ -13393,7 +13409,7 @@ export const PlayerScreen = {
       this.refreshSubtitleCueStyles();
       this.renderControlButtons();
       this.renderSubtitleDialog();
-      void this.applyFallbackAddonSubtitle(entry.subtitleIndex);
+      void this.applyFallbackAddonSubtitle(entry.subtitleIndex, selectionToken);
       return;
     }
 
@@ -13454,27 +13470,37 @@ export const PlayerScreen = {
     this.renderSubtitleDialog();
   },
 
-  async applyFallbackAddonSubtitle(subtitleIndex) {
+  async applyFallbackAddonSubtitle(subtitleIndex, selectionToken = this.subtitleSelectionToken) {
     const subtitle = this.subtitles[subtitleIndex];
     if (!subtitle?.url) {
       return;
     }
     const subtitleId = subtitle.id || subtitle.url || `subtitle-${subtitleIndex}`;
+    const isCurrentSelection = () => Number(selectionToken) === Number(this.subtitleSelectionToken);
+    if (!isCurrentSelection()) {
+      return;
+    }
 
     const usingAvPlay = typeof PlayerController.isUsingAvPlay === "function"
       ? PlayerController.isUsingAvPlay()
       : false;
     if ((usingAvPlay && Environment.isTizen()) || Environment.isWebOS()) {
       try {
-        if (await this.applyTvHtmlAddonSubtitle(subtitle, subtitleIndex)) {
+        if (await this.applyTvHtmlAddonSubtitle(subtitle, subtitleIndex, selectionToken)) {
           return;
         }
       } catch (error) {
+        if (!isCurrentSelection()) {
+          return;
+        }
         console.warn("HTML subtitle overlay failed", {
           subtitleUrl: subtitle.url,
           error: error?.message || String(error || "")
         });
       }
+    }
+    if (!isCurrentSelection()) {
+      return;
     }
     if (usingAvPlay) {
       let avPlaySubtitleUrl = subtitle.url;
@@ -13484,6 +13510,9 @@ export const PlayerScreen = {
           : await this.resolveSubtitlePlaybackUrl(subtitle.url) || subtitle.url;
       } catch (_) {
         avPlaySubtitleUrl = subtitle.url;
+      }
+      if (!isCurrentSelection()) {
+        return;
       }
       const applied = typeof PlayerController.setAvPlayExternalSubtitle === "function"
         ? PlayerController.setAvPlayExternalSubtitle(avPlaySubtitleUrl)
@@ -13518,7 +13547,7 @@ export const PlayerScreen = {
     this.clearMountedExternalSubtitleTracks();
 
     const resolvedSubtitleUrl = await this.resolveSubtitlePlaybackUrl(subtitle.url);
-    if (!resolvedSubtitleUrl) {
+    if (!isCurrentSelection() || !resolvedSubtitleUrl) {
       return;
     }
 
@@ -13540,7 +13569,12 @@ export const PlayerScreen = {
       // Best effort.
     }
 
-    const activateTrack = () => this.activateMountedExternalSubtitleTrack(track);
+    const activateTrack = () => {
+      if (!isCurrentSelection()) {
+        return false;
+      }
+      return this.activateMountedExternalSubtitleTrack(track);
+    };
     track.addEventListener("load", activateTrack, { once: true });
     track.addEventListener("error", () => {
       console.warn("Subtitle track failed to load", { subtitleUrl: subtitle.url });
@@ -13562,6 +13596,10 @@ export const PlayerScreen = {
     let activationAttempts = 0;
     const scheduleActivation = () => {
       this.subtitleSelectionTimer = setTimeout(() => {
+        if (!isCurrentSelection()) {
+          this.subtitleSelectionTimer = null;
+          return;
+        }
         activationAttempts += 1;
         const activated = activateTrack();
         if (!activated && activationAttempts < 6) {
@@ -17146,6 +17184,7 @@ export const PlayerScreen = {
     this.failedPlaybackStreamIds?.clear?.();
     this.skipIntervalsRequestToken = Number(this.skipIntervalsRequestToken || 0) + 1;
     this.subtitleLoadToken = (this.subtitleLoadToken || 0) + 1;
+    this.subtitleSelectionToken = Number(this.subtitleSelectionToken || 0) + 1;
     this.manifestLoadToken = (this.manifestLoadToken || 0) + 1;
     this.trackDiscoveryToken = (this.trackDiscoveryToken || 0) + 1;
     this.clearStartupAudioPreferenceRetry();

--- a/js/ui/screens/player/playerScreen.subtitleSelection.test.mjs
+++ b/js/ui/screens/player/playerScreen.subtitleSelection.test.mjs
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { PlayerController } from "../../../core/player/playerController.js";
+import { Router } from "../../navigation/router.js";
+
+const PlayerScreen = Router.routes.player;
+
+function deferred() {
+  let resolve;
+  const promise = new Promise((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+test("a stale HTML subtitle response cannot replace the latest selection", async (context) => {
+  const originalFetch = globalThis.fetch;
+  context.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const responseText = deferred();
+  globalThis.fetch = async () => ({
+    ok: true,
+    text: () => responseText.promise
+  });
+
+  const player = Object.create(PlayerScreen);
+  Object.assign(player, {
+    subtitleSelectionToken: 1,
+    resolveSubtitlePlaybackUrl: async () => "blob:subtitle",
+    clearMountedExternalSubtitleTracks() {
+      assert.fail("stale selection cleared the active track");
+    },
+    clearHtmlSubtitleOverlay() {
+      assert.fail("stale selection cleared the active overlay");
+    }
+  });
+
+  const applying = player.applyTvHtmlAddonSubtitle({ id: "old", url: "old.srt" }, 0, 1);
+  player.subtitleSelectionToken = 2;
+  responseText.resolve("1\n00:00:01,000 --> 00:00:02,000\nOld subtitle");
+
+  assert.equal(await applying, false);
+});
+
+test("a stale fallback subtitle load cannot mount a track", async (context) => {
+  const originalVideo = PlayerController.video;
+  const originalIsUsingAvPlay = PlayerController.isUsingAvPlay;
+  const originalDocument = globalThis.document;
+  context.after(() => {
+    PlayerController.video = originalVideo;
+    PlayerController.isUsingAvPlay = originalIsUsingAvPlay;
+    globalThis.document = originalDocument;
+  });
+
+  PlayerController.video = {};
+  PlayerController.isUsingAvPlay = () => false;
+  globalThis.document = {
+    createElement() {
+      assert.fail("stale selection mounted a track");
+    }
+  };
+
+  const resolvedUrl = deferred();
+  const player = Object.create(PlayerScreen);
+  Object.assign(player, {
+    subtitles: [{ id: "old", url: "old.srt" }],
+    subtitleSelectionToken: 1,
+    externalTrackNodes: [],
+    getTextTracks: () => [],
+    disableEmbeddedSubtitleSelection() {},
+    clearMountedExternalSubtitleTracks() {},
+    resolveSubtitlePlaybackUrl: () => resolvedUrl.promise
+  });
+
+  const applying = player.applyFallbackAddonSubtitle(0, 1);
+  player.subtitleSelectionToken = 2;
+  resolvedUrl.resolve("blob:subtitle");
+
+  await applying;
+});


### PR DESCRIPTION
## Summary

- Prevent stale asynchronous subtitle loads from replacing a newer selection.
- Clear superseded addon subtitle output immediately during a switch.
- Re-arm Samsung AVPlay subtitle rendering when selecting or reselecting a built-in track.
- Add regression coverage for stale HTML/fallback loads and AVPlay renderer transitions.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix
- [ ] Approved feature/change

## Affected area

- [x] Shared web app
- [x] Samsung Tizen
- [x] LG webOS
- [x] Browser development mode
- [x] Playback
- [ ] Audio tracks
- [x] Subtitles
- [ ] Focus / Remote navigation
- [ ] UI / Layout
- [ ] Resume / Watch progress
- [ ] Continue Watching
- [ ] Next Episode / Auto-play
- [ ] Packaging / Build
- [ ] Nuvio WebTV Installer compatibility
- [ ] TizenBrew wrapper
- [ ] webOS Homebrew wrapper
- [ ] Documentation
- [ ] Other

## Why

Subtitle changes can overlap while playback continues. A slower addon subtitle request could complete after a newer selection and overwrite it, leaving an old or apparently out-of-sync track visible. On Tizen, AVPlay can also continue reporting the selected TEXT track while its renderer remains inactive after switching away and back.

## Issue or approval

Potentially addresses parts of #523. This intentionally does not close the issue because unsupported embedded formats and the reported subtitle-list layout problem are separate.

## Reproduction steps

1. Start playback with subtitles available.
2. Select an addon subtitle, then quickly select another addon, a built-in track, or Off while the first request is still loading.
3. Observe that the older request can finish later and replace the current selection.
4. On Samsung Tizen, select a built-in SRT track, switch to Off or another subtitle, then select the original built-in track again.
5. Observe that AVPlay can report the track as selected without rendering it.

## Old behavior

Asynchronous subtitle work had no selection identity, so stale responses and delayed track activation could mutate the active subtitle state. AVPlay applied its final renderer mode before selecting the TEXT track, which did not reliably re-arm an already-selected decoder.

## New behavior

Each subtitle choice invalidates older asynchronous work. Stale responses, mounted tracks, and delayed activation attempts are ignored, and superseded output is cleared immediately. AVPlay transitions through the opposite silent-subtitle state before track selection and restores the requested native/HTML mode afterward.

## Platform impact

- Samsung Tizen: Protects shared async subtitle selection and re-arms built-in AVPlay TEXT tracks.
- LG webOS: Protects HTML overlay and fallback track selection from stale async completion.
- Browser development mode: Protects the shared fallback text-track path from stale completion.
- Installer / packaging: No code or metadata changes; packages were generated only for validation.
- Wrapper repositories: No changes.

## UI / behavior / playback impact

- [x] No UI change
- [ ] No behavior change
- [ ] No playback change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [x] Playback changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval
- [ ] Playback change has explicit maintainer approval

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact
- [ ] Tizen `.wgt` packaging changed
- [ ] webOS `.ipk` packaging changed
- [ ] App identifiers or metadata changed
- [ ] `local.properties` / environment handling changed
- [ ] `sync:tizen` changed
- [ ] `sync:webos` changed
- [ ] Nuvio WebTV Installer compatibility changed
- [ ] TizenBrew wrapper support changed
- [ ] webOS Homebrew metadata support changed

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I included a linked issue, reproduction steps, and testing notes if this is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

No UI changes, subtitle extraction, SSA/ASS fallback, PGS/VobSub rendering, platform rewrite, dependency change, or packaging change. This does not attempt to fix the separate subtitle-list overflow report in #523.

## Testing

### Devices / platforms tested

- Automated Node tests on macOS.
- Tizen and webOS packages generated successfully.
- Hardware validation of this exact commit is pending.

### Commands tested

```sh
npm test
npm run build
npm run package:tizen
npm run package:webos
git diff --check upstream/main...HEAD
```

## Manual test flow

Hardware validation should cover addon-to-addon, addon-to-built-in, built-in-to-Off, and Off-to-built-in switches while playback continues, in both Native and HTML overlay modes where available.

## Screenshots / Video

Not a UI change.

## Logs

Not applicable. No new playback or packaging errors were produced by local validation.

## Regression risk

Low to moderate. Subtitle output is now cleared while a replacement loads, so a slow request shows no subtitle instead of continuing to display the superseded track. Tizen renderer-mode transitions are synchronous and do not seek or restart playback.

## Breaking changes

None.

## Linked issues

Related to #523; potentially fixes the stale selection and built-in re-selection portions without claiming the full ticket is resolved.
