### PR TITLE
Translate subtitle settings descriptions in all locales

### DIFF
--- a/res/values-ar/strings.xml
+++ b/res/values-ar/strings.xml
@@ -1374,4 +1374,12 @@
     <string name="unsupported_device_required_platform">النظام المطلوب</string>
     <string name="unsupported_device_close">إغلاق</string>
     <string name="unsupported_device_unavailable">غير متاح</string>
+    <string name="subtitle_position">موضع الترجمة</string>
+    <string name="subtitle_position_subtitle">حرّك الترجمة لأعلى أو لأسفل على الشاشة.</string>
+    <string name="subtitle_font_size_subtitle">حجم النص المستخدم للترجمة أثناء التشغيل.</string>
+    <string name="subtitle_bold_subtitle">عرض نص الترجمة بخط عريض.</string>
+    <string name="subtitle_outline_subtitle">رسم إطار حول نص الترجمة لتحسين وضوح القراءة.</string>
+    <string name="subtitle_outline_color_subtitle">لون إطار الترجمة.</string>
+    <string name="subtitle_text_color_subtitle">لون نص الترجمة.</string>
+    <string name="player_error_web_headers_unsupported">هذا المصدر غير متوافق مع مشغّل هذا الجهاز لأنه يتطلب ترويسات طلب خاصة. جرّب مصدرًا آخر أو تواصل مع مزوّد الإضافة.</string>
 </resources>

--- a/res/values-bs/strings.xml
+++ b/res/values-bs/strings.xml
@@ -1384,4 +1384,12 @@
     <string name="unsupported_device_required_platform">Potrebna platforma</string>
     <string name="unsupported_device_close">Zatvori</string>
     <string name="unsupported_device_unavailable">Nedostupno</string>
+    <string name="subtitle_position">Pozicija titlova</string>
+    <string name="subtitle_position_subtitle">Pomjeri titlove gore ili dolje na ekranu.</string>
+    <string name="subtitle_font_size_subtitle">Veličina teksta koja se koristi za titlove tokom reprodukcije.</string>
+    <string name="subtitle_bold_subtitle">Prikaži tekst titlova podebljano.</string>
+    <string name="subtitle_outline_subtitle">Nacrtaj obris oko teksta titlova radi bolje čitljivosti.</string>
+    <string name="subtitle_outline_color_subtitle">Boja obrisa titlova.</string>
+    <string name="subtitle_text_color_subtitle">Boja teksta titlova.</string>
+    <string name="player_error_web_headers_unsupported">Ovaj izvor nije kompatibilan s plejerom ovog uređaja jer zahtijeva posebna zaglavlja zahtjeva. Pokušajte s drugim izvorom ili kontaktirajte pružatelja dodatka.</string>
 </resources>

--- a/res/values-cs/strings.xml
+++ b/res/values-cs/strings.xml
@@ -1819,4 +1819,12 @@
     <string name="unsupported_device_required_platform">Požadovaná platforma</string>
     <string name="unsupported_device_close">Zavřít</string>
     <string name="unsupported_device_unavailable">Nedostupné</string>
+    <string name="subtitle_position">Pozice titulků</string>
+    <string name="subtitle_position_subtitle">Posune titulky nahoru nebo dolů po obrazovce.</string>
+    <string name="subtitle_font_size_subtitle">Velikost textu použitá pro titulky během přehrávání.</string>
+    <string name="subtitle_bold_subtitle">Zobrazit text titulků tučně.</string>
+    <string name="subtitle_outline_subtitle">Vykreslit obrys kolem textu titulků pro lepší čitelnost.</string>
+    <string name="subtitle_outline_color_subtitle">Barva obrysu titulků.</string>
+    <string name="subtitle_text_color_subtitle">Barva textu titulků.</string>
+    <string name="player_error_web_headers_unsupported">Tento zdroj není kompatibilní s přehrávačem tohoto zařízení, protože vyžaduje speciální hlavičky požadavku. Zkuste jiný zdroj nebo kontaktujte poskytovatele doplňku.</string>
 </resources>

--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -2096,4 +2096,12 @@
     <string name="unsupported_device_required_platform">Erforderliche Plattform</string>
     <string name="unsupported_device_close">Schließen</string>
     <string name="unsupported_device_unavailable">Nicht verfügbar</string>
+    <string name="subtitle_position">Untertitelposition</string>
+    <string name="subtitle_position_subtitle">Untertitel auf dem Bildschirm nach oben oder unten verschieben.</string>
+    <string name="subtitle_font_size_subtitle">Textgröße, die während der Wiedergabe für Untertitel verwendet wird.</string>
+    <string name="subtitle_bold_subtitle">Untertiteltext fett anzeigen.</string>
+    <string name="subtitle_outline_subtitle">Einen Umriss um den Untertiteltext zeichnen, um die Lesbarkeit zu verbessern.</string>
+    <string name="subtitle_outline_color_subtitle">Farbe des Untertitelumrisses.</string>
+    <string name="subtitle_text_color_subtitle">Farbe des Untertiteltextes.</string>
+    <string name="player_error_web_headers_unsupported">Diese Quelle ist mit dem Player dieses Geräts nicht kompatibel, da sie spezielle Anfrage-Header erfordert. Versuchen Sie eine andere Quelle oder wenden Sie sich an den Add-on-Anbieter.</string>
 </resources>

--- a/res/values-el/strings.xml
+++ b/res/values-el/strings.xml
@@ -2244,4 +2244,12 @@
     <string name="unsupported_device_required_platform">Απαιτούμενη πλατφόρμα</string>
     <string name="unsupported_device_close">Κλείσιμο</string>
     <string name="unsupported_device_unavailable">Μη διαθέσιμο</string>
+    <string name="subtitle_position">Θέση υποτίτλων</string>
+    <string name="subtitle_position_subtitle">Μετακίνηση των υποτίτλων προς τα πάνω ή προς τα κάτω στην οθόνη.</string>
+    <string name="subtitle_font_size_subtitle">Μέγεθος κειμένου που χρησιμοποιείται για τους υπότιτλους κατά την αναπαραγωγή.</string>
+    <string name="subtitle_bold_subtitle">Εμφάνιση του κειμένου των υποτίτλων με έντονη γραφή.</string>
+    <string name="subtitle_outline_subtitle">Σχεδίαση περιγράμματος γύρω από το κείμενο των υποτίτλων για καλύτερη αναγνωσιμότητα.</string>
+    <string name="subtitle_outline_color_subtitle">Χρώμα του περιγράμματος των υποτίτλων.</string>
+    <string name="subtitle_text_color_subtitle">Χρώμα του κειμένου των υποτίτλων.</string>
+    <string name="player_error_web_headers_unsupported">Αυτή η πηγή δεν είναι συμβατή με την αναπαραγωγή αυτής της συσκευής επειδή απαιτεί ειδικές κεφαλίδες αιτήματος. Δοκιμάστε άλλη πηγή ή επικοινωνήστε με τον πάροχο του πρόσθετου.</string>
 </resources>

--- a/res/values-es-419/strings.xml
+++ b/res/values-es-419/strings.xml
@@ -2266,4 +2266,12 @@
     <string name="unsupported_device_required_platform">Plataforma requerida</string>
     <string name="unsupported_device_close">Cerrar</string>
     <string name="unsupported_device_unavailable">No disponible</string>
+    <string name="subtitle_position">Posición de subtítulos</string>
+    <string name="subtitle_position_subtitle">Mueve los subtítulos hacia arriba o hacia abajo en la pantalla.</string>
+    <string name="subtitle_font_size_subtitle">Tamaño del texto usado para los subtítulos durante la reproducción.</string>
+    <string name="subtitle_bold_subtitle">Muestra el texto de los subtítulos en negrita.</string>
+    <string name="subtitle_outline_subtitle">Dibuja un contorno alrededor del texto de los subtítulos para mejorar la legibilidad.</string>
+    <string name="subtitle_outline_color_subtitle">Color del contorno de los subtítulos.</string>
+    <string name="subtitle_text_color_subtitle">Color del texto de los subtítulos.</string>
+    <string name="player_error_web_headers_unsupported">Esta fuente no es compatible con el reproductor de este dispositivo porque requiere encabezados de solicitud especiales. Prueba con otra fuente o contacta al proveedor del complemento.</string>
 </resources>

--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -1105,4 +1105,12 @@
     <string name="unsupported_device_required_platform">Plataforma requerida</string>
     <string name="unsupported_device_close">Cerrar</string>
     <string name="unsupported_device_unavailable">No disponible</string>
+    <string name="subtitle_position">Posición de subtítulos</string>
+    <string name="subtitle_position_subtitle">Mueve los subtítulos hacia arriba o hacia abajo en la pantalla.</string>
+    <string name="subtitle_font_size_subtitle">Tamaño del texto usado para los subtítulos durante la reproducción.</string>
+    <string name="subtitle_bold_subtitle">Muestra el texto de los subtítulos en negrita.</string>
+    <string name="subtitle_outline_subtitle">Dibuja un contorno alrededor del texto de los subtítulos para mejorar la legibilidad.</string>
+    <string name="subtitle_outline_color_subtitle">Color del contorno de los subtítulos.</string>
+    <string name="subtitle_text_color_subtitle">Color del texto de los subtítulos.</string>
+    <string name="player_error_web_headers_unsupported">Esta fuente no es compatible con el reproductor de este dispositivo porque requiere encabezados de solicitud especiales. Prueba con otra fuente o contacta con el proveedor del complemento.</string>
 </resources>

--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -2529,4 +2529,12 @@
     <string name="unsupported_device_required_platform">Plateforme requise</string>
     <string name="unsupported_device_close">Fermer</string>
     <string name="unsupported_device_unavailable">Indisponible</string>
+    <string name="subtitle_position">Position des sous-titres</string>
+    <string name="subtitle_position_subtitle">Déplacez les sous-titres vers le haut ou le bas de l'écran.</string>
+    <string name="subtitle_font_size_subtitle">Taille du texte utilisée pour les sous-titres pendant la lecture.</string>
+    <string name="subtitle_bold_subtitle">Afficher le texte des sous-titres en gras.</string>
+    <string name="subtitle_outline_subtitle">Dessiner un contour autour du texte des sous-titres pour améliorer la lisibilité.</string>
+    <string name="subtitle_outline_color_subtitle">Couleur du contour des sous-titres.</string>
+    <string name="subtitle_text_color_subtitle">Couleur du texte des sous-titres.</string>
+    <string name="player_error_web_headers_unsupported">Cette source n'est pas compatible avec le lecteur de cet appareil car elle nécessite des en-têtes de requête spéciaux. Essayez une autre source ou contactez le fournisseur de l'extension.</string>
 </resources>

--- a/res/values-he/strings.xml
+++ b/res/values-he/strings.xml
@@ -963,4 +963,12 @@
     <string name="unsupported_device_required_platform">פלטפורמה נדרשת</string>
     <string name="unsupported_device_close">סגור</string>
     <string name="unsupported_device_unavailable">לא זמין</string>
+    <string name="subtitle_position">מיקום הכתוביות</string>
+    <string name="subtitle_position_subtitle">הזז את הכתוביות למעלה או למטה על המסך.</string>
+    <string name="subtitle_font_size_subtitle">גודל הטקסט שבו משתמשים בכתוביות במהלך ההפעלה.</string>
+    <string name="subtitle_bold_subtitle">הצג את טקסט הכתוביות בהדגשה.</string>
+    <string name="subtitle_outline_subtitle">צייר מתאר סביב טקסט הכתוביות לשיפור הקריאות.</string>
+    <string name="subtitle_outline_color_subtitle">צבע המתאר של הכתוביות.</string>
+    <string name="subtitle_text_color_subtitle">צבע הטקסט של הכתוביות.</string>
+    <string name="player_error_web_headers_unsupported">מקור זה אינו תואם לנגן של מכשיר זה מכיוון שהוא דורש כותרות בקשה מיוחדות. נסה מקור אחר או פנה לספק התוסף.</string>
 </resources>

--- a/res/values-hi/strings.xml
+++ b/res/values-hi/strings.xml
@@ -1056,4 +1056,12 @@
     <string name="unsupported_device_required_platform">आवश्यक प्लेटफ़ॉर्म</string>
     <string name="unsupported_device_close">बंद करें</string>
     <string name="unsupported_device_unavailable">उपलब्ध नहीं</string>
+    <string name="subtitle_position">उपशीर्षक स्थिति</string>
+    <string name="subtitle_position_subtitle">उपशीर्षक को स्क्रीन पर ऊपर या नीचे ले जाएँ।</string>
+    <string name="subtitle_font_size_subtitle">प्लेबैक के दौरान उपशीर्षक के लिए उपयोग किया जाने वाला टेक्स्ट आकार।</string>
+    <string name="subtitle_bold_subtitle">उपशीर्षक टेक्स्ट को बोल्ड में दिखाएँ।</string>
+    <string name="subtitle_outline_subtitle">पठनीयता के लिए उपशीर्षक टेक्स्ट के चारों ओर आउटलाइन बनाएँ।</string>
+    <string name="subtitle_outline_color_subtitle">उपशीर्षक आउटलाइन का रंग।</string>
+    <string name="subtitle_text_color_subtitle">उपशीर्षक टेक्स्ट का रंग।</string>
+    <string name="player_error_web_headers_unsupported">यह स्रोत इस डिवाइस के प्लेयर के साथ संगत नहीं है क्योंकि इसके लिए विशेष अनुरोध हेडर आवश्यक हैं। कोई अन्य स्रोत आज़माएँ या ऐड-ऑन प्रदाता से संपर्क करें।</string>
 </resources>

--- a/res/values-hu/strings.xml
+++ b/res/values-hu/strings.xml
@@ -1018,4 +1018,12 @@
     <string name="unsupported_device_required_platform">Szükséges platform</string>
     <string name="unsupported_device_close">Bezárás</string>
     <string name="unsupported_device_unavailable">Nem elérhető</string>
+    <string name="subtitle_position">Felirat pozíciója</string>
+    <string name="subtitle_position_subtitle">A felirat mozgatása felfelé vagy lefelé a képernyőn.</string>
+    <string name="subtitle_font_size_subtitle">A lejátszás során a feliratokhoz használt szövegméret.</string>
+    <string name="subtitle_bold_subtitle">A felirat szövegének félkövér megjelenítése.</string>
+    <string name="subtitle_outline_subtitle">Körvonal rajzolása a felirat szövege köré az olvashatóság érdekében.</string>
+    <string name="subtitle_outline_color_subtitle">A felirat körvonalának színe.</string>
+    <string name="subtitle_text_color_subtitle">A felirat szövegének színe.</string>
+    <string name="player_error_web_headers_unsupported">Ez a forrás nem kompatibilis az eszköz lejátszójával, mert speciális kérésfejléceket igényel. Próbálj másik forrást, vagy vedd fel a kapcsolatot a kiegészítő szolgáltatójával.</string>
 </resources>

--- a/res/values-id/strings.xml
+++ b/res/values-id/strings.xml
@@ -2266,4 +2266,12 @@
     <string name="unsupported_device_required_platform">Platform yang diperlukan</string>
     <string name="unsupported_device_close">Tutup</string>
     <string name="unsupported_device_unavailable">Tidak tersedia</string>
+    <string name="subtitle_position">Posisi Subtitle</string>
+    <string name="subtitle_position_subtitle">Pindahkan subtitle ke atas atau ke bawah di layar.</string>
+    <string name="subtitle_font_size_subtitle">Ukuran teks yang digunakan untuk subtitle saat pemutaran.</string>
+    <string name="subtitle_bold_subtitle">Tampilkan teks subtitle dalam huruf tebal.</string>
+    <string name="subtitle_outline_subtitle">Gambar garis tepi di sekeliling teks subtitle agar lebih mudah dibaca.</string>
+    <string name="subtitle_outline_color_subtitle">Warna garis tepi subtitle.</string>
+    <string name="subtitle_text_color_subtitle">Warna teks subtitle.</string>
+    <string name="player_error_web_headers_unsupported">Sumber ini tidak kompatibel dengan pemutar perangkat ini karena memerlukan header permintaan khusus. Coba sumber lain atau hubungi penyedia add-on.</string>
 </resources>

--- a/res/values-it/strings.xml
+++ b/res/values-it/strings.xml
@@ -2660,4 +2660,12 @@
     <string name="unsupported_device_required_platform">Piattaforma richiesta</string>
     <string name="unsupported_device_close">Chiudi</string>
     <string name="unsupported_device_unavailable">Non disponibile</string>
+    <string name="subtitle_position">Posizione dei sottotitoli</string>
+    <string name="subtitle_position_subtitle">Sposta i sottotitoli verso l'alto o verso il basso sullo schermo.</string>
+    <string name="subtitle_font_size_subtitle">Dimensione del testo usata per i sottotitoli durante la riproduzione.</string>
+    <string name="subtitle_bold_subtitle">Mostra il testo dei sottotitoli in grassetto.</string>
+    <string name="subtitle_outline_subtitle">Disegna un bordo attorno al testo dei sottotitoli per migliorare la leggibilità.</string>
+    <string name="subtitle_outline_color_subtitle">Colore del bordo dei sottotitoli.</string>
+    <string name="subtitle_text_color_subtitle">Colore del testo dei sottotitoli.</string>
+    <string name="player_error_web_headers_unsupported">Questa fonte non è compatibile con il lettore di questo dispositivo perché richiede header di richiesta speciali. Prova un'altra fonte o contatta il fornitore dell'add-on.</string>
 </resources>

--- a/res/values-ja/strings.xml
+++ b/res/values-ja/strings.xml
@@ -1236,4 +1236,12 @@
     <string name="unsupported_device_required_platform">必要なプラットフォーム</string>
     <string name="unsupported_device_close">閉じる</string>
     <string name="unsupported_device_unavailable">利用不可</string>
+    <string name="subtitle_position">字幕の位置</string>
+    <string name="subtitle_position_subtitle">字幕を画面の上下に移動します。</string>
+    <string name="subtitle_font_size_subtitle">再生中に字幕に使用される文字サイズ。</string>
+    <string name="subtitle_bold_subtitle">字幕テキストを太字で表示します。</string>
+    <string name="subtitle_outline_subtitle">読みやすくするために字幕テキストの周囲にアウトラインを描画します。</string>
+    <string name="subtitle_outline_color_subtitle">字幕のアウトラインの色。</string>
+    <string name="subtitle_text_color_subtitle">字幕テキストの色。</string>
+    <string name="player_error_web_headers_unsupported">このソースは特別なリクエストヘッダーを必要とするため、このデバイスのプレーヤーと互換性がありません。別のソースを試すか、アドオンの提供元にお問い合わせください。</string>
 </resources>

--- a/res/values-lt/strings.xml
+++ b/res/values-lt/strings.xml
@@ -934,4 +934,12 @@ Klaida: Bandomoji simuliuojama klaida — tai nėra tikras gedimas. Šaltinis gr
     <string name="unsupported_device_required_platform">Reikalinga platforma</string>
     <string name="unsupported_device_close">Uždaryti</string>
     <string name="unsupported_device_unavailable">Nepasiekiama</string>
+    <string name="subtitle_position">Subtitrų padėtis</string>
+    <string name="subtitle_position_subtitle">Perkelkite subtitrus aukštyn arba žemyn ekrane.</string>
+    <string name="subtitle_font_size_subtitle">Teksto dydis, naudojamas subtitrams atkūrimo metu.</string>
+    <string name="subtitle_bold_subtitle">Rodyti subtitrų tekstą paryškintą.</string>
+    <string name="subtitle_outline_subtitle">Nubrėžti kontūrą aplink subtitrų tekstą, kad būtų geriau įskaitoma.</string>
+    <string name="subtitle_outline_color_subtitle">Subtitrų kontūro spalva.</string>
+    <string name="subtitle_text_color_subtitle">Subtitrų teksto spalva.</string>
+    <string name="player_error_web_headers_unsupported">Šis šaltinis nesuderinamas su šio įrenginio grotuvu, nes jam reikia specialių užklausos antraščių. Išbandykite kitą šaltinį arba susisiekite su priedo teikėju.</string>
 </resources>

--- a/res/values-nl/strings.xml
+++ b/res/values-nl/strings.xml
@@ -932,4 +932,12 @@
     <string name="unsupported_device_required_platform">Vereist platform</string>
     <string name="unsupported_device_close">Sluiten</string>
     <string name="unsupported_device_unavailable">Niet beschikbaar</string>
+    <string name="subtitle_position">Ondertitelpositie</string>
+    <string name="subtitle_position_subtitle">Verplaats ondertitels omhoog of omlaag op het scherm.</string>
+    <string name="subtitle_font_size_subtitle">Tekstgrootte die tijdens het afspelen voor ondertitels wordt gebruikt.</string>
+    <string name="subtitle_bold_subtitle">Ondertiteltekst vet weergeven.</string>
+    <string name="subtitle_outline_subtitle">Teken een rand rond de ondertiteltekst voor betere leesbaarheid.</string>
+    <string name="subtitle_outline_color_subtitle">Kleur van de ondertitelrand.</string>
+    <string name="subtitle_text_color_subtitle">Kleur van de ondertiteltekst.</string>
+    <string name="player_error_web_headers_unsupported">Deze bron is niet compatibel met de speler van dit apparaat omdat er speciale request-headers nodig zijn. Probeer een andere bron of neem contact op met de add-on-aanbieder.</string>
 </resources>

--- a/res/values-no/strings.xml
+++ b/res/values-no/strings.xml
@@ -1047,4 +1047,12 @@
     <string name="unsupported_device_required_platform">Påkrevd plattform</string>
     <string name="unsupported_device_close">Lukk</string>
     <string name="unsupported_device_unavailable">Ikke tilgjengelig</string>
+    <string name="subtitle_position">Undertekstposisjon</string>
+    <string name="subtitle_position_subtitle">Flytt undertekstene opp eller ned på skjermen.</string>
+    <string name="subtitle_font_size_subtitle">Tekststørrelse som brukes for undertekster under avspilling.</string>
+    <string name="subtitle_bold_subtitle">Vis undertekstteksten i fet skrift.</string>
+    <string name="subtitle_outline_subtitle">Tegn et omriss rundt undertekstteksten for bedre lesbarhet.</string>
+    <string name="subtitle_outline_color_subtitle">Farge på undertekstens omriss.</string>
+    <string name="subtitle_text_color_subtitle">Farge på undertekstteksten.</string>
+    <string name="player_error_web_headers_unsupported">Denne kilden er ikke kompatibel med enhetens spiller fordi den krever spesielle forespørselshoder. Prøv en annen kilde eller kontakt tilleggsleverandøren.</string>
 </resources>

--- a/res/values-pl/strings.xml
+++ b/res/values-pl/strings.xml
@@ -2507,4 +2507,12 @@
     <string name="unsupported_device_required_platform">Wymagana platforma</string>
     <string name="unsupported_device_close">Zamknij</string>
     <string name="unsupported_device_unavailable">Niedostępne</string>
+    <string name="subtitle_position">Pozycja napisów</string>
+    <string name="subtitle_position_subtitle">Przesuń napisy w górę lub w dół ekranu.</string>
+    <string name="subtitle_font_size_subtitle">Rozmiar tekstu używany dla napisów podczas odtwarzania.</string>
+    <string name="subtitle_bold_subtitle">Wyświetlaj tekst napisów pogrubiony.</string>
+    <string name="subtitle_outline_subtitle">Rysuj obrys wokół tekstu napisów dla lepszej czytelności.</string>
+    <string name="subtitle_outline_color_subtitle">Kolor obrysu napisów.</string>
+    <string name="subtitle_text_color_subtitle">Kolor tekstu napisów.</string>
+    <string name="player_error_web_headers_unsupported">To źródło nie jest zgodne z odtwarzaczem tego urządzenia, ponieważ wymaga specjalnych nagłówków żądania. Wypróbuj inne źródło lub skontaktuj się z dostawcą dodatku.</string>
 </resources>

--- a/res/values-pt-br/strings.xml
+++ b/res/values-pt-br/strings.xml
@@ -2642,4 +2642,12 @@
     <string name="unsupported_device_required_platform">Plataforma necessária</string>
     <string name="unsupported_device_close">Fechar</string>
     <string name="unsupported_device_unavailable">Indisponível</string>
+    <string name="subtitle_position">Posição das legendas</string>
+    <string name="subtitle_position_subtitle">Move as legendas para cima ou para baixo na tela.</string>
+    <string name="subtitle_font_size_subtitle">Tamanho do texto usado nas legendas durante a reprodução.</string>
+    <string name="subtitle_bold_subtitle">Exibe o texto das legendas em negrito.</string>
+    <string name="subtitle_outline_subtitle">Desenha um contorno ao redor do texto das legendas para melhorar a legibilidade.</string>
+    <string name="subtitle_outline_color_subtitle">Cor do contorno das legendas.</string>
+    <string name="subtitle_text_color_subtitle">Cor do texto das legendas.</string>
+    <string name="player_error_web_headers_unsupported">Esta fonte não é compatível com o player deste dispositivo porque exige cabeçalhos de requisição especiais. Tente outra fonte ou entre em contato com o provedor do complemento.</string>
 </resources>

--- a/res/values-pt-pt/strings.xml
+++ b/res/values-pt-pt/strings.xml
@@ -2622,4 +2622,12 @@
     <string name="unsupported_device_required_platform">Plataforma necessária</string>
     <string name="unsupported_device_close">Fechar</string>
     <string name="unsupported_device_unavailable">Indisponível</string>
+    <string name="subtitle_position">Posição das legendas</string>
+    <string name="subtitle_position_subtitle">Move as legendas para cima ou para baixo no ecrã.</string>
+    <string name="subtitle_font_size_subtitle">Tamanho do texto utilizado nas legendas durante a reprodução.</string>
+    <string name="subtitle_bold_subtitle">Mostra o texto das legendas a negrito.</string>
+    <string name="subtitle_outline_subtitle">Desenha um contorno à volta do texto das legendas para melhorar a legibilidade.</string>
+    <string name="subtitle_outline_color_subtitle">Cor do contorno das legendas.</string>
+    <string name="subtitle_text_color_subtitle">Cor do texto das legendas.</string>
+    <string name="player_error_web_headers_unsupported">Esta fonte não é compatível com o leitor deste dispositivo porque requer cabeçalhos de pedido especiais. Experimente outra fonte ou contacte o fornecedor do add-on.</string>
 </resources>

--- a/res/values-ro/strings.xml
+++ b/res/values-ro/strings.xml
@@ -776,4 +776,12 @@
     <string name="unsupported_device_required_platform">Platformă necesară</string>
     <string name="unsupported_device_close">Închide</string>
     <string name="unsupported_device_unavailable">Indisponibil</string>
+    <string name="subtitle_position">Poziția subtitrărilor</string>
+    <string name="subtitle_position_subtitle">Mută subtitrările în sus sau în jos pe ecran.</string>
+    <string name="subtitle_font_size_subtitle">Dimensiunea textului folosită pentru subtitrări în timpul redării.</string>
+    <string name="subtitle_bold_subtitle">Afișează textul subtitrărilor cu caractere îngroșate.</string>
+    <string name="subtitle_outline_subtitle">Desenează un contur în jurul textului subtitrărilor pentru lizibilitate.</string>
+    <string name="subtitle_outline_color_subtitle">Culoarea conturului subtitrărilor.</string>
+    <string name="subtitle_text_color_subtitle">Culoarea textului subtitrărilor.</string>
+    <string name="player_error_web_headers_unsupported">Această sursă nu este compatibilă cu playerul acestui dispozitiv deoarece necesită anteturi de cerere speciale. Încearcă altă sursă sau contactează furnizorul add-on-ului.</string>
 </resources>

--- a/res/values-ru/strings.xml
+++ b/res/values-ru/strings.xml
@@ -2364,4 +2364,12 @@
     <string name="unsupported_device_required_platform">Требуемая платформа</string>
     <string name="unsupported_device_close">Закрыть</string>
     <string name="unsupported_device_unavailable">Недоступно</string>
+    <string name="subtitle_position">Положение субтитров</string>
+    <string name="subtitle_position_subtitle">Перемещение субтитров вверх или вниз по экрану.</string>
+    <string name="subtitle_font_size_subtitle">Размер текста, используемый для субтитров во время воспроизведения.</string>
+    <string name="subtitle_bold_subtitle">Показывать текст субтитров жирным шрифтом.</string>
+    <string name="subtitle_outline_subtitle">Рисовать обводку вокруг текста субтитров для лучшей читаемости.</string>
+    <string name="subtitle_outline_color_subtitle">Цвет обводки субтитров.</string>
+    <string name="subtitle_text_color_subtitle">Цвет текста субтитров.</string>
+    <string name="player_error_web_headers_unsupported">Этот источник несовместим с плеером данного устройства, так как требует специальных заголовков запроса. Попробуйте другой источник или обратитесь к разработчику дополнения.</string>
 </resources>

--- a/res/values-se/string.xml
+++ b/res/values-se/string.xml
@@ -855,4 +855,12 @@
     <string name="player.audio.noSupportedTracks">Inga ljudspår som stöds är tillgängliga</string>
     <string name="settings_stream_addon_logo_title">Tilläggslogotyp</string>
     <string name="settings_stream_addon_logo_description">Visa tilläggets logotyp och namn bredvid strömkällor.</string>
+    <string name="subtitle_position">Undertextposition</string>
+    <string name="subtitle_position_subtitle">Flytta undertexterna uppåt eller nedåt på skärmen.</string>
+    <string name="subtitle_font_size_subtitle">Textstorlek som används för undertexter under uppspelning.</string>
+    <string name="subtitle_bold_subtitle">Visa undertexten med fet stil.</string>
+    <string name="subtitle_outline_subtitle">Rita en kontur runt undertexten för bättre läsbarhet.</string>
+    <string name="subtitle_outline_color_subtitle">Färg på undertextens kontur.</string>
+    <string name="subtitle_text_color_subtitle">Färg på undertextens text.</string>
+    <string name="player_error_web_headers_unsupported">Den här källan är inte kompatibel med enhetens spelare eftersom den kräver särskilda begäranshuvuden. Prova en annan källa eller kontakta tilläggets leverantör.</string>
 </resources>

--- a/res/values-sk/strings.xml
+++ b/res/values-sk/strings.xml
@@ -2400,4 +2400,12 @@
     <string name="unsupported_device_required_platform">Požadovaná platforma</string>
     <string name="unsupported_device_close">Zavrieť</string>
     <string name="unsupported_device_unavailable">Nedostupné</string>
+    <string name="subtitle_position">Poloha titulkov</string>
+    <string name="subtitle_position_subtitle">Posunie titulky nahor alebo nadol po obrazovke.</string>
+    <string name="subtitle_font_size_subtitle">Veľkosť textu použitá pre titulky počas prehrávania.</string>
+    <string name="subtitle_bold_subtitle">Zobraziť text titulkov tučne.</string>
+    <string name="subtitle_outline_subtitle">Vykresliť obrys okolo textu titulkov pre lepšiu čitateľnosť.</string>
+    <string name="subtitle_outline_color_subtitle">Farba obrysu titulkov.</string>
+    <string name="subtitle_text_color_subtitle">Farba textu titulkov.</string>
+    <string name="player_error_web_headers_unsupported">Tento zdroj nie je kompatibilný s prehrávačom tohto zariadenia, pretože vyžaduje špeciálne hlavičky požiadavky. Skúste iný zdroj alebo kontaktujte poskytovateľa doplnku.</string>
 </resources>

--- a/res/values-sl/strings.xml
+++ b/res/values-sl/strings.xml
@@ -2215,4 +2215,12 @@
     <string name="unsupported_device_required_platform">Zahtevana platforma</string>
     <string name="unsupported_device_close">Zapri</string>
     <string name="unsupported_device_unavailable">Ni na voljo</string>
+    <string name="subtitle_position">Položaj podnapisov</string>
+    <string name="subtitle_position_subtitle">Premakne podnapise navzgor ali navzdol po zaslonu.</string>
+    <string name="subtitle_font_size_subtitle">Velikost besedila, uporabljena za podnapise med predvajanjem.</string>
+    <string name="subtitle_bold_subtitle">Prikaži besedilo podnapisov krepko.</string>
+    <string name="subtitle_outline_subtitle">Nariše obrobo okoli besedila podnapisov za boljšo berljivost.</string>
+    <string name="subtitle_outline_color_subtitle">Barva obrobe podnapisov.</string>
+    <string name="subtitle_text_color_subtitle">Barva besedila podnapisov.</string>
+    <string name="player_error_web_headers_unsupported">Ta vir ni združljiv s predvajalnikom te naprave, ker zahteva posebne glave zahteve. Poskusite z drugim virom ali se obrnite na ponudnika dodatka.</string>
 </resources>

--- a/res/values-sv/strings.xml
+++ b/res/values-sv/strings.xml
@@ -1432,4 +1432,12 @@
     <string name="unsupported_device_required_platform">Plattform som krävs</string>
     <string name="unsupported_device_close">Stäng</string>
     <string name="unsupported_device_unavailable">Inte tillgänglig</string>
+    <string name="subtitle_position">Undertextposition</string>
+    <string name="subtitle_position_subtitle">Flytta undertexterna uppåt eller nedåt på skärmen.</string>
+    <string name="subtitle_font_size_subtitle">Textstorlek som används för undertexter under uppspelning.</string>
+    <string name="subtitle_bold_subtitle">Visa undertexten med fet stil.</string>
+    <string name="subtitle_outline_subtitle">Rita en kontur runt undertexten för bättre läsbarhet.</string>
+    <string name="subtitle_outline_color_subtitle">Färg på undertextens kontur.</string>
+    <string name="subtitle_text_color_subtitle">Färg på undertextens text.</string>
+    <string name="player_error_web_headers_unsupported">Den här källan är inte kompatibel med enhetens spelare eftersom den kräver särskilda begäranshuvuden. Prova en annan källa eller kontakta tilläggets leverantör.</string>
 </resources>

--- a/res/values-ta/strings.xml
+++ b/res/values-ta/strings.xml
@@ -2099,4 +2099,12 @@
     <string name="unsupported_device_required_platform">தேவையான இயங்குதளம்</string>
     <string name="unsupported_device_close">மூடு</string>
     <string name="unsupported_device_unavailable">கிடைக்கவில்லை</string>
+    <string name="subtitle_position">வசன வரிகளின் நிலை</string>
+    <string name="subtitle_position_subtitle">வசன வரிகளைத் திரையில் மேலே அல்லது கீழே நகர்த்தவும்.</string>
+    <string name="subtitle_font_size_subtitle">இயக்கத்தின்போது வசன வரிகளுக்குப் பயன்படுத்தப்படும் உரை அளவு.</string>
+    <string name="subtitle_bold_subtitle">வசன வரிகளின் உரையைத் தடிமனாகக் காட்டு.</string>
+    <string name="subtitle_outline_subtitle">படிக்கும் தன்மைக்காக வசன வரிகளின் உரையைச் சுற்றி வெளிக்கோடு வரையவும்.</string>
+    <string name="subtitle_outline_color_subtitle">வசன வரிகளின் வெளிக்கோட்டின் நிறம்.</string>
+    <string name="subtitle_text_color_subtitle">வசன வரிகளின் உரையின் நிறம்.</string>
+    <string name="player_error_web_headers_unsupported">இந்த மூலம் சிறப்பு கோரிக்கை தலைப்புகளைக் கோருவதால் இந்தச் சாதனத்தின் பிளேயருடன் இணக்கமில்லை. வேறு மூலத்தை முயற்சிக்கவும் அல்லது ஆட்-ஆன் வழங்குநரைத் தொடர்பு கொள்ளவும்.</string>
 </resources>

--- a/res/values-tr/strings.xml
+++ b/res/values-tr/strings.xml
@@ -2370,4 +2370,12 @@
     <string name="unsupported_device_required_platform">Gerekli platform</string>
     <string name="unsupported_device_close">Kapat</string>
     <string name="unsupported_device_unavailable">Kullanılamıyor</string>
+    <string name="subtitle_position">Altyazı Konumu</string>
+    <string name="subtitle_position_subtitle">Altyazıları ekranda yukarı veya aşağı taşıyın.</string>
+    <string name="subtitle_font_size_subtitle">Oynatma sırasında altyazılar için kullanılan metin boyutu.</string>
+    <string name="subtitle_bold_subtitle">Altyazı metnini kalın göster.</string>
+    <string name="subtitle_outline_subtitle">Okunabilirlik için altyazı metninin etrafına dış çizgi çiz.</string>
+    <string name="subtitle_outline_color_subtitle">Altyazı dış çizgisinin rengi.</string>
+    <string name="subtitle_text_color_subtitle">Altyazı metninin rengi.</string>
+    <string name="player_error_web_headers_unsupported">Bu kaynak, özel istek başlıkları gerektirdiği için bu cihazın oynatıcısıyla uyumlu değil. Başka bir kaynak deneyin veya eklenti sağlayıcısıyla iletişime geçin.</string>
 </resources>

--- a/res/values-vi/strings.xml
+++ b/res/values-vi/strings.xml
@@ -950,4 +950,12 @@
     <string name="unsupported_device_required_platform">Nền tảng yêu cầu</string>
     <string name="unsupported_device_close">Đóng</string>
     <string name="unsupported_device_unavailable">Không có</string>
+    <string name="subtitle_position">Vị trí phụ đề</string>
+    <string name="subtitle_position_subtitle">Di chuyển phụ đề lên hoặc xuống trên màn hình.</string>
+    <string name="subtitle_font_size_subtitle">Cỡ chữ dùng cho phụ đề trong khi phát.</string>
+    <string name="subtitle_bold_subtitle">Hiển thị chữ phụ đề in đậm.</string>
+    <string name="subtitle_outline_subtitle">Vẽ viền quanh chữ phụ đề để dễ đọc hơn.</string>
+    <string name="subtitle_outline_color_subtitle">Màu viền của phụ đề.</string>
+    <string name="subtitle_text_color_subtitle">Màu chữ của phụ đề.</string>
+    <string name="player_error_web_headers_unsupported">Nguồn này không tương thích với trình phát của thiết bị vì nó yêu cầu các tiêu đề yêu cầu đặc biệt. Hãy thử nguồn khác hoặc liên hệ nhà cung cấp tiện ích bổ sung.</string>
 </resources>

--- a/res/values-zh-cn/strings.xml
+++ b/res/values-zh-cn/strings.xml
@@ -2183,4 +2183,12 @@
     <string name="unsupported_device_required_platform">所需平台</string>
     <string name="unsupported_device_close">关闭</string>
     <string name="unsupported_device_unavailable">不可用</string>
+    <string name="subtitle_position">字幕位置</string>
+    <string name="subtitle_position_subtitle">在屏幕上向上或向下移动字幕。</string>
+    <string name="subtitle_font_size_subtitle">播放时字幕所用的文字大小。</string>
+    <string name="subtitle_bold_subtitle">以粗体显示字幕文字。</string>
+    <string name="subtitle_outline_subtitle">在字幕文字周围绘制描边以提高可读性。</string>
+    <string name="subtitle_outline_color_subtitle">字幕描边的颜色。</string>
+    <string name="subtitle_text_color_subtitle">字幕文字的颜色。</string>
+    <string name="player_error_web_headers_unsupported">此来源需要特殊的请求头，因此与本设备的播放器不兼容。请尝试其他来源或联系此附加组件的提供方。</string>
 </resources>


### PR DESCRIPTION
## Summary

Add the eight missing subtitle-setting and player-error translations to all 30 non-English locale files.

## PR type

- [x] Translation/localization only
- [ ] Critical bug fix
- [ ] Approved feature/change

## Affected area

- [x] Shared web app
- [x] Samsung Tizen
- [x] LG webOS
- [x] Browser development mode
- [x] Playback
- [ ] Audio tracks
- [x] Subtitles
- [ ] Focus / Remote navigation
- [ ] UI / Layout
- [ ] Resume / Watch progress
- [ ] Continue Watching
- [ ] Next Episode / Auto-play
- [ ] Packaging / Build
- [ ] Nuvio WebTV Installer compatibility
- [ ] TizenBrew wrapper
- [ ] webOS Homebrew wrapper
- [ ] Documentation
- [ ] Other

## Why

Non-English locales fell back to English for subtitle styling descriptions and for the special-request-header playback error. The subtitle-position row also lacked its translated title.

## Issue or approval

Fixes #598.

## Reproduction steps

No reproduction steps - localization-only update.

## Old behavior

Not applicable - localization-only update.

## New behavior

Subtitle styling rows and the affected playback error resolve in the selected locale instead of falling back to English.

## Platform impact

- Samsung Tizen: Shared translated strings only.
- LG webOS: Shared translated strings only.
- Browser development mode: Shared translated strings only.
- Installer / packaging: None.
- Wrapper repositories: None.

## UI / behavior / playback impact

- [ ] No UI change
- [x] No behavior change
- [x] No playback change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] Playback changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval
- [ ] Playback change has explicit maintainer approval

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact
- [ ] Tizen `.wgt` packaging changed
- [ ] webOS `.ipk` packaging changed
- [ ] App identifiers or metadata changed
- [ ] `local.properties` / environment handling changed
- [ ] `sync:tizen` changed
- [ ] `sync:webos` changed
- [ ] Nuvio WebTV Installer compatibility changed
- [ ] TizenBrew wrapper support changed
- [ ] webOS Homebrew metadata support changed

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I included a linked issue, reproduction steps, and testing notes if this is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Translation resources only. No code, UI layout, behavior, playback logic, packaging, metadata, dependency, installer, or wrapper changes.

## Testing

Validated all 30 locale XML files, verified each of the eight keys occurs exactly once per locale, and ran the repository test, lint, formatting, build, Tizen-package, and webOS-package checks on the resolved merge tree.

### Devices / platforms tested

Source and package validation on macOS. No physical Samsung or LG TV validation.

### Commands tested

```sh
npm test
npm run lint
npm run format:check
npm run build
npm run package:tizen
npm run package:webos
```

## Manual test flow

Verified key resolution for German, French, Spanish, Russian, and Japanese subtitle styling strings; validated the complete locale set structurally.

## Screenshots / Video

Not a UI layout change.

## Logs

Not applicable.

## Regression risk

Low. The change only supplies values for existing localization keys. Main risk is wording quality in locales without native-speaker review; missing/duplicate keys and malformed XML were checked.

## Breaking changes

None.

## Linked issues

Fixes #598.
