### PR TITLE
Fix Continue Watching showing episodes before release on webOS

### DIFF
--- a/js/ui/screens/home/homeScreen.js
+++ b/js/ui/screens/home/homeScreen.js
@@ -1146,9 +1146,17 @@ function parseEpisodeReleaseDateForContinueWatching(released) {
   if (!raw) {
     return null;
   }
-  const exactTime = Date.parse(raw);
-  if (Number.isFinite(exactTime)) {
-    return exactTime;
+  // Only a strict ISO 8601 date-time parses identically across engines, so keep
+  // its exact time. For any other string, use the extracted ISO date portion:
+  // Date.parse on non-ISO / space separated / locale date strings is
+  // implementation and timezone dependent, and on some TV browsers resolved a
+  // day or more off, which made Continue Watching treat episodes as aired
+  // before their real release date.
+  if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/.test(raw)) {
+    const exactTime = Date.parse(raw);
+    if (Number.isFinite(exactTime)) {
+      return exactTime;
+    }
   }
   const datePortion = raw.match(/\b\d{4}-\d{2}-\d{2}\b/)?.[0];
   const parsedTime = datePortion ? Date.parse(datePortion) : NaN;


### PR DESCRIPTION
Fixes #637.

Continue Watching was marking episodes as aired before their real release date on webOS (reported as showing up around two days early, while mobile was correct).

parseEpisodeReleaseDateForContinueWatching was changed (in an earlier fix) to call Date.parse on the whole raw release string first. Date.parse is only reliable for strict ISO 8601 strings; for anything else (a space separated date-time like `2026-08-08 20:00:00`, or a locale style date) it is implementation and timezone dependent, and older TV browsers resolve it a day or more off. That earlier/wrong value is then compared against Date.now(), so the episode looks already aired.

This keeps the exact time only for a strict ISO 8601 date-time (which every engine parses the same) and otherwise uses the extracted `YYYY-MM-DD` date portion, which is a consistent value across engines and timezones. Restores the pre regression behavior for non ISO strings while keeping precise times for real ISO date-times.

Checked the parsing across formats:
- `2026-08-08` and `2026-08-08T00:00:00.000Z` -> same UTC date (unchanged)
- `2026-08-08 20:00:00` -> now the consistent date portion instead of a timezone dependent value (this is the case that drifted)
- `2026-08-08T20:00:00Z` -> exact time kept
- ambiguous `Fri Aug 08 2026` / `08/08/2026` -> no longer trusted as an engine dependent timestamp