### PR TITLE
chore: enforce Prettier before commits

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npm run format:check

--- a/.prettierignore
+++ b/.prettierignore
@@ -7,8 +7,7 @@ services/**/runtime
 *.ipk
 *.wgt
 
-# Legacy home files are adopted incrementally to avoid noisy formatting-only diffs.
-js/ui/screens/home/classicHomeLayout.js
-js/ui/screens/home/gridHomeLayout.js
-js/ui/screens/home/homeScreen.js
-js/ui/screens/home/modernHomeLayout.js
+# Local agent state is not project source.
+.claude
+.opencode
+.orchestration

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "eslint": "^9.39.4",
         "eslint-config-prettier": "^10.1.8",
         "globals": "^16.5.0",
+        "husky": "^9.1.7",
         "postcss": "^8.5.9",
         "prettier": "^3.8.4"
       }
@@ -5303,6 +5304,22 @@
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.4.0.tgz",
       "integrity": "sha512-8nxjcBcd8wovbeKx7h3wTji4e6+rhaVuPNpMqwWgnHh+N9ToqsCs6XztWRBPQ+UtzsoMAdKZtUENoVzU/EMtZA==",
       "license": "MIT"
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
     },
     "node_modules/ignore": {
       "version": "5.3.2",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "version": "0.3.26",
   "scripts": {
     "build": "node ./scripts/build.mjs",
+    "prepare": "husky || true",
     "test": "node --test \"**/*.test.mjs\"",
     "build:on-release": "node ./scripts/release-build-poller.mjs",
     "install:webos": "node ./scripts/ares-install-webos.mjs",
@@ -15,10 +16,8 @@
     "lint:home:incremental": "eslint \"js/ui/screens/home/**/*.js\" \"eslint.config.mjs\"",
     "package:tizen": "npm run build && node ./scripts/package-tizen.mjs",
     "package:webos": "npm run build && node ./scripts/package-webos.mjs",
-    "format": "npm run format:incremental",
-    "format:incremental": "prettier --write \"js/ui/screens/home/**/*.js\" \"eslint.config.mjs\" \"package.json\" \".prettierrc.json\"",
-    "format:check": "npm run format:check:incremental",
-    "format:check:incremental": "prettier --check \"js/ui/screens/home/**/*.js\" \"eslint.config.mjs\" \"package.json\" \".prettierrc.json\"",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "serve": "node ./scripts/serve.mjs",
     "sync": "node ./scripts/sync-wrapper.mjs",
     "sync:tizen": "node ./scripts/sync-wrapper.mjs --tizen",
@@ -37,6 +36,7 @@
     "eslint": "^9.39.4",
     "eslint-config-prettier": "^10.1.8",
     "globals": "^16.5.0",
+    "husky": "^9.1.7",
     "postcss": "^8.5.9",
     "prettier": "^3.8.4"
   },


### PR DESCRIPTION
## Summary

- Adds Husky 9.1.7 with automatic hook setup through the npm `prepare` lifecycle.
- Adds a versioned `.husky/pre-commit` hook that runs `npm run format:check` and rejects unformatted commits.
- Expands `format` and `format:check` from the temporary Home-only scope to the maintained project.
- Removes the legacy Home exclusions and excludes local agent/orchestration state.

This is a tooling-only PR with no runtime source or behavior changes. It depends on #594 and must merge after that formatting baseline.

## PR type

- [ ] Translation/localization only
- [ ] Critical bug fix
- [x] Approved feature/change

## Affected area

- [ ] Shared web app
- [ ] Samsung Tizen
- [ ] LG webOS
- [ ] Browser development mode
- [ ] Playback
- [ ] Audio tracks
- [ ] Subtitles
- [ ] Focus / Remote navigation
- [ ] UI / Layout
- [ ] Resume / Watch progress
- [ ] Continue Watching
- [ ] Next Episode / Auto-play
- [x] Packaging / Build
- [ ] Nuvio WebTV Installer compatibility
- [ ] TizenBrew wrapper
- [ ] webOS Homebrew wrapper
- [ ] Documentation
- [x] Other

Other: local contributor Git-hook tooling.

## Why

PR #594 establishes a one-time repository-wide formatting baseline. Without an automatic check, formatting drift can return and functional PRs will again carry unrelated Prettier churn. The pre-commit gate keeps that baseline stable before commits are created.

## Issue or approval

Depends on and is approved as the tooling follow-up to #594. The Husky structure follows the established pattern in the maintainer-provided Sciensus NX repository.

## Reproduction steps

1. On current `main`, run `npm run format:check`; it rejects the 76 files corrected by #594.
2. Apply #594, install dependencies, and run `npm run prepare`.
3. Run `.husky/pre-commit`; the repository-wide check passes on the formatted baseline.
4. Introduce an unformatted maintained file and attempt a normal commit; Prettier returns non-zero and the commit is rejected.
5. Format the file and commit again; the hook passes.

## Old behavior

The npm formatter scripts checked only a temporary Home subset, and no versioned pre-commit hook prevented formatting drift.

## New behavior

Normal npm installation configures Husky. Every normal commit runs the full maintained-project Prettier check and fails when formatting does not match `.prettierrc.json`. Git's standard `--no-verify` escape hatch remains available for exceptional cases.

## Platform impact

- Samsung Tizen: No runtime or package behavior change.
- LG webOS: No runtime or package behavior change.
- Browser development mode: No runtime behavior change.
- Installer / packaging: Application packaging scripts are unchanged; npm install additionally configures local Git hooks when Husky is available.
- Wrapper repositories: No changes.

## UI / behavior / playback impact

- [x] No UI change
- [x] No behavior change
- [x] No playback change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] Playback changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval
- [ ] Playback change has explicit maintainer approval

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact
- [ ] Tizen `.wgt` packaging changed
- [ ] webOS `.ipk` packaging changed
- [ ] App identifiers or metadata changed
- [ ] `local.properties` / environment handling changed
- [ ] `sync:tizen` changed
- [ ] `sync:webos` changed
- [ ] Nuvio WebTV Installer compatibility changed
- [ ] TizenBrew wrapper support changed
- [ ] webOS Homebrew metadata support changed

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I included a linked issue, reproduction steps, and testing notes if this is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Exactly four tooling files change: `.husky/pre-commit`, `.prettierignore`, `package.json`, and `package-lock.json`. No application source, formatting baseline, CI, lint rules, runtime code, package identifiers, or release behavior is changed. Merge only after #594.

## Testing

### Devices / platforms tested

Tooling validated on macOS with Node 24 and npm. No TV/device testing is required because runtime bundles are unchanged.

### Commands tested

```sh
npm run prepare
npm run format:check
sh .husky/pre-commit
npm test
npm run build
npm run lint
git diff --check upstream/main...HEAD
```

Results:

- Current-main negative case: full check rejects exactly #594's 76 unformatted files.
- Temporary #594 + hook integration: full check and actual hook pass.
- Existing suite: 16/16 pass.
- Build, configured lint, prepare lifecycle, and diff check pass.

## Manual test flow

The hook commit was created on a temporary branch containing #594 with Husky active, so its own pre-commit check passed without `--no-verify`. The resulting four-file tooling commit was then cherry-picked onto this separate main-based branch.

## Screenshots / Video

Not a UI change.

## Logs

Not applicable; no runtime logging changes.

## Regression risk

Low runtime risk because no application source changes. Contributor commits will take longer because they check the maintained repository rather than staged files only. `prepare` uses Husky's documented `husky || true` form so production installs omitting dev dependencies do not fail.

## Breaking changes

None for the application. Contributors must format files before normal commits after #594 merges.

## Linked issues

Dependent tooling follow-up to #594. Do not merge this PR first.
