### PR TITLE
Fix Continue Watching next-up backfill (#577)

### DIFF
--- a/js/ui/screens/home/homeConstants.js
+++ b/js/ui/screens/home/homeConstants.js
@@ -8,6 +8,7 @@ export const HERO_ROTATE_INTERVAL_MS = 10000;
 export const HOME_LAYOUT_SEQUENCE = ["modern", "grid", "classic"];
 
 export const CW_MAX_NEXT_UP_LOOKUPS = 24;
+export const CW_MAX_NEXT_UP_CONCURRENCY = 4;
 export const CW_MAX_VISIBLE_ITEMS = 10;
 export const CW_DAYS_CAP = 60;
 export const CW_PROGRESS_START_THRESHOLD = WATCH_PROGRESS_STARTED_THRESHOLD;

--- a/js/ui/screens/home/homeScreen.js
+++ b/js/ui/screens/home/homeScreen.js
@@ -63,6 +63,7 @@ import {
   CW_ENRICHMENT_CACHE_MAX_AGE_MS,
   CW_ENTER_DELAY_MS,
   CW_HOLD_DELAY_MS,
+  CW_MAX_NEXT_UP_CONCURRENCY,
   CW_MAX_NEXT_UP_LOOKUPS,
   CW_MAX_VISIBLE_ITEMS,
   CW_META_TIMEOUT_MS,
@@ -89,6 +90,7 @@ import {
   HOME_ROW_RETRY_TIMEOUT_MS,
   HOME_ROW_TIMEOUT_MS
 } from "./homeConstants.js";
+import { resolveNextUpCandidates } from "./nextUpCandidateResolver.js";
 import {
   buildHeroBackdropSources,
   buildImageFallbackErrorHandler,
@@ -8553,12 +8555,9 @@ export const HomeScreen = {
       return [];
     }
 
-    const neededSlots = Math.max(0, CW_MAX_VISIBLE_ITEMS - Math.min(CW_MAX_VISIBLE_ITEMS, Number(inProgressItems?.length || 0)));
-    const lookupCount = Math.min(CW_MAX_NEXT_UP_LOOKUPS, neededSlots || CW_MAX_VISIBLE_ITEMS);
-    const limitedCandidates = activeCandidates.slice(0, lookupCount);
     const watchedEpisodeIndex = this.buildWatchedEpisodeIndex(watchedItems);
 
-    const nextUpItems = await Promise.all(limitedCandidates.map(async (progressEntry) => {
+    const nextUpItems = await resolveNextUpCandidates(activeCandidates, async (progressEntry) => {
       const contentType = String(progressEntry?.contentType || "series").toLowerCase();
       const contentId = String(progressEntry?.contentId || "").trim();
       if (!contentId || !isSeriesTypeForContinueWatching(contentType)) {
@@ -8636,10 +8635,12 @@ export const HomeScreen = {
         language: firstNonEmpty(meta.language),
         country: firstNonEmpty(meta.country)
       };
-    }));
+    }, {
+      maxLookups: CW_MAX_NEXT_UP_LOOKUPS,
+      concurrency: CW_MAX_NEXT_UP_CONCURRENCY
+    });
 
     return nextUpItems
-      .filter(Boolean)
       .sort((left, right) => Number(right.updatedAt || 0) - Number(left.updatedAt || 0));
   },
 

--- a/js/ui/screens/home/nextUpCandidateResolver.js
+++ b/js/ui/screens/home/nextUpCandidateResolver.js
@@ -1,0 +1,35 @@
+export async function resolveNextUpCandidates(
+  candidates = [],
+  resolver,
+  { maxLookups = 24, concurrency = 4 } = {}
+) {
+  if (typeof resolver !== "function") {
+    return [];
+  }
+
+  const limitedCandidates = (Array.isArray(candidates) ? candidates : []).slice(
+    0,
+    Math.max(0, Number(maxLookups || 0))
+  );
+  if (!limitedCandidates.length) {
+    return [];
+  }
+
+  const results = new Array(limitedCandidates.length);
+  const workerCount = Math.min(
+    limitedCandidates.length,
+    Math.max(1, Number(concurrency || 1))
+  );
+  let nextIndex = 0;
+
+  const worker = async () => {
+    while (nextIndex < limitedCandidates.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      results[index] = await resolver(limitedCandidates[index], index);
+    }
+  };
+
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+  return results.filter(Boolean);
+}

--- a/js/ui/screens/home/nextUpCandidateResolver.test.mjs
+++ b/js/ui/screens/home/nextUpCandidateResolver.test.mjs
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { resolveNextUpCandidates } from "./nextUpCandidateResolver.js";
+
+test("continues past candidates without a next episode until the lookup limit", async () => {
+  const candidates = Array.from({ length: 10 }, (_, index) => index + 1);
+  const visited = [];
+
+  const resolved = await resolveNextUpCandidates(
+    candidates,
+    async (candidate) => {
+      visited.push(candidate);
+      return candidate > 8 ? `next-${candidate}` : null;
+    },
+    { maxLookups: 10, concurrency: 2 }
+  );
+
+  assert.deepEqual(visited.slice().sort((left, right) => left - right), candidates);
+  assert.deepEqual(resolved, ["next-9", "next-10"]);
+});
+
+test("bounds concurrent candidate resolution", async () => {
+  let active = 0;
+  let peak = 0;
+
+  await resolveNextUpCandidates(
+    Array.from({ length: 12 }, (_, index) => index),
+    async (candidate) => {
+      active += 1;
+      peak = Math.max(peak, active);
+      await new Promise((resolve) => setTimeout(resolve, 2));
+      active -= 1;
+      return candidate;
+    },
+    { maxLookups: 12, concurrency: 4 }
+  );
+
+  assert.equal(peak, 4);
+});


### PR DESCRIPTION
## Summary

Fix Continue Watching so valid Next Up, New Episode, and New Season cards are not lost when earlier candidates resolve without a next episode.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix
- [ ] Approved feature/change

## Affected area

- [x] Shared web app
- [x] Samsung Tizen
- [x] LG webOS
- [x] Browser development mode
- [ ] Playback
- [ ] Audio tracks
- [ ] Subtitles
- [ ] Focus / Remote navigation
- [ ] UI / Layout
- [x] Resume / Watch progress
- [x] Continue Watching
- [ ] Next Episode / Auto-play
- [ ] Packaging / Build
- [ ] Nuvio WebTV Installer compatibility
- [ ] TizenBrew wrapper
- [ ] webOS Homebrew wrapper
- [ ] Documentation
- [ ] Other

## Why

Web stopped resolving candidates after the number of empty Continue Watching slots. Candidates for completed series, missing metadata, or series without a next episode produced no card, and later valid candidates were never evaluated. This could leave only recent in-progress items visible while Android TV still found Next Up entries.

## Issue or approval

Fixes #577.

## Reproduction steps

1. Use Nuvio Sync with more completed series seeds than available Continue Watching slots.
2. Ensure several of the newest seeds have no resolvable next episode while later seeds do.
3. Open Home and inspect Continue Watching.
4. Before this fix, later valid Next Up entries are missing.

## Old behavior

Web attempted only as many candidates as there were empty display slots. Null resolutions created holes and prevented later valid candidates from being considered.

## New behavior

Web evaluates the bounded candidate set, limits metadata work to four concurrent resolutions, and then keeps the existing ten-card display limit. Later valid candidates backfill holes left by null resolutions.

## Platform impact

- Samsung Tizen: Shared Continue Watching resolution changes; no platform API or playback changes.
- LG webOS: Fixes the reported shared Continue Watching behavior with bounded concurrency for TV resource safety.
- Browser development mode: Shared Continue Watching resolution changes in the same way.
- Installer / packaging: No impact.
- Wrapper repositories: No impact.

## UI / behavior / playback impact

- [x] No UI change
- [ ] No behavior change
- [x] No playback change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] Playback changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval
- [ ] Playback change has explicit maintainer approval

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact
- [ ] Tizen `.wgt` packaging changed
- [ ] webOS `.ipk` packaging changed
- [ ] App identifiers or metadata changed
- [ ] `local.properties` / environment handling changed
- [ ] `sync:tizen` changed
- [ ] `sync:webos` changed
- [ ] Nuvio WebTV Installer compatibility changed
- [ ] TizenBrew wrapper support changed
- [ ] webOS Homebrew metadata support changed

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I included a linked issue, reproduction steps, and testing notes if this is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

No UI polish, watch-progress schema changes, sync-service changes, playback changes, packaging changes, or platform rewrites. The patch only changes bounded Next Up candidate resolution and adds regression tests.

## Testing

The pure resolver regression test verifies that later valid candidates are returned after earlier null resolutions and that concurrency never exceeds four. The complete project test suite, incremental Home lint, build, and diff checks pass.

### Devices / platforms tested

Source-level validation on macOS. No physical LG or Samsung TV was available in this run.

### Commands tested

```sh
npm test
npm run lint
npm run build
git diff --check
```

## Manual test flow

Covered deterministically by the resolver test using eight null candidates followed by two valid candidates. Physical-TV reporter confirmation remains separate from source and build validation.

## Screenshots / Video

Not a UI change.

## Logs

Not applicable; this is candidate selection logic rather than a crash, playback, platform API, or packaging failure.

## Regression risk

Low. The existing candidate and ten-card display limits remain unchanged. The patch can perform more candidate resolutions than before, but concurrency is capped at four to match the bounded Android-style approach and protect constrained TVs.

## Breaking changes

None.

## Linked issues

Closes #577.